### PR TITLE
refactor: drop statics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,6 @@
 # TODO
 
 ## Initial 0.1.0 build
-- [ ] structs don't need to know about statics
-  - the statics are just regular fns with qualified names
 - [ ] enum methods need some way to know "self"
 - [ ] need a void expression (Unit)
 - [ ] need to be able to alias fn signatures with `type`

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -320,29 +320,18 @@ func (c *checker) resolveType(t ast.DeclaredType) Type {
 	return baseType
 }
 
-// resolveStaticPath resolves a nested static path to its final module and property name
-func (c *checker) resolveStaticPath(expr ast.Expression) (Module, string) {
-	switch e := expr.(type) {
-	case *ast.Identifier:
-		// Simple case: single identifier refers to a module
-		if mod := c.resolveModule(e.Name); mod != nil {
-			return mod, ""
-		}
-		return nil, ""
-	case *ast.StaticProperty:
-		// Nested case: recursively resolve the target
-		targetModule, _ := c.resolveStaticPath(e.Target)
-		if targetModule == nil {
-			return nil, ""
-		}
+func (c *checker) destructurePath(expr *ast.StaticFunction) (string, string) {
+	absolute := expr.Target.String() + "::" + expr.Function.Name
+	parts := strings.Split(absolute, "::")
 
-		// The property should be an identifier
-		if propId, ok := e.Property.(*ast.Identifier); ok {
-			return targetModule, propId.Name
-		}
-		return nil, ""
+	switch len(parts) {
+	case 3:
+		return parts[0], strings.Join(parts[1:], "::")
+	case 2:
+		return parts[0], parts[1]
+	default:
+		return parts[0], parts[0]
 	}
-	return nil, ""
 }
 
 func typeMismatch(expected, got Type) string {
@@ -1815,77 +1804,25 @@ func (c *checker) checkExpr(expr ast.Expression) Expression {
 				panic(fmt.Errorf("Unexpected operator: %v", s.Operator))
 			}
 		}
+
+	// [refactor] a lot of the function call checking can be extracted
+	// - validate args and resolve generics
 	case *ast.StaticFunction:
 		{
-			// Process module function calls like io::print() or http::Response::new()
-			mod, structName := c.resolveStaticPath(s.Target)
-
-			if mod != nil {
-				var fnDef *FunctionDef
-
-				if structName != "" {
-					// We have a nested path like http::Response::new, resolve the struct first
-					structSymbol := mod.Get(structName)
-					if structSymbol.IsZero() {
-						c.addError(fmt.Sprintf("Undefined: %s", structName), s.GetLocation())
-						return nil
-					}
-
-					structDef, ok := structSymbol.Type.(*StructDef)
-					if !ok {
-						c.addError(fmt.Sprintf("%s is not a struct", structName), s.GetLocation())
-						return nil
-					}
-
-					// Look for the static function in the struct
-					staticFn, exists := structDef.Statics[s.Function.Name]
-					if !exists {
-						targetName := s.Target.String()
-						c.addError(fmt.Sprintf("Undefined static function: %s::%s", targetName, s.Function.Name), s.GetLocation())
-						return nil
-					}
-					staticFn.Name = structName + "::" + s.Function.Name
-					fnDef = staticFn
-				} else {
-					// Simple case like io::print(), look for function directly in module
-					sym := mod.Get(s.Function.Name)
-					if sym.IsZero() {
-						targetName := s.Target.String()
-						c.addError(fmt.Sprintf("Undefined: %s::%s", targetName, s.Function.Name), s.GetLocation())
-						return nil
-					}
-
-					// Handle both regular functions and external functions
-					var ok bool
-					switch fn := sym.Type.(type) {
-					case *FunctionDef:
-						fnDef = fn
-						ok = true
-					case *ExternalFunctionDef:
-						// Convert ExternalFunctionDef to FunctionDef for validation
-						fnDef = &FunctionDef{
-							Name:       fn.Name,
-							Parameters: fn.Parameters,
-							ReturnType: fn.ReturnType,
-							Private:    fn.Private,
-						}
-						ok = true
-					default:
-						ok = false
-					}
-
-					if !ok {
-						targetName := s.Target.String()
-						c.addError(fmt.Sprintf("%s::%s is not a function", targetName, s.Function.Name), s.GetLocation())
-						return nil
-					}
+			// Handle local functions
+			absolutePath := s.Target.String() + "::" + s.Function.Name
+			if sym, ok := c.scope.get(absolutePath); ok {
+				fnDef := sym.Type.(*FunctionDef)
+				call := &FunctionCall{
+					Name: absolutePath,
+					Args: []Expression{},
+					fn:   fnDef,
 				}
-
 				// Check argument count
 				if len(s.Function.Args) != len(fnDef.Parameters) {
 					c.addError(fmt.Sprintf("Incorrect number of arguments: Expected %d, got %d",
 						len(fnDef.Parameters), len(s.Function.Args)), s.GetLocation())
-					return nil
+					return call
 				}
 
 				// Check and process arguments
@@ -1893,14 +1830,14 @@ func (c *checker) checkExpr(expr ast.Expression) Expression {
 				for i, arg := range s.Function.Args {
 					checkedArg := c.checkExpr(arg.Value)
 					if checkedArg == nil {
-						return nil
+						return call
 					}
 
 					// Type check the argument against the parameter type
 					paramType := fnDef.Parameters[i].Type
 					if !areCompatible(paramType, checkedArg.Type()) {
 						c.addError(typeMismatch(paramType, checkedArg.Type()), arg.Value.GetLocation())
-						return nil
+						return call
 					}
 
 					// Check mutability constraints if needed
@@ -1911,107 +1848,7 @@ func (c *checker) checkExpr(expr ast.Expression) Expression {
 					args[i] = checkedArg
 				}
 
-				// Use new generic resolution system
-				if fnDef.hasGenerics() {
-					specialized, err := c.resolveGenericFunction(fnDef, args, s.Function.TypeArgs, s.GetLocation())
-					if err != nil {
-						c.addError(err.Error(), s.GetLocation())
-						return nil
-					}
-
-					return &ModuleFunctionCall{
-						Module: mod.Path(),
-						Call: &FunctionCall{
-							Name: s.Function.Name,
-							Args: args,
-							fn:   specialized,
-						},
-					}
-				}
-
-				// Create function call
-				call := &FunctionCall{
-					Name: fnDef.Name,
-					Args: args,
-					fn:   fnDef,
-				}
-
-				// Special validation for async::start calls
-				if mod.Path() == "ard/async" && s.Function.Name == "start" {
-					c.validateFiberFunction(s.Function.Args[0].Value)
-				}
-
-				// Create module static function call if struct is involved, otherwise regular module function call
-				if structName != "" {
-					return &ModuleStaticFunctionCall{
-						Module: mod.Path(),
-						Struct: structName,
-						Call:   call,
-					}
-				} else {
-					return &ModuleFunctionCall{
-						Module: mod.Path(),
-						Call:   call,
-					}
-				}
-			} else {
-				// Handle local static functions (non-module case)
-				// For now, we only support simple identifiers for local static functions
-				var fnDef *FunctionDef
-				if id, ok := s.Target.(*ast.Identifier); ok {
-					sym, ok := c.scope.get(id.Name)
-
-					if !ok {
-						c.addError(fmt.Sprintf("Undefined: %s", id.Name), s.Target.GetLocation())
-						return nil
-					}
-
-					strct, ok := sym.Type.(*StructDef)
-					if !ok {
-						c.addError(fmt.Sprintf("Undefined: %s", id.Name), s.GetLocation())
-						return nil
-					}
-
-					var exists bool
-					fnDef, exists = strct.Statics[s.Function.Name]
-					if !exists {
-						c.addError(fmt.Sprintf("Undefined: %s::%s", id.Name, s.Function.Name), s.GetLocation())
-						return nil
-					}
-				} else {
-					c.addError("Unsupported static function target", s.Target.GetLocation())
-					return nil
-				}
-
-				// Check argument count
-				if len(s.Function.Args) != len(fnDef.Parameters) {
-					c.addError(fmt.Sprintf("Incorrect number of arguments: Expected %d, got %d",
-						len(fnDef.Parameters), len(s.Function.Args)), s.GetLocation())
-					return nil
-				}
-
-				// Check and process arguments
-				args := make([]Expression, len(s.Function.Args))
-				for i, arg := range s.Function.Args {
-					checkedArg := c.checkExpr(arg.Value)
-					if checkedArg == nil {
-						return nil
-					}
-
-					// Type check the argument against the parameter type
-					paramType := fnDef.Parameters[i].Type
-					if !areCompatible(paramType, checkedArg.Type()) {
-						c.addError(typeMismatch(paramType, checkedArg.Type()), arg.Value.GetLocation())
-						return nil
-					}
-
-					// Check mutability constraints if needed
-					if fnDef.Parameters[i].Mutable && !c.isMutable(checkedArg) {
-						c.addError(fmt.Sprintf("Type mismatch: Expected a mutable %s", fnDef.Parameters[i].Type.String()), arg.Value.GetLocation())
-					}
-
-					args[i] = checkedArg
-				}
+				call.Args = args
 
 				// Use new generic resolution system
 				if fnDef.hasGenerics() {
@@ -2021,34 +1858,110 @@ func (c *checker) checkExpr(expr ast.Expression) Expression {
 						return nil
 					}
 
-					return &ModuleFunctionCall{
-						Module: mod.Path(),
-						Call: &FunctionCall{
-							Name: s.Function.Name,
-							Args: args,
-							fn:   specialized,
-						},
-					}
+					call.fn = specialized
+					return call
 				}
 
-				// Create function call
-				call := &FunctionCall{
-					Name: s.Function.Name,
-					Args: args,
-					fn:   fnDef,
+				return call
+			}
+
+			// find the function in a module
+			modName, name := c.destructurePath(s)
+			var fnDef *FunctionDef
+			mod := c.resolveModule(modName)
+			if mod == nil {
+				c.addError(fmt.Sprintf("Undefined module: %s", modName), s.Target.GetLocation())
+				return nil
+			}
+
+			sym := mod.Get(name)
+			if sym.IsZero() {
+				targetName := s.Target.String()
+				c.addError(fmt.Sprintf("Undefined: %s::%s", targetName, s.Function.Name), s.GetLocation())
+				return nil
+			}
+
+			// Handle both regular functions and external functions
+			var ok bool
+			switch fn := sym.Type.(type) {
+			case *FunctionDef:
+				fnDef = fn
+				ok = true
+			case *ExternalFunctionDef:
+				// Convert ExternalFunctionDef to FunctionDef for validation
+				fnDef = &FunctionDef{
+					Name:       fn.Name,
+					Parameters: fn.Parameters,
+					ReturnType: fn.ReturnType,
+					Private:    fn.Private,
 				}
-				// Get the struct definition for the scope
-				var scopeStruct *StructDef
-				if id, ok := s.Target.(*ast.Identifier); ok {
-					if sym, ok := c.scope.get(id.Name); ok {
-						scopeStruct, _ = sym.Type.(*StructDef)
-					}
+				ok = true
+			default:
+				ok = false
+			}
+
+			if !ok {
+				targetName := s.Target.String()
+				c.addError(fmt.Sprintf("%s::%s is not a function", targetName, s.Function.Name), s.GetLocation())
+				return nil
+			}
+
+			// Check argument count
+			if len(s.Function.Args) != len(fnDef.Parameters) {
+				c.addError(fmt.Sprintf("Incorrect number of arguments: Expected %d, got %d",
+					len(fnDef.Parameters), len(s.Function.Args)), s.GetLocation())
+				return nil
+			}
+
+			// Check and process arguments
+			args := make([]Expression, len(s.Function.Args))
+			for i, arg := range s.Function.Args {
+				checkedArg := c.checkExpr(arg.Value)
+				if checkedArg == nil {
+					return nil
 				}
 
-				return &StaticFunctionCall{
-					Scope: scopeStruct,
-					Call:  call,
+				// Type check the argument against the parameter type
+				paramType := fnDef.Parameters[i].Type
+				if !areCompatible(paramType, checkedArg.Type()) {
+					c.addError(typeMismatch(paramType, checkedArg.Type()), arg.Value.GetLocation())
+					return nil
 				}
+
+				// Check mutability constraints if needed
+				if fnDef.Parameters[i].Mutable && !c.isMutable(checkedArg) {
+					c.addError(fmt.Sprintf("Type mismatch: Expected a mutable %s", fnDef.Parameters[i].Type.String()), arg.Value.GetLocation())
+				}
+
+				args[i] = checkedArg
+			}
+
+			// Create function call
+			call := &FunctionCall{
+				Name: fnDef.Name,
+				Args: args,
+				fn:   fnDef,
+			}
+
+			// resolve generics
+			if fnDef.hasGenerics() {
+				specialized, err := c.resolveGenericFunction(fnDef, args, s.Function.TypeArgs, s.GetLocation())
+				if err != nil {
+					c.addError(err.Error(), s.GetLocation())
+					return nil
+				}
+
+				call.fn = specialized
+			}
+
+			// Special validation for async::start calls
+			if mod.Path() == "ard/async" && s.Function.Name == "start" {
+				c.validateFiberFunction(s.Function.Args[0].Value)
+			}
+
+			return &ModuleFunctionCall{
+				Module: mod.Path(),
+				Call:   call,
 			}
 		}
 	case *ast.IfStatement:
@@ -2173,29 +2086,10 @@ func (c *checker) checkExpr(expr ast.Expression) Expression {
 			return fn
 		}
 	case *ast.StaticFunctionDeclaration:
-		qualifier := s.Path.Target.(*ast.Identifier)
-		sym, ok := c.scope.get(qualifier.Name)
-		if !ok {
-			c.addError(fmt.Sprintf("Undefined: %s", qualifier), qualifier.GetLocation())
-			return nil
-		}
-
-		strct, ok := sym.Type.(*StructDef)
-		if !ok {
-			c.addError(fmt.Sprintf("Not a struct: %s", sym.Name), s.GetLocation())
-			return nil
-		}
-
-		segment := s.Path.Property.(*ast.Identifier)
-		if _, ok := strct.Statics[segment.Name]; ok {
-			c.addError(fmt.Sprintf("Duplicate declaration: %s", s.Path), s.Path.GetLocation())
-			return nil
-		}
-
 		fn := c.checkFunction(&s.FunctionDeclaration, nil)
 		if fn != nil {
 			fn.Name = s.Path.String()
-			strct.Statics[segment.Name] = fn
+			c.scope.add(fn.Name, fn, false)
 		}
 
 		return fn

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -904,7 +904,6 @@ func (c *checker) checkStmt(stmt *ast.Statement) *Statement {
 				Fields:  make(map[string]Type),
 				Methods: make(map[string]*FunctionDef),
 				Private: s.Private,
-				Statics: map[string]*FunctionDef{},
 			}
 			for _, field := range s.Fields {
 				fieldType := c.resolveType(field.Type)

--- a/checker/nodes.go
+++ b/checker/nodes.go
@@ -741,16 +741,6 @@ func (p *StaticFunctionCall) Type() Type {
 	return p.Call.Type()
 }
 
-type ModuleStaticFunctionCall struct {
-	Module string
-	Struct string
-	Call   *FunctionCall
-}
-
-func (p *ModuleStaticFunctionCall) Type() Type {
-	return p.Call.Type()
-}
-
 type ModuleSymbol struct {
 	Module string
 	Symbol Symbol

--- a/checker/nodes.go
+++ b/checker/nodes.go
@@ -904,7 +904,6 @@ type StructDef struct {
 	Self    string
 	Traits  []*Trait
 	Private bool
-	Statics map[string]*FunctionDef
 }
 
 func (def StructDef) NonProducing() {}

--- a/checker/nodes.go
+++ b/checker/nodes.go
@@ -732,15 +732,6 @@ func (p *ModuleFunctionCall) Type() Type {
 	return p.Call.Type()
 }
 
-type StaticFunctionCall struct {
-	Scope *StructDef
-	Call  *FunctionCall
-}
-
-func (p *StaticFunctionCall) Type() Type {
-	return p.Call.Type()
-}
-
 type ModuleSymbol struct {
 	Module string
 	Symbol Symbol

--- a/checker/structs_test.go
+++ b/checker/structs_test.go
@@ -52,7 +52,6 @@ func TestStructs(t *testing.T) {
 								"employed": checker.Bool,
 							},
 							Methods: map[string]*checker.FunctionDef{},
-							Statics: map[string]*checker.FunctionDef{},
 						},
 					},
 					{

--- a/std_lib/decode.ard
+++ b/std_lib/decode.ard
@@ -243,6 +243,21 @@ fn field(name: Str, as: fn(Dynamic) $T![Error]) fn(Dynamic) $T![Error] {
   }
 }
 
+// decode a nested field.
+// { foo: { bar: 20 } } --- path(["foo", "bar"], int)
+fn path(subpath: [Str], as: fn(Dynamic) $T![Error]) fn(Dynamic) $T![Error] {
+  fn (data: Dynamic) $T![Error] {
+    mut current_data = data
+    mut out: $T? = maybe::none()
+
+    for seg, idx in subpath {
+      current_data = try extract_field(current_data, seg)
+    }
+
+    as(current_data)
+  }
+}
+
 // take the first successful decoding. if all fail, return the first set of errors
 fn one_of(first: fn(Dynamic) $T![Error], others: [fn(Dynamic) $T![Error]]) fn(Dynamic) $T![Error] {
   fn(data: Dynamic) $T![Error] {

--- a/std_lib/list.ard
+++ b/std_lib/list.ard
@@ -1,1 +1,9 @@
 extern fn new() [$T] = "NewList"
+
+fn concat(a: [$T], b: [$T]) [$T] {
+  mut res = a
+  for i in b {
+    res.push(i)
+  }
+  res
+}

--- a/vm/decode_test.go
+++ b/vm/decode_test.go
@@ -546,6 +546,41 @@ func TestDecodeField(t *testing.T) {
 	})
 }
 
+func TestDecodePath(t *testing.T) {
+	runTests(t, []test{
+		{
+			name: "valid field decoding",
+			input: `
+				use ard/decode
+				use ard/json
+
+				struct Qux {
+					item: Int
+				}
+
+				struct Bar {
+					qux: Qux
+				}
+
+				struct Foo {
+					bar: Bar
+				}
+
+				let qux = Qux{item: 42}
+				let bar = Bar{qux: qux}
+				let foo = Foo{bar: bar}
+
+				let json_str = json::encode(foo).expect("Failed to json encode")
+
+				let data = decode::from_json(json_str).expect("Failed to parse json")
+				let result = decode::run(data, decode::path(["bar", "qux", "item"], decode::int))
+				result.expect("Failed to decode nested path")
+			`,
+			want: 42,
+		},
+	})
+}
+
 func TestDecodeOneOf(t *testing.T) {
 	runTests(t, []test{
 		{

--- a/vm/interpret.go
+++ b/vm/interpret.go
@@ -367,23 +367,6 @@ func (vm *VM) eval(expr checker.Expression) *runtime.Object {
 				return args
 			})
 		}
-	case *checker.ModuleStaticFunctionCall:
-		{
-			// todo: revisit this
-			// Handle module static function calls like http::Response::new()
-			// if vm.moduleRegistry.HasModule(e.Module) {
-			// 	// Pass the struct context to the module handler
-			// 	return vm.moduleRegistry.HandleStatic(e.Module, e.Struct, vm, e.Call)
-			// }
-
-			return vm.hq.callOn(e.Module, e.Call, func() []*runtime.Object {
-				args := []*runtime.Object{}
-				for _, arg := range e.Call.Args {
-					args = append(args, vm.eval(arg))
-				}
-				return args
-			})
-		}
 	case *checker.StaticFunctionCall:
 		{
 			name := e.Scope.Name + "::" + e.Call.Name

--- a/vm/interpret.go
+++ b/vm/interpret.go
@@ -367,22 +367,6 @@ func (vm *VM) eval(expr checker.Expression) *runtime.Object {
 				return args
 			})
 		}
-	case *checker.StaticFunctionCall:
-		{
-			name := e.Scope.Name + "::" + e.Call.Name
-			obj, ok := vm.scope.get(name)
-			if !ok {
-				panic(fmt.Errorf("Undefined function: %s()", name))
-			}
-
-			fn := obj.Raw().(runtime.Closure)
-
-			args := make([]*runtime.Object, len(e.Call.Args))
-			for i := range e.Call.Args {
-				args[i] = vm.eval(e.Call.Args[i])
-			}
-			return fn.Eval(args...)
-		}
 	case *checker.ListLiteral:
 		{
 			raw := make([]*runtime.Object, len(e.Elements))

--- a/vm/interpret.go
+++ b/vm/interpret.go
@@ -386,23 +386,13 @@ func (vm *VM) eval(expr checker.Expression) *runtime.Object {
 		}
 	case *checker.StaticFunctionCall:
 		{
-			// retrieve static definition
-			def, ok := e.Scope.Statics[e.Call.Name]
+			name := e.Scope.Name + "::" + e.Call.Name
+			obj, ok := vm.scope.get(name)
 			if !ok {
-				panic(fmt.Errorf("Undefined function: %s()", e.Call.Name))
+				panic(fmt.Errorf("Undefined function: %s()", name))
 			}
 
-			path := e.Scope.Name + "::" + e.Call.Name
-
-			// if it's not yet in scope, add it
-			obj, ok := vm.scope.get(path)
-			if !ok {
-				obj = vm.eval(def)
-				vm.scope.add(path, obj)
-			}
-
-			// cast to a func
-			fn := obj.Raw().(*VMClosure)
+			fn := obj.Raw().(runtime.Closure)
 
 			args := make([]*runtime.Object, len(e.Call.Args))
 			for i := range e.Call.Args {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -479,12 +479,21 @@ func TestListApi(t *testing.T) {
 			want: 11,
 		},
 		{
-			name: "List::swap swaps values at the given indexes",
+			name: "List.swap swaps values at the given indexes",
 			input: `
 				mut list = [1,2,3]
 				list.swap(0,2)
 				list.at(0)`,
 			want: 3,
+		},
+		{
+			name: "List::concat a combined list",
+			input: `
+				let a = [1,2,3]
+				let b = [4,5,6]
+				let list = List::concat(a, b)
+				list.at(3) == 4`,
+			want: true,
 		},
 	})
 }


### PR DESCRIPTION
static methods don't actually have to be attached to a type. they are simply functions with a more complex identifier

also includes:
* `List::concat()` method for joining lists
* `decode::path()` for decoding nested fields