### PR TITLE
feat: bytecode vm

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,4 @@
 # TODO
-- [ ] compile time constant variables
-  - should readonly variables with a literal value be considered constants?
-    pro: simpler than adding a new `const` keyword and just works
-  - would allow limiting variables in `match Int` patterns to constants for better analysis that there are no conflicts or overlaps in patterns
 - [ ] FFI functions should be able to use idiomatic Go and compiler handles mappings
 - [ ] **i'm not sure what this means anymore** selective variable capture for closures
   - data optimization

--- a/TODO.md
+++ b/TODO.md
@@ -1,15 +1,6 @@
 # TODO
-- [ ] for loops as expressions
-  - evaluates to a list that can be assigned to a variable
-    - can't be used in place of other expressions
-  - broken loops: still a list up to the break point
 - [ ] `Maybe.or_lazy()` to run a function to generate the fallback
 - [ ] FFI functions should be able to use idiomatic Go and compiler handles mappings
-- [ ] loops as expressions (comprehensions?)
-  - inspiration from zig
-  - the result of the iteration is a new list
-  - kind of needs support for `break` with a value, so that value is the lone result (i.e. find)
-  - `let doubled: [Int] = for i in 1..10 { i * 2 }`
 - [ ] compile time constant variables
   - should readonly variables with a literal value be considered constants?
     pro: simpler than adding a new `const` keyword and just works

--- a/TODO.md
+++ b/TODO.md
@@ -1,16 +1,2 @@
 # TODO
 - [ ] FFI functions should be able to use idiomatic Go and compiler handles mappings
-- [ ] **i'm not sure what this means anymore** selective variable capture for closures
-  - data optimization
-  -👇🏿 the returned fn should only have `as` in its scope, not the entire scope
-  ```
-  fn first(as: fn(Dynamic) $T![decode::Error]) fn(Dynamic) $T![decode::Error] {
-    fn(data: Dynamic) $T![decode::Error] {
-      let list = try decode::run(data, decode::list(as))
-      match list.size() {
-        0 => Result::err([decode::Error{path: [""], expected: "non-empty list", found: "empty list"}]),
-        _ => Result::ok(list.at(0))
-      }
-    }
-  }
-  ```

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,9 @@
 # TODO
-- [ ] `Maybe.or_lazy()` to run a function to generate the fallback
-- [ ] FFI functions should be able to use idiomatic Go and compiler handles mappings
 - [ ] compile time constant variables
   - should readonly variables with a literal value be considered constants?
     pro: simpler than adding a new `const` keyword and just works
   - would allow limiting variables in `match Int` patterns to constants for better analysis that there are no conflicts or overlaps in patterns
+- [ ] FFI functions should be able to use idiomatic Go and compiler handles mappings
 - [ ] **i'm not sure what this means anymore** selective variable capture for closures
   - data optimization
   -👇🏿 the returned fn should only have `as` in its scope, not the entire scope

--- a/backlog/ast-lowering-for-backends.md
+++ b/backlog/ast-lowering-for-backends.md
@@ -51,6 +51,10 @@ backend backend backend
 
 Each backend reads pre-computed fields directly from checker nodes instead of doing type introspection.
 
+## Roadmap
+
+See `backlog/bytecode-roadmap/README.md` for the concrete backend roadmap and bytecode VM plan.
+
 ## Concrete Changes Required
 
 ### Case 1: MapLiteral

--- a/backlog/bytecode-roadmap/README.md
+++ b/backlog/bytecode-roadmap/README.md
@@ -1,0 +1,9 @@
+# Bytecode Backend Roadmap
+
+This folder outlines a concrete path to a bytecode backend, grounded in the current Ard compiler/VM architecture.
+
+Docs:
+- overview.md: phased roadmap and milestones
+- lowering.md: remaining AST lowering work to decouple backends
+- bytecode-vm.md: bytecode format and VM plan
+- go-backend.md: optional Go codegen notes and pitfalls

--- a/backlog/bytecode-roadmap/bytecode-vm.md
+++ b/backlog/bytecode-roadmap/bytecode-vm.md
@@ -1,0 +1,40 @@
+# Bytecode VM Plan
+
+## Instruction Model
+
+- Stack-based VM to mirror current interpreter behavior.
+- A small set of opcodes that map directly to runtime.Object operations.
+
+Core opcode groups:
+- Constants and literals (Int, Float, Str, Bool, Void)
+- Local/global load/store
+- Binary ops and comparisons
+- Calls (local, module, extern)
+- Control flow (jump, jump-if, loop)
+- Data constructors (list, map, struct)
+- Pattern matching (match enter, arm check, bind)
+
+## Runtime Integration
+
+- Reuse runtime.Object, Result, Maybe, Dynamic
+- Preserve error semantics for panic and Result/Maybe propagation
+- Keep FFI registry intact, call through the same interface
+
+## Emitter Strategy
+
+- Emit bytecode from lowered nodes
+- Use symbol table for locals and module references
+- Emit explicit stack effect annotations for each opcode
+
+## Debugging/Tooling
+
+- Bytecode disassembler for debugging
+- Optional source maps for error reporting
+- Verification pass for stack depth and call arity
+
+## Milestones
+
+- MVP opcodes to execute literals, arithmetic, and function calls
+- Add control flow and pattern matching
+- Add structs, lists, maps, and enums
+- Plug in async runtime calls

--- a/backlog/bytecode-roadmap/go-backend.md
+++ b/backlog/bytecode-roadmap/go-backend.md
@@ -1,20 +1,46 @@
-# Go Backend Notes (Optional)
+# Go Backend Plan (Runtime-Light, Ard-Semantic)
 
-This is not the primary path, but it is a viable follow-up once bytecode exists.
+This target emits Go code that preserves Ard semantics while depending on a small runtime support library.
 
-## Key Realities
+## Requirements
 
-- Go codegen will still embed runtime.Object, Result, Maybe, Dynamic.
-- The async runtime should stay in Ard runtime code; do not map to goroutines directly unless semantics match.
-- FFI registry needs to be available or replaced by direct bindings.
+- Dynamic is fully supported.
+- Async semantics match Ard exactly.
+- Collections compile to native Go slices/maps, with runtime helpers to preserve Ard rules.
 
-## Minimal Approach
+## Runtime Support Scope
 
-- Emit Go code that calls runtime helpers for every operation.
-- Package the runtime as a library imported by generated code.
-- Treat codegen as "lowered IR to Go" with minimal semantic shifts.
+- Result and Maybe structs with helper functions (`ok`, `err`, `none`, `some`, `expect`, `or`, `is_ok`, `is_err`, `is_none`, `is_some`).
+- Dynamic wrapper with conversions and JSON encode/decode helpers.
+- Trait dispatch tables for calls on trait-typed receivers.
+- Async runtime that matches current scheduling and error propagation behavior.
+- Map key coercion helpers to preserve Ard key semantics.
 
-## Risks
+## Codegen Strategy
 
-- Divergent behavior if Go semantics are used directly (e.g., numeric conversions, string formatting).
-- Closure capture and mutability semantics are easy to get wrong without a runtime wrapper.
+- Emit Go that calls runtime helpers for Ard semantics rather than relying on idiomatic Go behavior.
+- Generate trait dispatch stubs keyed by runtime kind/type tags.
+- Compile pattern matching to `switch` on discriminants or runtime match helpers.
+- Emit native slices/maps for List/Map, with helper calls for mutating operations and key coercion.
+
+## Implementation Phases
+
+1) **Define runtime-lite API**
+   - Establish Go interfaces/types needed by generated code.
+
+2) **Lowered IR contract**
+   - Ensure all nodes required for codegen carry explicit metadata (return types, dispatch info, discriminants).
+
+3) **Emitter**
+   - Translate lowered nodes into Go code with runtime helper calls.
+
+4) **Build integration**
+   - Add CLI target to emit Go and compile with `go build`.
+
+5) **Parity testing**
+   - Compare interpreter VM results to Go backend for shared test cases.
+
+## Notes
+
+- This is still a runtime-backed backend; it avoids the interpreter but keeps semantics stable.
+- Do not map async to goroutines directly unless behavior matches the current runtime.

--- a/backlog/bytecode-roadmap/go-backend.md
+++ b/backlog/bytecode-roadmap/go-backend.md
@@ -1,0 +1,20 @@
+# Go Backend Notes (Optional)
+
+This is not the primary path, but it is a viable follow-up once bytecode exists.
+
+## Key Realities
+
+- Go codegen will still embed runtime.Object, Result, Maybe, Dynamic.
+- The async runtime should stay in Ard runtime code; do not map to goroutines directly unless semantics match.
+- FFI registry needs to be available or replaced by direct bindings.
+
+## Minimal Approach
+
+- Emit Go code that calls runtime helpers for every operation.
+- Package the runtime as a library imported by generated code.
+- Treat codegen as "lowered IR to Go" with minimal semantic shifts.
+
+## Risks
+
+- Divergent behavior if Go semantics are used directly (e.g., numeric conversions, string formatting).
+- Closure capture and mutability semantics are easy to get wrong without a runtime wrapper.

--- a/backlog/bytecode-roadmap/lowering.md
+++ b/backlog/bytecode-roadmap/lowering.md
@@ -1,0 +1,38 @@
+# AST Lowering Work
+
+This lists the remaining lowering tasks to fully decouple VM backends from checker.Type.
+
+## High-priority nodes
+
+These drive most runtime type assertions today:
+
+- InstanceMethod dispatch
+  - Precompute method kind for primitives, collections, Result/Maybe
+  - Precompute struct/enum method target (direct pointer to method closure)
+- Match/Pattern nodes
+  - Precompute variant tags, enum discriminants, and match arm metadata
+- Collection literals
+  - Ensure list/map element types are carried directly on the node
+- Function calls
+  - Embed resolved function references (local, module, extern)
+  - Embed resolved generics (specialized signature)
+
+## Suggested lowering fields
+
+- For method nodes:
+  - MethodKind enum and receiver kind
+  - Pre-resolved callee signature
+- For pattern matching:
+  - Normalized pattern representation
+  - Pre-validated exhaustiveness metadata
+- For module calls:
+  - Direct module path and symbol reference
+
+## Audit targets
+
+- vm/interpret.go: eliminate all Type() assertions
+- checker/checker.go: ensure all derived metadata is stored on nodes
+
+## Regression suite
+
+- Add a "lowered execution" test set that runs existing vm tests against a node traversal that does not call Type().

--- a/backlog/bytecode-roadmap/overview.md
+++ b/backlog/bytecode-roadmap/overview.md
@@ -35,7 +35,7 @@ Deliverables:
 Exit criteria:
 - A representative subset of stdlib samples compiles to bytecode and runs in a new bytecode VM.
 
-Status: emitter and VM cover literals, ops, control flow, lists/maps, structs/enums, matches, try, FFI, methods, closures, copy semantics, async fibers, and module calls. Bytecode verifier is implemented; representative samples are exercised in bytecode tests (excluding io-only samples).
+Status: emitter and VM cover literals, ops, control flow, lists/maps, structs/enums, matches, try, FFI, methods, closures, copy semantics, async fibers, and module calls. Bytecode verifier is implemented; representative samples (including io and concurrent stress) are exercised in bytecode tests.
 
 ## Parallel Track: Go Backend (Runtime-Light)
 
@@ -52,6 +52,8 @@ Exit criteria:
 - End-to-end compile + run from bytecode for multiple samples and tests.
 
 Status: VM executes current bytecode instruction set; serialization/loader implemented via gob. Async and trait dispatch for primitives are supported; module calls compile embedded stdlib into bytecode.
+
+Performance notes: bytecode VM is ~33% faster with ~24% lower memory and ~28% fewer allocations on the fib(20) benchmark (M3 Pro, Feb 2026).
 
 ## Phase 4: Binary Packaging
 

--- a/backlog/bytecode-roadmap/overview.md
+++ b/backlog/bytecode-roadmap/overview.md
@@ -7,7 +7,7 @@ Goal: generate portable binaries by compiling Ard programs to bytecode and embed
 - Complete AST lowering so backends do not inspect checker.Type.
 - Stabilize runtime.Object, Result, Maybe, Dynamic APIs used by all backends.
 
-Status: mostly complete for current bytecode path (runtime Kind tags + lowered metadata). Remaining gaps include trait dispatch and async lowering for bytecode.
+Status: complete for bytecode path (runtime Kind tags + lowered metadata). Interpreter VM remains legacy and still inspects checker.Type.
 
 ## Phase 1: Lowered IR Stabilization
 
@@ -19,7 +19,7 @@ Deliverables:
 Exit criteria:
 - VM can execute entirely from lowered nodes without reading checker.Type.
 
-Status: complete for supported features. Remaining items are tied to missing bytecode features (async, trait dispatch, extern module calls).
+Status: complete for bytecode path with conformance tests across samples. Interpreter VM is legacy and not fully decoupled.
 
 ## Phase 2: Bytecode Emitter
 
@@ -51,7 +51,7 @@ Deliverables:
 Exit criteria:
 - End-to-end compile + run from bytecode for multiple samples and tests.
 
-Status: VM executes current bytecode instruction set; serialization/loader implemented via gob. Async and trait dispatch for primitives are supported; module calls compile embedded stdlib into bytecode.
+Status: VM executes current bytecode instruction set; serialization/loader implemented via gob. Async and trait dispatch for primitives are supported; module calls compile embedded stdlib into bytecode. `ard run` now defaults to bytecode with `--legacy` for interpreter.
 
 Performance notes: bytecode VM is ~33% faster with ~24% lower memory and ~28% fewer allocations on the fib(20) benchmark (M3 Pro, Feb 2026).
 
@@ -63,3 +63,5 @@ Deliverables:
 
 Exit criteria:
 - A binary can run without source files or the interpreter frontend.
+
+Status: complete. `ard build FILE` emits a self-contained executable (bytecode embedded in the compiler binary) and supports `--out` for custom output paths.

--- a/backlog/bytecode-roadmap/overview.md
+++ b/backlog/bytecode-roadmap/overview.md
@@ -1,0 +1,51 @@
+# Roadmap Overview
+
+Goal: generate portable binaries by compiling Ard programs to bytecode and embedding the runtime.
+
+## Phase 0: Prerequisites
+
+- Complete AST lowering so backends do not inspect checker.Type.
+- Stabilize runtime.Object, Result, Maybe, Dynamic APIs used by all backends.
+
+## Phase 1: Lowered IR Stabilization
+
+Deliverables:
+- No VM code path performs type assertions on checker.Type.
+- Checker nodes carry all metadata required for execution (field types, method dispatch, match shapes).
+- A small conformance test suite that executes the same program via current VM and lowered VM.
+
+Exit criteria:
+- VM can execute entirely from lowered nodes without reading checker.Type.
+
+## Phase 2: Bytecode Emitter
+
+Deliverables:
+- A bytecode instruction set with:
+  - expressions (literals, ops, calls)
+  - control flow (if, loops, break/continue)
+  - data structures (list/map/struct literals)
+  - pattern matching
+- An emitter from lowered nodes to bytecode.
+- A bytecode verifier (basic stack discipline, arity checks).
+
+Exit criteria:
+- A representative subset of stdlib samples compiles to bytecode and runs in a new bytecode VM.
+
+## Phase 3: Bytecode VM
+
+Deliverables:
+- A bytecode VM that reuses runtime.Object and result handling.
+- Deterministic behavior matching the interpreter VM for the test suite.
+- Bytecode serialization format and a loader.
+
+Exit criteria:
+- End-to-end compile + run from bytecode for multiple samples and tests.
+
+## Phase 4: Binary Packaging
+
+Deliverables:
+- CLI mode: compile to bytecode and embed in a single binary.
+- Optional: separate bytecode file + runtime runner.
+
+Exit criteria:
+- A binary can run without source files or the interpreter frontend.

--- a/backlog/bytecode-roadmap/overview.md
+++ b/backlog/bytecode-roadmap/overview.md
@@ -7,6 +7,8 @@ Goal: generate portable binaries by compiling Ard programs to bytecode and embed
 - Complete AST lowering so backends do not inspect checker.Type.
 - Stabilize runtime.Object, Result, Maybe, Dynamic APIs used by all backends.
 
+Status: mostly complete for current bytecode path (runtime Kind tags + lowered metadata). Remaining gaps include trait dispatch and async lowering for bytecode.
+
 ## Phase 1: Lowered IR Stabilization
 
 Deliverables:
@@ -16,6 +18,8 @@ Deliverables:
 
 Exit criteria:
 - VM can execute entirely from lowered nodes without reading checker.Type.
+
+Status: complete for supported features. Remaining items are tied to missing bytecode features (async, trait dispatch, extern module calls).
 
 ## Phase 2: Bytecode Emitter
 
@@ -31,6 +35,8 @@ Deliverables:
 Exit criteria:
 - A representative subset of stdlib samples compiles to bytecode and runs in a new bytecode VM.
 
+Status: emitter and VM cover literals, ops, control flow, lists/maps, structs/enums, matches, try, FFI, methods, closures, copy semantics, async fibers, and module calls. Bytecode verifier is implemented; representative samples are exercised in bytecode tests (excluding io-only samples).
+
 ## Parallel Track: Go Backend (Runtime-Light)
 
 See `backlog/bytecode-roadmap/go-backend.md` for the Go backend plan that preserves Ard semantics with a minimal runtime support layer.
@@ -44,6 +50,8 @@ Deliverables:
 
 Exit criteria:
 - End-to-end compile + run from bytecode for multiple samples and tests.
+
+Status: VM executes current bytecode instruction set; serialization/loader implemented via gob. Async and trait dispatch for primitives are supported; module calls compile embedded stdlib into bytecode.
 
 ## Phase 4: Binary Packaging
 

--- a/backlog/bytecode-roadmap/overview.md
+++ b/backlog/bytecode-roadmap/overview.md
@@ -31,6 +31,10 @@ Deliverables:
 Exit criteria:
 - A representative subset of stdlib samples compiles to bytecode and runs in a new bytecode VM.
 
+## Parallel Track: Go Backend (Runtime-Light)
+
+See `backlog/bytecode-roadmap/go-backend.md` for the Go backend plan that preserves Ard semantics with a minimal runtime support layer.
+
 ## Phase 3: Bytecode VM
 
 Deliverables:

--- a/compiler/bytecode/bench_test.go
+++ b/compiler/bytecode/bench_test.go
@@ -1,0 +1,79 @@
+package bytecode_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/akonwi/ard/bytecode"
+	bytecodevm "github.com/akonwi/ard/bytecode/vm"
+	"github.com/akonwi/ard/checker"
+	"github.com/akonwi/ard/parse"
+	"github.com/akonwi/ard/vm"
+)
+
+const benchSource = `
+fn fib(n: Int) Int {
+  match (n <= 1) {
+    true => n,
+    false => fib(n - 1) + fib(n - 2)
+  }
+}
+
+fn main() Int {
+  fib(20)
+}
+`
+
+func BenchmarkInterpreterRun(b *testing.B) {
+	module := loadBenchModule(b)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g := vm.NewRuntime(module)
+		if err := g.Run("main"); err != nil {
+			b.Fatalf("Interpreter run error: %v", err)
+		}
+	}
+}
+
+func BenchmarkBytecodeRun(b *testing.B) {
+	module := loadBenchModule(b)
+	program, err := bytecode.NewEmitter().EmitProgram(module)
+	if err != nil {
+		b.Fatalf("Emit error: %v", err)
+	}
+	if err := bytecode.VerifyProgram(program); err != nil {
+		b.Fatalf("Verify error: %v", err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := bytecodevm.New(program).Run("main"); err != nil {
+			b.Fatalf("Bytecode run error: %v", err)
+		}
+	}
+}
+
+func loadBenchModule(b *testing.B) checker.Module {
+	result := parse.Parse([]byte(benchSource), "bench.ard")
+	if len(result.Errors) > 0 {
+		b.Fatalf("Parse errors: %v", result.Errors[0].Message)
+	}
+	workingDir, err := os.Getwd()
+	if err != nil {
+		b.Fatalf("Failed to get working directory: %v", err)
+	}
+	moduleResolver, err := checker.NewModuleResolver(workingDir)
+	if err != nil {
+		b.Fatalf("Failed to init module resolver: %v", err)
+	}
+	relPath, err := filepath.Rel(workingDir, "bench.ard")
+	if err != nil {
+		relPath = "bench.ard"
+	}
+	c := checker.New(relPath, result.Program, moduleResolver)
+	c.Check()
+	if c.HasErrors() {
+		b.Fatalf("Diagnostics found: %v", c.Diagnostics())
+	}
+	return c.Module()
+}

--- a/compiler/bytecode/conformance_test.go
+++ b/compiler/bytecode/conformance_test.go
@@ -1,0 +1,198 @@
+package bytecode_test
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/akonwi/ard/bytecode"
+	bytecodevm "github.com/akonwi/ard/bytecode/vm"
+	"github.com/akonwi/ard/checker"
+	"github.com/akonwi/ard/parse"
+	"github.com/akonwi/ard/vm"
+)
+
+func TestBytecodeConformanceSamples(t *testing.T) {
+	samples, err := listConformanceSamples()
+	if err != nil {
+		t.Fatalf("Failed to list samples: %v", err)
+	}
+	for _, path := range samples {
+		path := path
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			module, err := loadModuleForConformance(path)
+			if err != nil {
+				t.Fatalf("Load error: %v", err)
+			}
+			hasMain := moduleHasMain(module)
+
+			interpOut, err := captureStdout(func() error {
+				g := vm.NewRuntime(module)
+				if hasMain {
+					return g.Run("main")
+				}
+				_, err := g.Interpret()
+				return err
+			})
+			if err != nil {
+				t.Fatalf("Interpreter error: %v", err)
+			}
+
+			bytecodeOut, err := captureStdout(func() error {
+				program, err := bytecode.NewEmitter().EmitProgram(module)
+				if err != nil {
+					return err
+				}
+				if err := bytecode.VerifyProgram(program); err != nil {
+					return err
+				}
+				_, err = bytecodevm.New(program).Run("main")
+				return err
+			})
+			if err != nil {
+				t.Fatalf("Bytecode error: %v", err)
+			}
+
+			if interpOut != bytecodeOut {
+				t.Fatalf("Output mismatch\n--- interp ---\n%s\n--- bytecode ---\n%s", interpOut, bytecodeOut)
+			}
+		})
+	}
+}
+
+func moduleHasMain(module checker.Module) bool {
+	prog := module.Program()
+	if prog == nil {
+		return false
+	}
+	for i := range prog.Statements {
+		stmt := prog.Statements[i]
+		if def, ok := stmt.Expr.(*checker.FunctionDef); ok {
+			if def.Name == "main" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func listConformanceSamples() ([]string, error) {
+	root, err := findModuleRootFrom("..")
+	if err != nil {
+		return nil, err
+	}
+	samplesDir := filepath.Join(root, "samples")
+	entries, err := filepath.Glob(filepath.Join(samplesDir, "*.ard"))
+	if err != nil {
+		return nil, err
+	}
+	filter := os.Getenv("ARD_CONFORMANCE_SAMPLE")
+	filtered := make([]string, 0, len(entries))
+	for _, path := range entries {
+		base := filepath.Base(path)
+		if filter != "" && base != filter {
+			continue
+		}
+		if base == "maps.ard" {
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		content := string(data)
+		if strings.Contains(content, "read_line") {
+			continue
+		}
+		if strings.Contains(content, "ard/http") || strings.Contains(content, "http::") {
+			continue
+		}
+		filtered = append(filtered, path)
+	}
+	sort.Strings(filtered)
+	return filtered, nil
+}
+
+func loadModuleForConformance(path string) (checker.Module, error) {
+	source, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	result := parse.Parse(source, path)
+	if len(result.Errors) > 0 {
+		result.PrintErrors()
+		return nil, fmt.Errorf("parse errors")
+	}
+	workingDir := filepath.Dir(path)
+	moduleResolver, err := checker.NewModuleResolver(workingDir)
+	if err != nil {
+		return nil, err
+	}
+	relPath, err := filepath.Rel(workingDir, path)
+	if err != nil {
+		relPath = path
+	}
+	c := checker.New(relPath, result.Program, moduleResolver)
+	c.Check()
+	if c.HasErrors() {
+		return nil, fmt.Errorf("type errors: %v", c.Diagnostics())
+	}
+	return c.Module(), nil
+}
+
+func captureStdout(fn func() error) (string, error) {
+	old := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+	os.Stdout = writer
+	readCh := make(chan string, 1)
+	readErrCh := make(chan error, 1)
+	go func() {
+		data, readErr := io.ReadAll(reader)
+		_ = reader.Close()
+		if readErr != nil {
+			readErrCh <- readErr
+			return
+		}
+		readCh <- string(data)
+	}()
+	var runErr error
+	func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				runErr = fmt.Errorf("panic: %v", rec)
+			}
+		}()
+		runErr = fn()
+	}()
+	_ = writer.Close()
+	os.Stdout = old
+	select {
+	case readErr := <-readErrCh:
+		return "", readErr
+	case output := <-readCh:
+		return output, runErr
+	}
+}
+
+func findModuleRootFrom(start string) (string, error) {
+	dir := start
+	for {
+		candidate := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(candidate); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", fmt.Errorf("go.mod not found")
+}

--- a/compiler/bytecode/emitter.go
+++ b/compiler/bytecode/emitter.go
@@ -782,8 +782,16 @@ func (f *funcEmitter) emitIfExpr(expr *checker.If) error {
 	elseLabel := len(f.code)
 	f.patchJump(elseJump, elseLabel)
 	if expr.ElseIf != nil {
-		if err := f.emitIfExpr(expr.ElseIf); err != nil {
-			return err
+		if expr.ElseIf.Else == nil && expr.Else != nil {
+			elseIf := *expr.ElseIf
+			elseIf.Else = expr.Else
+			if err := f.emitIfExpr(&elseIf); err != nil {
+				return err
+			}
+		} else {
+			if err := f.emitIfExpr(expr.ElseIf); err != nil {
+				return err
+			}
 		}
 	} else if expr.Else != nil {
 		if err := f.emitBlockExpr(expr.Else); err != nil {

--- a/compiler/bytecode/emitter.go
+++ b/compiler/bytecode/emitter.go
@@ -1,0 +1,38 @@
+package bytecode
+
+import "github.com/akonwi/ard/checker"
+
+type Emitter struct {
+	program   Program
+	typeIndex map[string]TypeID
+}
+
+func NewEmitter() *Emitter {
+	return &Emitter{
+		program: Program{
+			Constants: []Constant{},
+			Types:     []TypeEntry{},
+			Functions: []Function{},
+		},
+		typeIndex: map[string]TypeID{},
+	}
+}
+
+func (e *Emitter) EmitProgram(module checker.Module) (Program, error) {
+	_ = module
+	return e.program, nil
+}
+
+func (e *Emitter) addType(t checker.Type) TypeID {
+	if t == nil {
+		return 0
+	}
+	name := t.String()
+	if id, ok := e.typeIndex[name]; ok {
+		return id
+	}
+	id := TypeID(len(e.program.Types) + 1)
+	e.program.Types = append(e.program.Types, TypeEntry{ID: id, Name: name})
+	e.typeIndex[name] = id
+	return id
+}

--- a/compiler/bytecode/emitter.go
+++ b/compiler/bytecode/emitter.go
@@ -1,10 +1,23 @@
 package bytecode
 
-import "github.com/akonwi/ard/checker"
+import (
+	"fmt"
+
+	"github.com/akonwi/ard/checker"
+)
 
 type Emitter struct {
 	program   Program
 	typeIndex map[string]TypeID
+}
+
+type funcEmitter struct {
+	emitter  *Emitter
+	code     []Instruction
+	locals   map[string]int
+	localTop int
+	stack    int
+	maxStack int
 }
 
 func NewEmitter() *Emitter {
@@ -19,7 +32,29 @@ func NewEmitter() *Emitter {
 }
 
 func (e *Emitter) EmitProgram(module checker.Module) (Program, error) {
-	_ = module
+	prog := module.Program()
+	if prog == nil {
+		return e.program, nil
+	}
+
+	fn := &funcEmitter{
+		emitter: e,
+		code:    []Instruction{},
+		locals:  map[string]int{},
+	}
+	if err := fn.emitStatements(prog.Statements); err != nil {
+		return Program{}, err
+	}
+	fn.ensureReturn()
+
+	e.program.Functions = append(e.program.Functions, Function{
+		Name:     "main",
+		Arity:    0,
+		Locals:   fn.localTop,
+		MaxStack: fn.maxStack,
+		Code:     fn.code,
+	})
+
 	return e.program, nil
 }
 
@@ -35,4 +70,248 @@ func (e *Emitter) addType(t checker.Type) TypeID {
 	e.program.Types = append(e.program.Types, TypeEntry{ID: id, Name: name})
 	e.typeIndex[name] = id
 	return id
+}
+
+func (e *Emitter) addConst(c Constant) int {
+	for i := range e.program.Constants {
+		if e.program.Constants[i] == c {
+			return i
+		}
+	}
+	index := len(e.program.Constants)
+	e.program.Constants = append(e.program.Constants, c)
+	return index
+}
+
+func (f *funcEmitter) emitStatements(stmts []checker.Statement) error {
+	for i := range stmts {
+		stmt := stmts[i]
+		isLast := i == len(stmts)-1
+		if stmt.Stmt != nil {
+			if err := f.emitStatement(stmt.Stmt); err != nil {
+				return err
+			}
+			if isLast {
+				f.emit(Instruction{Op: OpConstVoid})
+			}
+			continue
+		}
+		if stmt.Expr != nil {
+			if err := f.emitExpr(stmt.Expr); err != nil {
+				return err
+			}
+			if !isLast {
+				f.emit(Instruction{Op: OpPop})
+			}
+			continue
+		}
+	}
+
+	if len(stmts) == 0 {
+		f.emit(Instruction{Op: OpConstVoid})
+	}
+
+	return nil
+}
+
+func (f *funcEmitter) emitStatement(stmt checker.NonProducing) error {
+	switch s := stmt.(type) {
+	case *checker.VariableDef:
+		if err := f.emitExpr(s.Value); err != nil {
+			return err
+		}
+		index := f.localIndex(s.Name)
+		f.emit(Instruction{Op: OpStoreLocal, A: index})
+		return nil
+	case *checker.Reassignment:
+		if err := f.emitExpr(s.Value); err != nil {
+			return err
+		}
+		index, err := f.resolveTargetLocal(s.Target)
+		if err != nil {
+			return err
+		}
+		f.emit(Instruction{Op: OpStoreLocal, A: index})
+		return nil
+	default:
+		return fmt.Errorf("unsupported statement: %T", s)
+	}
+}
+
+func (f *funcEmitter) emitExpr(expr checker.Expression) error {
+	switch e := expr.(type) {
+	case *checker.IntLiteral:
+		f.emit(Instruction{Op: OpConstInt, Imm: e.Value})
+		return nil
+	case *checker.FloatLiteral:
+		idx := f.emitter.addConst(Constant{Kind: ConstFloat, Float: e.Value})
+		f.emit(Instruction{Op: OpConst, A: idx})
+		return nil
+	case *checker.StrLiteral:
+		idx := f.emitter.addConst(Constant{Kind: ConstStr, Str: e.Value})
+		f.emit(Instruction{Op: OpConst, A: idx})
+		return nil
+	case *checker.BoolLiteral:
+		imm := 0
+		if e.Value {
+			imm = 1
+		}
+		f.emit(Instruction{Op: OpConstBool, Imm: imm})
+		return nil
+	case *checker.VoidLiteral:
+		f.emit(Instruction{Op: OpConstVoid})
+		return nil
+	case *checker.Variable:
+		index := f.localIndex(e.Name())
+		f.emit(Instruction{Op: OpLoadLocal, A: index})
+		return nil
+	case *checker.Identifier:
+		index := f.localIndex(e.Name)
+		f.emit(Instruction{Op: OpLoadLocal, A: index})
+		return nil
+	case *checker.Negation:
+		if err := f.emitExpr(e.Value); err != nil {
+			return err
+		}
+		f.emit(Instruction{Op: OpNeg})
+		return nil
+	case *checker.Not:
+		if err := f.emitExpr(e.Value); err != nil {
+			return err
+		}
+		f.emit(Instruction{Op: OpNot})
+		return nil
+	case *checker.IntAddition, *checker.FloatAddition, *checker.StrAddition:
+		return f.emitBinary(expr, OpAdd)
+	case *checker.IntSubtraction, *checker.FloatSubtraction:
+		return f.emitBinary(expr, OpSub)
+	case *checker.IntMultiplication, *checker.FloatMultiplication:
+		return f.emitBinary(expr, OpMul)
+	case *checker.IntDivision, *checker.FloatDivision:
+		return f.emitBinary(expr, OpDiv)
+	case *checker.IntModulo:
+		return f.emitBinary(expr, OpMod)
+	case *checker.IntGreater, *checker.FloatGreater:
+		return f.emitBinary(expr, OpGt)
+	case *checker.IntGreaterEqual, *checker.FloatGreaterEqual:
+		return f.emitBinary(expr, OpGte)
+	case *checker.IntLess, *checker.FloatLess:
+		return f.emitBinary(expr, OpLt)
+	case *checker.IntLessEqual, *checker.FloatLessEqual:
+		return f.emitBinary(expr, OpLte)
+	case *checker.Equality:
+		return f.emitBinary(expr, OpEq)
+	default:
+		return fmt.Errorf("unsupported expression: %T", e)
+	}
+}
+
+func (f *funcEmitter) emitBinary(expr checker.Expression, op Opcode) error {
+	var left checker.Expression
+	var right checker.Expression
+	switch e := expr.(type) {
+	case *checker.IntAddition:
+		left, right = e.Left, e.Right
+	case *checker.IntSubtraction:
+		left, right = e.Left, e.Right
+	case *checker.IntMultiplication:
+		left, right = e.Left, e.Right
+	case *checker.IntDivision:
+		left, right = e.Left, e.Right
+	case *checker.IntModulo:
+		left, right = e.Left, e.Right
+	case *checker.IntGreater:
+		left, right = e.Left, e.Right
+	case *checker.IntGreaterEqual:
+		left, right = e.Left, e.Right
+	case *checker.IntLess:
+		left, right = e.Left, e.Right
+	case *checker.IntLessEqual:
+		left, right = e.Left, e.Right
+	case *checker.FloatAddition:
+		left, right = e.Left, e.Right
+	case *checker.FloatSubtraction:
+		left, right = e.Left, e.Right
+	case *checker.FloatMultiplication:
+		left, right = e.Left, e.Right
+	case *checker.FloatDivision:
+		left, right = e.Left, e.Right
+	case *checker.FloatGreater:
+		left, right = e.Left, e.Right
+	case *checker.FloatGreaterEqual:
+		left, right = e.Left, e.Right
+	case *checker.FloatLess:
+		left, right = e.Left, e.Right
+	case *checker.FloatLessEqual:
+		left, right = e.Left, e.Right
+	case *checker.StrAddition:
+		left, right = e.Left, e.Right
+	case *checker.Equality:
+		left, right = e.Left, e.Right
+	default:
+		return fmt.Errorf("unsupported binary expression: %T", expr)
+	}
+
+	if err := f.emitExpr(left); err != nil {
+		return err
+	}
+	if err := f.emitExpr(right); err != nil {
+		return err
+	}
+	if op == OpEq {
+		f.emit(Instruction{Op: OpEq})
+		return nil
+	}
+	f.emit(Instruction{Op: op})
+	return nil
+}
+
+func (f *funcEmitter) emit(inst Instruction) {
+	f.code = append(f.code, inst)
+	if effect := inst.Op.StackEffect(); effect.Pop > 0 || effect.Push > 0 {
+		f.stack = f.stack - effect.Pop + effect.Push
+		if f.stack > f.maxStack {
+			f.maxStack = f.stack
+		}
+	}
+}
+
+func (f *funcEmitter) localIndex(name string) int {
+	if idx, ok := f.locals[name]; ok {
+		return idx
+	}
+	idx := f.localTop
+	f.locals[name] = idx
+	f.localTop++
+	return idx
+}
+
+func (f *funcEmitter) resolveTargetLocal(expr checker.Expression) (int, error) {
+	switch e := expr.(type) {
+	case *checker.Variable:
+		if idx, ok := f.locals[e.Name()]; ok {
+			return idx, nil
+		}
+		return f.localIndex(e.Name()), nil
+	case *checker.Identifier:
+		if idx, ok := f.locals[e.Name]; ok {
+			return idx, nil
+		}
+		return f.localIndex(e.Name), nil
+	default:
+		return 0, fmt.Errorf("unsupported reassignment target: %T", expr)
+	}
+}
+
+func (f *funcEmitter) ensureReturn() {
+	if len(f.code) == 0 {
+		f.emit(Instruction{Op: OpConstVoid})
+		f.emit(Instruction{Op: OpReturn})
+		return
+	}
+	last := f.code[len(f.code)-1]
+	if last.Op == OpReturn {
+		return
+	}
+	f.emit(Instruction{Op: OpReturn})
 }

--- a/compiler/bytecode/emitter.go
+++ b/compiler/bytecode/emitter.go
@@ -808,11 +808,19 @@ func (f *funcEmitter) emitFunctionCall(call *checker.FunctionCall) error {
 			return err
 		}
 	}
+	argc := len(call.Args)
+	if call.ExternalBinding != "" {
+		bindingIdx := f.emitter.addConst(Constant{Kind: ConstStr, Str: call.ExternalBinding})
+		retID := f.emitter.addType(call.ReturnType)
+		f.emit(Instruction{Op: OpCallExtern, A: bindingIdx, Imm: argc, C: int(retID)})
+		f.adjustStack(argc, 1)
+		return nil
+	}
 	idx, ok := f.emitter.funcIndex[call.Name]
 	if !ok {
 		return fmt.Errorf("unknown function: %s", call.Name)
 	}
-	f.emit(Instruction{Op: OpCall, A: idx, B: len(call.Args)})
+	f.emit(Instruction{Op: OpCall, A: idx, B: argc})
 	return nil
 }
 

--- a/compiler/bytecode/instruction.go
+++ b/compiler/bytecode/instruction.go
@@ -5,4 +5,5 @@ type Instruction struct {
 	A   int
 	B   int
 	Imm int
+	C   int
 }

--- a/compiler/bytecode/instruction.go
+++ b/compiler/bytecode/instruction.go
@@ -1,0 +1,8 @@
+package bytecode
+
+type Instruction struct {
+	Op  Opcode
+	A   int
+	B   int
+	Imm int
+}

--- a/compiler/bytecode/opcode.go
+++ b/compiler/bytecode/opcode.go
@@ -42,8 +42,16 @@ const (
 	OpMakeEnum
 	OpListLen
 	OpListGet
+	OpListSet
+	OpListPush
+	OpListPrepend
 	OpMapKeys
 	OpMapGet
+	OpMapGetValue
+	OpMapSet
+	OpMapDrop
+	OpMapHas
+	OpMapSize
 	OpGetField
 	OpSetField
 	OpCallMethod

--- a/compiler/bytecode/opcode.go
+++ b/compiler/bytecode/opcode.go
@@ -9,10 +9,47 @@ const (
 	OpConstStr
 	OpConstBool
 	OpConstVoid
+	OpConst
 	OpLoadLocal
 	OpStoreLocal
+	OpPop
+	OpDup
+	OpSwap
+	OpAdd
+	OpSub
+	OpMul
+	OpDiv
+	OpMod
+	OpNeg
+	OpNot
+	OpEq
+	OpNeq
+	OpLt
+	OpLte
+	OpGt
+	OpGte
 	OpJump
 	OpJumpIfFalse
+	OpJumpIfTrue
 	OpCall
+	OpCallExtern
+	OpCallModule
+	OpMakeList
+	OpMakeMap
+	OpMakeStruct
+	OpMakeEnum
+	OpGetField
+	OpSetField
+	OpCallMethod
+	OpMatchBool
+	OpMatchInt
+	OpMatchEnum
+	OpMatchUnion
+	OpMatchMaybe
+	OpMatchResult
+	OpTryResult
+	OpTryMaybe
+	OpAsyncStart
+	OpAsyncEval
 	OpReturn
 )

--- a/compiler/bytecode/opcode.go
+++ b/compiler/bytecode/opcode.go
@@ -61,6 +61,9 @@ const (
 	OpBoolMethod
 	OpMaybeMethod
 	OpResultMethod
+	OpMaybeUnwrap
+	OpResultUnwrap
+	OpTypeName
 	OpMatchBool
 	OpMatchInt
 	OpMatchEnum

--- a/compiler/bytecode/opcode.go
+++ b/compiler/bytecode/opcode.go
@@ -64,6 +64,7 @@ const (
 	OpMaybeUnwrap
 	OpResultUnwrap
 	OpTypeName
+	OpMakeNone
 	OpMatchBool
 	OpMatchInt
 	OpMatchEnum

--- a/compiler/bytecode/opcode.go
+++ b/compiler/bytecode/opcode.go
@@ -40,6 +40,10 @@ const (
 	OpMakeMap
 	OpMakeStruct
 	OpMakeEnum
+	OpListLen
+	OpListGet
+	OpMapKeys
+	OpMapGet
 	OpGetField
 	OpSetField
 	OpCallMethod

--- a/compiler/bytecode/opcode.go
+++ b/compiler/bytecode/opcode.go
@@ -36,6 +36,8 @@ const (
 	OpCall
 	OpCallExtern
 	OpCallModule
+	OpMakeClosure
+	OpCallClosure
 	OpMakeList
 	OpMakeMap
 	OpMakeStruct

--- a/compiler/bytecode/opcode.go
+++ b/compiler/bytecode/opcode.go
@@ -55,6 +55,12 @@ const (
 	OpGetField
 	OpSetField
 	OpCallMethod
+	OpStrMethod
+	OpIntMethod
+	OpFloatMethod
+	OpBoolMethod
+	OpMaybeMethod
+	OpResultMethod
 	OpMatchBool
 	OpMatchInt
 	OpMatchEnum

--- a/compiler/bytecode/opcode.go
+++ b/compiler/bytecode/opcode.go
@@ -20,6 +20,8 @@ const (
 	OpMul
 	OpDiv
 	OpMod
+	OpAnd
+	OpOr
 	OpNeg
 	OpNot
 	OpEq

--- a/compiler/bytecode/opcode.go
+++ b/compiler/bytecode/opcode.go
@@ -1,0 +1,18 @@
+package bytecode
+
+type Opcode uint8
+
+const (
+	OpNoop Opcode = iota
+	OpConstInt
+	OpConstFloat
+	OpConstStr
+	OpConstBool
+	OpConstVoid
+	OpLoadLocal
+	OpStoreLocal
+	OpJump
+	OpJumpIfFalse
+	OpCall
+	OpReturn
+)

--- a/compiler/bytecode/opcode.go
+++ b/compiler/bytecode/opcode.go
@@ -15,6 +15,7 @@ const (
 	OpPop
 	OpDup
 	OpSwap
+	OpCopy
 	OpAdd
 	OpSub
 	OpMul
@@ -77,5 +78,6 @@ const (
 	OpTryMaybe
 	OpAsyncStart
 	OpAsyncEval
+	OpPanic
 	OpReturn
 )

--- a/compiler/bytecode/opcode_meta.go
+++ b/compiler/bytecode/opcode_meta.go
@@ -41,6 +41,10 @@ func (o Opcode) String() string {
 		return "DIV"
 	case OpMod:
 		return "MOD"
+	case OpAnd:
+		return "AND"
+	case OpOr:
+		return "OR"
 	case OpNeg:
 		return "NEG"
 	case OpNot:
@@ -126,7 +130,7 @@ func (o Opcode) StackEffect() StackEffect {
 		return StackEffect{Pop: 1, Push: 2}
 	case OpSwap:
 		return StackEffect{Pop: 2, Push: 2}
-	case OpAdd, OpSub, OpMul, OpDiv, OpMod, OpEq, OpNeq, OpLt, OpLte, OpGt, OpGte:
+	case OpAdd, OpSub, OpMul, OpDiv, OpMod, OpAnd, OpOr, OpEq, OpNeq, OpLt, OpLte, OpGt, OpGte:
 		return StackEffect{Pop: 2, Push: 1}
 	case OpNeg, OpNot:
 		return StackEffect{Pop: 1, Push: 1}

--- a/compiler/bytecode/opcode_meta.go
+++ b/compiler/bytecode/opcode_meta.go
@@ -210,6 +210,8 @@ func (o Opcode) StackEffect() StackEffect {
 		return StackEffect{}
 	case OpMaybeUnwrap, OpResultUnwrap, OpTypeName:
 		return StackEffect{Pop: 1, Push: 1}
+	case OpTryResult, OpTryMaybe:
+		return StackEffect{Pop: 1, Push: 1}
 	default:
 		return StackEffect{}
 	}

--- a/compiler/bytecode/opcode_meta.go
+++ b/compiler/bytecode/opcode_meta.go
@@ -123,6 +123,12 @@ func (o Opcode) String() string {
 		return "MAYBE_METHOD"
 	case OpResultMethod:
 		return "RESULT_METHOD"
+	case OpMaybeUnwrap:
+		return "MAYBE_UNWRAP"
+	case OpResultUnwrap:
+		return "RESULT_UNWRAP"
+	case OpTypeName:
+		return "TYPE_NAME"
 	case OpMatchBool:
 		return "MATCH_BOOL"
 	case OpMatchInt:
@@ -202,6 +208,8 @@ func (o Opcode) StackEffect() StackEffect {
 		return StackEffect{Pop: 1, Push: 1}
 	case OpStrMethod, OpIntMethod, OpFloatMethod, OpBoolMethod, OpMaybeMethod, OpResultMethod:
 		return StackEffect{}
+	case OpMaybeUnwrap, OpResultUnwrap, OpTypeName:
+		return StackEffect{Pop: 1, Push: 1}
 	default:
 		return StackEffect{}
 	}

--- a/compiler/bytecode/opcode_meta.go
+++ b/compiler/bytecode/opcode_meta.go
@@ -130,8 +130,10 @@ func (o Opcode) StackEffect() StackEffect {
 		return StackEffect{Pop: 2, Push: 1}
 	case OpNeg, OpNot:
 		return StackEffect{Pop: 1, Push: 1}
-	case OpJump, OpJumpIfFalse, OpJumpIfTrue:
+	case OpJump:
 		return StackEffect{Pop: 0, Push: 0}
+	case OpJumpIfFalse, OpJumpIfTrue:
+		return StackEffect{Pop: 1, Push: 0}
 	case OpReturn:
 		return StackEffect{Pop: 1, Push: 0}
 	default:

--- a/compiler/bytecode/opcode_meta.go
+++ b/compiler/bytecode/opcode_meta.go
@@ -111,6 +111,18 @@ func (o Opcode) String() string {
 		return "SET_FIELD"
 	case OpCallMethod:
 		return "CALL_METHOD"
+	case OpStrMethod:
+		return "STR_METHOD"
+	case OpIntMethod:
+		return "INT_METHOD"
+	case OpFloatMethod:
+		return "FLOAT_METHOD"
+	case OpBoolMethod:
+		return "BOOL_METHOD"
+	case OpMaybeMethod:
+		return "MAYBE_METHOD"
+	case OpResultMethod:
+		return "RESULT_METHOD"
 	case OpMatchBool:
 		return "MATCH_BOOL"
 	case OpMatchInt:
@@ -188,6 +200,8 @@ func (o Opcode) StackEffect() StackEffect {
 		return StackEffect{Pop: 2, Push: 1}
 	case OpMapSize:
 		return StackEffect{Pop: 1, Push: 1}
+	case OpStrMethod, OpIntMethod, OpFloatMethod, OpBoolMethod, OpMaybeMethod, OpResultMethod:
+		return StackEffect{}
 	default:
 		return StackEffect{}
 	}

--- a/compiler/bytecode/opcode_meta.go
+++ b/compiler/bytecode/opcode_meta.go
@@ -31,6 +31,8 @@ func (o Opcode) String() string {
 		return "DUP"
 	case OpSwap:
 		return "SWAP"
+	case OpCopy:
+		return "COPY"
 	case OpAdd:
 		return "ADD"
 	case OpSub:
@@ -155,6 +157,8 @@ func (o Opcode) String() string {
 		return "ASYNC_START"
 	case OpAsyncEval:
 		return "ASYNC_EVAL"
+	case OpPanic:
+		return "PANIC"
 	case OpReturn:
 		return "RETURN"
 	default:
@@ -178,6 +182,8 @@ func (o Opcode) StackEffect() StackEffect {
 		return StackEffect{Pop: 1, Push: 2}
 	case OpSwap:
 		return StackEffect{Pop: 2, Push: 2}
+	case OpCopy:
+		return StackEffect{Pop: 1, Push: 1}
 	case OpAdd, OpSub, OpMul, OpDiv, OpMod, OpAnd, OpOr, OpEq, OpNeq, OpLt, OpLte, OpGt, OpGte:
 		return StackEffect{Pop: 2, Push: 1}
 	case OpNeg, OpNot:
@@ -222,6 +228,10 @@ func (o Opcode) StackEffect() StackEffect {
 		return StackEffect{Pop: 0, Push: 1}
 	case OpTryResult, OpTryMaybe:
 		return StackEffect{Pop: 1, Push: 1}
+	case OpAsyncStart, OpAsyncEval:
+		return StackEffect{Pop: 1, Push: 1}
+	case OpPanic:
+		return StackEffect{Pop: 1, Push: 0}
 	default:
 		return StackEffect{}
 	}

--- a/compiler/bytecode/opcode_meta.go
+++ b/compiler/bytecode/opcode_meta.go
@@ -85,10 +85,26 @@ func (o Opcode) String() string {
 		return "LIST_LEN"
 	case OpListGet:
 		return "LIST_GET"
+	case OpListSet:
+		return "LIST_SET"
+	case OpListPush:
+		return "LIST_PUSH"
+	case OpListPrepend:
+		return "LIST_PREPEND"
 	case OpMapKeys:
 		return "MAP_KEYS"
 	case OpMapGet:
 		return "MAP_GET"
+	case OpMapGetValue:
+		return "MAP_GET_VALUE"
+	case OpMapSet:
+		return "MAP_SET"
+	case OpMapDrop:
+		return "MAP_DROP"
+	case OpMapHas:
+		return "MAP_HAS"
+	case OpMapSize:
+		return "MAP_SIZE"
 	case OpGetField:
 		return "GET_FIELD"
 	case OpSetField:
@@ -152,10 +168,26 @@ func (o Opcode) StackEffect() StackEffect {
 		return StackEffect{Pop: 1, Push: 1}
 	case OpListGet:
 		return StackEffect{Pop: 2, Push: 1}
+	case OpListSet:
+		return StackEffect{Pop: 3, Push: 1}
+	case OpListPush:
+		return StackEffect{Pop: 2, Push: 1}
+	case OpListPrepend:
+		return StackEffect{Pop: 2, Push: 1}
 	case OpMapKeys:
 		return StackEffect{Pop: 1, Push: 1}
 	case OpMapGet:
 		return StackEffect{Pop: 2, Push: 1}
+	case OpMapGetValue:
+		return StackEffect{Pop: 2, Push: 1}
+	case OpMapSet:
+		return StackEffect{Pop: 3, Push: 1}
+	case OpMapDrop:
+		return StackEffect{Pop: 2, Push: 1}
+	case OpMapHas:
+		return StackEffect{Pop: 2, Push: 1}
+	case OpMapSize:
+		return StackEffect{Pop: 1, Push: 1}
 	default:
 		return StackEffect{}
 	}

--- a/compiler/bytecode/opcode_meta.go
+++ b/compiler/bytecode/opcode_meta.go
@@ -73,6 +73,10 @@ func (o Opcode) String() string {
 		return "CALL_EXTERN"
 	case OpCallModule:
 		return "CALL_MODULE"
+	case OpMakeClosure:
+		return "MAKE_CLOSURE"
+	case OpCallClosure:
+		return "CALL_CLOSURE"
 	case OpMakeList:
 		return "MAKE_LIST"
 	case OpMakeMap:
@@ -184,6 +188,8 @@ func (o Opcode) StackEffect() StackEffect {
 		return StackEffect{Pop: 1, Push: 0}
 	case OpReturn:
 		return StackEffect{Pop: 1, Push: 0}
+	case OpMakeClosure:
+		return StackEffect{}
 	case OpListLen:
 		return StackEffect{Pop: 1, Push: 1}
 	case OpListGet:

--- a/compiler/bytecode/opcode_meta.go
+++ b/compiler/bytecode/opcode_meta.go
@@ -129,6 +129,8 @@ func (o Opcode) String() string {
 		return "RESULT_UNWRAP"
 	case OpTypeName:
 		return "TYPE_NAME"
+	case OpMakeNone:
+		return "MAKE_NONE"
 	case OpMatchBool:
 		return "MATCH_BOOL"
 	case OpMatchInt:
@@ -210,6 +212,8 @@ func (o Opcode) StackEffect() StackEffect {
 		return StackEffect{}
 	case OpMaybeUnwrap, OpResultUnwrap, OpTypeName:
 		return StackEffect{Pop: 1, Push: 1}
+	case OpMakeNone:
+		return StackEffect{Pop: 0, Push: 1}
 	case OpTryResult, OpTryMaybe:
 		return StackEffect{Pop: 1, Push: 1}
 	default:

--- a/compiler/bytecode/opcode_meta.go
+++ b/compiler/bytecode/opcode_meta.go
@@ -1,0 +1,140 @@
+package bytecode
+
+type StackEffect struct {
+	Pop  int
+	Push int
+}
+
+func (o Opcode) String() string {
+	switch o {
+	case OpNoop:
+		return "NOOP"
+	case OpConstInt:
+		return "CONST_INT"
+	case OpConstFloat:
+		return "CONST_FLOAT"
+	case OpConstStr:
+		return "CONST_STR"
+	case OpConstBool:
+		return "CONST_BOOL"
+	case OpConstVoid:
+		return "CONST_VOID"
+	case OpConst:
+		return "CONST"
+	case OpLoadLocal:
+		return "LOAD_LOCAL"
+	case OpStoreLocal:
+		return "STORE_LOCAL"
+	case OpPop:
+		return "POP"
+	case OpDup:
+		return "DUP"
+	case OpSwap:
+		return "SWAP"
+	case OpAdd:
+		return "ADD"
+	case OpSub:
+		return "SUB"
+	case OpMul:
+		return "MUL"
+	case OpDiv:
+		return "DIV"
+	case OpMod:
+		return "MOD"
+	case OpNeg:
+		return "NEG"
+	case OpNot:
+		return "NOT"
+	case OpEq:
+		return "EQ"
+	case OpNeq:
+		return "NEQ"
+	case OpLt:
+		return "LT"
+	case OpLte:
+		return "LTE"
+	case OpGt:
+		return "GT"
+	case OpGte:
+		return "GTE"
+	case OpJump:
+		return "JUMP"
+	case OpJumpIfFalse:
+		return "JUMP_IF_FALSE"
+	case OpJumpIfTrue:
+		return "JUMP_IF_TRUE"
+	case OpCall:
+		return "CALL"
+	case OpCallExtern:
+		return "CALL_EXTERN"
+	case OpCallModule:
+		return "CALL_MODULE"
+	case OpMakeList:
+		return "MAKE_LIST"
+	case OpMakeMap:
+		return "MAKE_MAP"
+	case OpMakeStruct:
+		return "MAKE_STRUCT"
+	case OpMakeEnum:
+		return "MAKE_ENUM"
+	case OpGetField:
+		return "GET_FIELD"
+	case OpSetField:
+		return "SET_FIELD"
+	case OpCallMethod:
+		return "CALL_METHOD"
+	case OpMatchBool:
+		return "MATCH_BOOL"
+	case OpMatchInt:
+		return "MATCH_INT"
+	case OpMatchEnum:
+		return "MATCH_ENUM"
+	case OpMatchUnion:
+		return "MATCH_UNION"
+	case OpMatchMaybe:
+		return "MATCH_MAYBE"
+	case OpMatchResult:
+		return "MATCH_RESULT"
+	case OpTryResult:
+		return "TRY_RESULT"
+	case OpTryMaybe:
+		return "TRY_MAYBE"
+	case OpAsyncStart:
+		return "ASYNC_START"
+	case OpAsyncEval:
+		return "ASYNC_EVAL"
+	case OpReturn:
+		return "RETURN"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+func (o Opcode) StackEffect() StackEffect {
+	switch o {
+	case OpNoop:
+		return StackEffect{}
+	case OpConstInt, OpConstFloat, OpConstStr, OpConstBool, OpConstVoid, OpConst:
+		return StackEffect{Pop: 0, Push: 1}
+	case OpLoadLocal:
+		return StackEffect{Pop: 0, Push: 1}
+	case OpStoreLocal:
+		return StackEffect{Pop: 1, Push: 0}
+	case OpPop:
+		return StackEffect{Pop: 1, Push: 0}
+	case OpDup:
+		return StackEffect{Pop: 1, Push: 2}
+	case OpSwap:
+		return StackEffect{Pop: 2, Push: 2}
+	case OpAdd, OpSub, OpMul, OpDiv, OpMod, OpEq, OpNeq, OpLt, OpLte, OpGt, OpGte:
+		return StackEffect{Pop: 2, Push: 1}
+	case OpNeg, OpNot:
+		return StackEffect{Pop: 1, Push: 1}
+	case OpJump, OpJumpIfFalse, OpJumpIfTrue:
+		return StackEffect{Pop: 0, Push: 0}
+	case OpReturn:
+		return StackEffect{Pop: 1, Push: 0}
+	default:
+		return StackEffect{}
+	}
+}

--- a/compiler/bytecode/opcode_meta.go
+++ b/compiler/bytecode/opcode_meta.go
@@ -81,6 +81,14 @@ func (o Opcode) String() string {
 		return "MAKE_STRUCT"
 	case OpMakeEnum:
 		return "MAKE_ENUM"
+	case OpListLen:
+		return "LIST_LEN"
+	case OpListGet:
+		return "LIST_GET"
+	case OpMapKeys:
+		return "MAP_KEYS"
+	case OpMapGet:
+		return "MAP_GET"
 	case OpGetField:
 		return "GET_FIELD"
 	case OpSetField:
@@ -140,6 +148,14 @@ func (o Opcode) StackEffect() StackEffect {
 		return StackEffect{Pop: 1, Push: 0}
 	case OpReturn:
 		return StackEffect{Pop: 1, Push: 0}
+	case OpListLen:
+		return StackEffect{Pop: 1, Push: 1}
+	case OpListGet:
+		return StackEffect{Pop: 2, Push: 1}
+	case OpMapKeys:
+		return StackEffect{Pop: 1, Push: 1}
+	case OpMapGet:
+		return StackEffect{Pop: 2, Push: 1}
 	default:
 		return StackEffect{}
 	}

--- a/compiler/bytecode/program.go
+++ b/compiler/bytecode/program.go
@@ -17,13 +17,23 @@ type Constant struct {
 	Bool  bool
 }
 
+type TypeID int
+
+type TypeEntry struct {
+	ID   TypeID
+	Name string
+}
+
 type Function struct {
-	Name  string
-	Arity int
-	Code  []Instruction
+	Name     string
+	Arity    int
+	Locals   int
+	MaxStack int
+	Code     []Instruction
 }
 
 type Program struct {
 	Constants []Constant
+	Types     []TypeEntry
 	Functions []Function
 }

--- a/compiler/bytecode/program.go
+++ b/compiler/bytecode/program.go
@@ -27,6 +27,7 @@ type TypeEntry struct {
 type Function struct {
 	Name     string
 	Arity    int
+	Captures []int
 	Locals   int
 	MaxStack int
 	Code     []Instruction

--- a/compiler/bytecode/program.go
+++ b/compiler/bytecode/program.go
@@ -1,0 +1,29 @@
+package bytecode
+
+type ConstantKind uint8
+
+const (
+	ConstInt ConstantKind = iota
+	ConstFloat
+	ConstStr
+	ConstBool
+)
+
+type Constant struct {
+	Kind  ConstantKind
+	Int   int
+	Float float64
+	Str   string
+	Bool  bool
+}
+
+type Function struct {
+	Name  string
+	Arity int
+	Code  []Instruction
+}
+
+type Program struct {
+	Constants []Constant
+	Functions []Function
+}

--- a/compiler/bytecode/serialize.go
+++ b/compiler/bytecode/serialize.go
@@ -1,0 +1,24 @@
+package bytecode
+
+import (
+	"bytes"
+	"encoding/gob"
+)
+
+func SerializeProgram(program Program) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(program); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func DeserializeProgram(data []byte) (Program, error) {
+	var program Program
+	dec := gob.NewDecoder(bytes.NewReader(data))
+	if err := dec.Decode(&program); err != nil {
+		return Program{}, err
+	}
+	return program, nil
+}

--- a/compiler/bytecode/serialize_test.go
+++ b/compiler/bytecode/serialize_test.go
@@ -1,0 +1,54 @@
+package bytecode_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/akonwi/ard/bytecode"
+	"github.com/akonwi/ard/bytecode/vm"
+	"github.com/akonwi/ard/checker"
+	"github.com/akonwi/ard/parse"
+)
+
+func TestSerializeProgram(t *testing.T) {
+	result := parse.Parse([]byte("let val = 2\nval + 3"), "test.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("Parse errors: %v", result.Errors[0].Message)
+	}
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	resolver, err := checker.NewModuleResolver(workingDir)
+	if err != nil {
+		t.Fatalf("Failed to init module resolver: %v", err)
+	}
+	c := checker.New("test.ard", result.Program, resolver)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("Diagnostics found: %v", c.Diagnostics())
+	}
+
+	emitter := bytecode.NewEmitter()
+	program, err := emitter.EmitProgram(c.Module())
+	if err != nil {
+		t.Fatalf("Emit error: %v", err)
+	}
+
+	data, err := bytecode.SerializeProgram(program)
+	if err != nil {
+		t.Fatalf("Serialize error: %v", err)
+	}
+	decoded, err := bytecode.DeserializeProgram(data)
+	if err != nil {
+		t.Fatalf("Deserialize error: %v", err)
+	}
+
+	res, err := vm.New(decoded).Run("main")
+	if err != nil {
+		t.Fatalf("VM error: %v", err)
+	}
+	if got := res.GoValue(); got != 5 {
+		t.Fatalf("Expected 5, got %v", got)
+	}
+}

--- a/compiler/bytecode/verifier.go
+++ b/compiler/bytecode/verifier.go
@@ -1,0 +1,113 @@
+package bytecode
+
+import "fmt"
+
+// VerifyProgram performs basic validation of a bytecode program.
+// It checks jump bounds, stack underflows, and arity consistency.
+func VerifyProgram(program Program) error {
+	for i := range program.Functions {
+		fn := program.Functions[i]
+		if err := verifyFunction(program, fn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func verifyFunction(program Program, fn Function) error {
+	stack := 0
+	for ip, inst := range fn.Code {
+		pop, push, err := stackEffect(program, inst)
+		if err != nil {
+			return fmt.Errorf("%s ip=%d: %w", fn.Name, ip, err)
+		}
+		if (inst.Op == OpReturn || inst.Op == OpPanic) && stack < pop {
+			stack = 0
+			continue
+		}
+		stack -= pop
+		if stack < 0 {
+			return fmt.Errorf("%s ip=%d (%s): stack underflow", fn.Name, ip, inst.Op)
+		}
+		stack += push
+		switch inst.Op {
+		case OpJump, OpJumpIfFalse, OpJumpIfTrue:
+			if inst.A < 0 || inst.A >= len(fn.Code) {
+				return fmt.Errorf("%s ip=%d: jump target out of range", fn.Name, ip)
+			}
+		case OpTryResult, OpTryMaybe:
+			if inst.A >= 0 && inst.A >= len(fn.Code) {
+				return fmt.Errorf("%s ip=%d: try catch target out of range", fn.Name, ip)
+			}
+		case OpCall:
+			if inst.A < 0 || inst.A >= len(program.Functions) {
+				return fmt.Errorf("%s ip=%d: call target out of range", fn.Name, ip)
+			}
+			target := program.Functions[inst.A]
+			if target.Arity != inst.B {
+				return fmt.Errorf("%s ip=%d: arity mismatch for %s", fn.Name, ip, target.Name)
+			}
+		case OpMakeClosure:
+			if inst.A < 0 || inst.A >= len(program.Functions) {
+				return fmt.Errorf("%s ip=%d: closure target out of range", fn.Name, ip)
+			}
+			if inst.B < 0 {
+				return fmt.Errorf("%s ip=%d: invalid capture count", fn.Name, ip)
+			}
+		}
+	}
+	return nil
+}
+
+func stackEffect(program Program, inst Instruction) (int, int, error) {
+	switch inst.Op {
+	case OpCall:
+		return inst.B, 1, nil
+	case OpCallExtern:
+		return inst.Imm, 1, nil
+	case OpCallModule:
+		return inst.Imm, 1, nil
+	case OpCallClosure:
+		return inst.B + 1, 1, nil
+	case OpCallMethod:
+		return inst.B + 1, 1, nil
+	case OpMakeList:
+		return inst.B, 1, nil
+	case OpMakeMap:
+		return inst.B * 2, 1, nil
+	case OpMakeStruct:
+		return inst.B * 2, 1, nil
+	case OpMakeEnum:
+		return 1, 1, nil
+	case OpMakeNone:
+		return 0, 1, nil
+	case OpStrMethod:
+		return inst.B + 1, 1, nil
+	case OpIntMethod, OpFloatMethod, OpBoolMethod:
+		return 1, 1, nil
+	case OpMaybeMethod, OpResultMethod:
+		return inst.B + 1, 1, nil
+	case OpMaybeUnwrap, OpResultUnwrap, OpTypeName:
+		return 1, 1, nil
+	case OpTryResult, OpTryMaybe:
+		return 1, 1, nil
+	case OpMakeClosure:
+		return inst.B, 1, nil
+	case OpAsyncStart, OpAsyncEval:
+		return 1, 1, nil
+	case OpSetField:
+		return 2, 0, nil
+	case OpGetField:
+		return 1, 1, nil
+	case OpListPush, OpListPrepend:
+		return 2, 1, nil
+	case OpListSet:
+		return 3, 1, nil
+	case OpMapSet:
+		return 3, 1, nil
+	case OpMapDrop, OpMapHas, OpMapGet, OpMapGetValue:
+		return 2, 1, nil
+	}
+	effect := inst.Op.StackEffect()
+	return effect.Pop, effect.Push, nil
+}

--- a/compiler/bytecode/vm/methods.go
+++ b/compiler/bytecode/vm/methods.go
@@ -143,12 +143,14 @@ func (vm *VM) evalResultMethod(kind checker.ResultMethodKind, subj *runtime.Obje
 			}
 			return nil, fmt.Errorf("%s: %s", args[0].AsString(), actual)
 		}
-		return subj.UnwrapResult(), nil
+		unwrapped := subj.UnwrapResult()
+		return unwrapped, nil
 	case checker.ResultOr:
 		if subj.IsErr() {
 			return args[0], nil
 		}
-		return subj.UnwrapResult(), nil
+		unwrapped := subj.UnwrapResult()
+		return unwrapped, nil
 	case checker.ResultIsOk:
 		return runtime.MakeBool(!subj.IsErr()), nil
 	case checker.ResultIsErr:

--- a/compiler/bytecode/vm/methods.go
+++ b/compiler/bytecode/vm/methods.go
@@ -1,0 +1,170 @@
+package vm
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/akonwi/ard/bytecode"
+	"github.com/akonwi/ard/checker"
+	"github.com/akonwi/ard/runtime"
+)
+
+func bytecodeToStrKind(kind int) checker.StrMethodKind {
+	return checker.StrMethodKind(kind)
+}
+
+func bytecodeToIntKind(kind int) checker.IntMethodKind {
+	return checker.IntMethodKind(kind)
+}
+
+func bytecodeToFloatKind(kind int) checker.FloatMethodKind {
+	return checker.FloatMethodKind(kind)
+}
+
+func bytecodeToBoolKind(kind int) checker.BoolMethodKind {
+	return checker.BoolMethodKind(kind)
+}
+
+func bytecodeToMaybeKind(kind int) checker.MaybeMethodKind {
+	return checker.MaybeMethodKind(kind)
+}
+
+func bytecodeToResultKind(kind int) checker.ResultMethodKind {
+	return checker.ResultMethodKind(kind)
+}
+
+func (vm *VM) evalStrMethod(kind checker.StrMethodKind, subj *runtime.Object, args []*runtime.Object) (*runtime.Object, error) {
+	raw := subj.AsString()
+	switch kind {
+	case checker.StrSize:
+		return runtime.MakeInt(len(raw)), nil
+	case checker.StrIsEmpty:
+		return runtime.MakeBool(len(raw) == 0), nil
+	case checker.StrContains:
+		return runtime.MakeBool(strings.Contains(raw, args[0].AsString())), nil
+	case checker.StrReplace:
+		old := args[0].AsString()
+		newStr := args[1].AsString()
+		return runtime.MakeStr(strings.Replace(raw, old, newStr, 1)), nil
+	case checker.StrReplaceAll:
+		old := args[0].AsString()
+		newStr := args[1].AsString()
+		return runtime.MakeStr(strings.ReplaceAll(raw, old, newStr)), nil
+	case checker.StrSplit:
+		sep := args[0].AsString()
+		split := strings.Split(raw, sep)
+		values := make([]*runtime.Object, len(split))
+		for i, str := range split {
+			values[i] = runtime.MakeStr(str)
+		}
+		return runtime.MakeList(checker.Str, values...), nil
+	case checker.StrStartsWith:
+		prefix := args[0].AsString()
+		return runtime.MakeBool(strings.HasPrefix(raw, prefix)), nil
+	case checker.StrToStr:
+		return subj, nil
+	case checker.StrToDyn:
+		return runtime.MakeDynamic(raw), nil
+	case checker.StrTrim:
+		return runtime.MakeStr(strings.Trim(raw, " ")), nil
+	default:
+		return nil, fmt.Errorf("Unknown StrMethodKind: %d", kind)
+	}
+}
+
+func (vm *VM) evalIntMethod(kind checker.IntMethodKind, subj *runtime.Object) (*runtime.Object, error) {
+	switch kind {
+	case checker.IntToStr:
+		return runtime.MakeStr(strconv.Itoa(subj.AsInt())), nil
+	case checker.IntToDyn:
+		return runtime.MakeDynamic(subj.AsInt()), nil
+	default:
+		return nil, fmt.Errorf("Unknown IntMethodKind: %d", kind)
+	}
+}
+
+func (vm *VM) evalFloatMethod(kind checker.FloatMethodKind, subj *runtime.Object) (*runtime.Object, error) {
+	switch kind {
+	case checker.FloatToStr:
+		return runtime.MakeStr(strconv.FormatFloat(subj.AsFloat(), 'f', 2, 64)), nil
+	case checker.FloatToInt:
+		floatVal := subj.AsFloat()
+		intVal := int(floatVal)
+		return runtime.MakeInt(intVal), nil
+	case checker.FloatToDyn:
+		return runtime.MakeDynamic(subj.AsFloat()), nil
+	default:
+		return nil, fmt.Errorf("Unknown FloatMethodKind: %d", kind)
+	}
+}
+
+func (vm *VM) evalBoolMethod(kind checker.BoolMethodKind, subj *runtime.Object) (*runtime.Object, error) {
+	switch kind {
+	case checker.BoolToStr:
+		return runtime.MakeStr(strconv.FormatBool(subj.AsBool())), nil
+	case checker.BoolToDyn:
+		return runtime.MakeDynamic(subj.AsBool()), nil
+	default:
+		return nil, fmt.Errorf("Unknown BoolMethodKind: %d", kind)
+	}
+}
+
+func (vm *VM) evalMaybeMethod(kind checker.MaybeMethodKind, subj *runtime.Object, args []*runtime.Object, returnType bytecode.TypeID) (*runtime.Object, error) {
+	switch kind {
+	case checker.MaybeExpect:
+		if subj.Raw() == nil {
+			return nil, fmt.Errorf("%s", args[0].AsString())
+		}
+		return vm.makeValueWithType(subj.Raw(), returnType)
+	case checker.MaybeIsNone:
+		return runtime.MakeBool(subj.Raw() == nil), nil
+	case checker.MaybeIsSome:
+		return runtime.MakeBool(subj.Raw() != nil), nil
+	case checker.MaybeOr:
+		if subj.Raw() == nil {
+			return args[0], nil
+		}
+		return vm.makeValueWithType(subj.Raw(), returnType)
+	default:
+		return nil, fmt.Errorf("Unknown MaybeMethodKind: %d", kind)
+	}
+}
+
+func (vm *VM) evalResultMethod(kind checker.ResultMethodKind, subj *runtime.Object, args []*runtime.Object) (*runtime.Object, error) {
+	switch kind {
+	case checker.ResultExpect:
+		if subj.IsErr() {
+			actual := ""
+			if str, ok := subj.IsStr(); ok {
+				actual = str
+			} else {
+				actual = fmt.Sprintf("%v", subj.GoValue())
+			}
+			return nil, fmt.Errorf("%s: %s", args[0].AsString(), actual)
+		}
+		return subj.UnwrapResult(), nil
+	case checker.ResultOr:
+		if subj.IsErr() {
+			return args[0], nil
+		}
+		return subj.UnwrapResult(), nil
+	case checker.ResultIsOk:
+		return runtime.MakeBool(!subj.IsErr()), nil
+	case checker.ResultIsErr:
+		return runtime.MakeBool(subj.IsErr()), nil
+	default:
+		return nil, fmt.Errorf("Unknown ResultMethodKind: %d", kind)
+	}
+}
+
+func (vm *VM) makeValueWithType(raw any, typeID bytecode.TypeID) (*runtime.Object, error) {
+	if typeID == 0 {
+		return runtime.MakeDynamic(raw), nil
+	}
+	resolved, err := vm.typeFor(typeID)
+	if err != nil {
+		return nil, err
+	}
+	return runtime.Make(raw, resolved), nil
+}

--- a/compiler/bytecode/vm/methods.go
+++ b/compiler/bytecode/vm/methods.go
@@ -160,6 +160,43 @@ func (vm *VM) evalResultMethod(kind checker.ResultMethodKind, subj *runtime.Obje
 	}
 }
 
+func (vm *VM) evalTraitMethodByName(subj *runtime.Object, name string, args []*runtime.Object) (*runtime.Object, error) {
+	if len(args) != 0 {
+		return nil, fmt.Errorf("trait method %s expects no args", name)
+	}
+	switch subj.Kind() {
+	case runtime.KindStr:
+		switch name {
+		case "to_str":
+			return vm.evalStrMethod(checker.StrToStr, subj, nil)
+		case "to_dyn":
+			return vm.evalStrMethod(checker.StrToDyn, subj, nil)
+		}
+	case runtime.KindInt:
+		switch name {
+		case "to_str":
+			return vm.evalIntMethod(checker.IntToStr, subj)
+		case "to_dyn":
+			return vm.evalIntMethod(checker.IntToDyn, subj)
+		}
+	case runtime.KindFloat:
+		switch name {
+		case "to_str":
+			return vm.evalFloatMethod(checker.FloatToStr, subj)
+		case "to_dyn":
+			return vm.evalFloatMethod(checker.FloatToDyn, subj)
+		}
+	case runtime.KindBool:
+		switch name {
+		case "to_str":
+			return vm.evalBoolMethod(checker.BoolToStr, subj)
+		case "to_dyn":
+			return vm.evalBoolMethod(checker.BoolToDyn, subj)
+		}
+	}
+	return nil, fmt.Errorf("unsupported trait method: %s", name)
+}
+
 func (vm *VM) makeValueWithType(raw any, typeID bytecode.TypeID) (*runtime.Object, error) {
 	if typeID == 0 {
 		return runtime.MakeDynamic(raw), nil

--- a/compiler/bytecode/vm/module_registry.go
+++ b/compiler/bytecode/vm/module_registry.go
@@ -1,0 +1,37 @@
+package vm
+
+import (
+	"fmt"
+
+	"github.com/akonwi/ard/checker"
+	"github.com/akonwi/ard/runtime"
+	corevm "github.com/akonwi/ard/vm"
+)
+
+type ModuleHandler interface {
+	Handle(call *checker.FunctionCall, args []*runtime.Object) *runtime.Object
+	Path() string
+}
+
+type ModuleRegistry struct {
+	handlers map[string]ModuleHandler
+}
+
+func NewModuleRegistry() *ModuleRegistry {
+	r := &ModuleRegistry{handlers: map[string]ModuleHandler{}}
+	r.Register(&corevm.MaybeModule{})
+	r.Register(&corevm.ResultModule{})
+	return r
+}
+
+func (r *ModuleRegistry) Register(handler ModuleHandler) {
+	r.handlers[handler.Path()] = handler
+}
+
+func (r *ModuleRegistry) Call(module string, call *checker.FunctionCall, args []*runtime.Object) (*runtime.Object, error) {
+	h, ok := r.handlers[module]
+	if !ok {
+		return nil, fmt.Errorf("unknown module: %s", module)
+	}
+	return h.Handle(call, args), nil
+}

--- a/compiler/bytecode/vm/type_resolver.go
+++ b/compiler/bytecode/vm/type_resolver.go
@@ -81,9 +81,6 @@ func (vm *VM) enumTypeFor(id bytecode.TypeID) (*checker.Enum, error) {
 
 func parseTypeName(name string) (checker.Type, error) {
 	trimmed := strings.TrimSpace(name)
-	if strings.Contains(trimmed, "$") {
-		return checker.Dynamic, nil
-	}
 	switch trimmed {
 	case checker.Int.String():
 		return checker.Int, nil
@@ -138,6 +135,9 @@ func parseTypeName(name string) (checker.Type, error) {
 			return nil, err
 		}
 		return checker.MakeMap(keyType, valType), nil
+	}
+	if strings.HasPrefix(trimmed, "$") {
+		return checker.Dynamic, nil
 	}
 
 	return &checker.StructDef{Name: trimmed, Fields: map[string]checker.Type{}, Methods: map[string]*checker.FunctionDef{}}, nil

--- a/compiler/bytecode/vm/type_resolver.go
+++ b/compiler/bytecode/vm/type_resolver.go
@@ -1,0 +1,96 @@
+package vm
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/akonwi/ard/bytecode"
+	"github.com/akonwi/ard/checker"
+)
+
+func (vm *VM) typeFor(id bytecode.TypeID) (checker.Type, error) {
+	if id == 0 {
+		return nil, nil
+	}
+	if vm.typeCache == nil {
+		vm.typeCache = map[bytecode.TypeID]checker.Type{}
+	}
+	if t, ok := vm.typeCache[id]; ok {
+		return t, nil
+	}
+
+	var entry *bytecode.TypeEntry
+	for i := range vm.Program.Types {
+		if vm.Program.Types[i].ID == id {
+			entry = &vm.Program.Types[i]
+			break
+		}
+	}
+	if entry == nil {
+		return nil, fmt.Errorf("unknown type id: %d", id)
+	}
+	parsed, err := parseTypeName(entry.Name)
+	if err != nil {
+		return nil, err
+	}
+	vm.typeCache[id] = parsed
+	return parsed, nil
+}
+
+func parseTypeName(name string) (checker.Type, error) {
+	trimmed := strings.TrimSpace(name)
+	switch trimmed {
+	case checker.Int.String():
+		return checker.Int, nil
+	case checker.Float.String():
+		return checker.Float, nil
+	case checker.Str.String():
+		return checker.Str, nil
+	case checker.Bool.String():
+		return checker.Bool, nil
+	case checker.Void.String():
+		return checker.Void, nil
+	case checker.Dynamic.String():
+		return checker.Dynamic, nil
+	}
+
+	if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]")
+		left, right := splitTopLevel(inner, ':')
+		if right == "" {
+			of, err := parseTypeName(left)
+			if err != nil {
+				return nil, err
+			}
+			return checker.MakeList(of), nil
+		}
+		keyType, err := parseTypeName(left)
+		if err != nil {
+			return nil, err
+		}
+		valType, err := parseTypeName(right)
+		if err != nil {
+			return nil, err
+		}
+		return checker.MakeMap(keyType, valType), nil
+	}
+
+	return nil, fmt.Errorf("unsupported type name: %s", name)
+}
+
+func splitTopLevel(s string, sep rune) (string, string) {
+	depth := 0
+	for i, r := range s {
+		switch r {
+		case '[':
+			depth++
+		case ']':
+			depth--
+		default:
+			if r == sep && depth == 0 {
+				return strings.TrimSpace(s[:i]), strings.TrimSpace(s[i+1:])
+			}
+		}
+	}
+	return strings.TrimSpace(s), ""
+}

--- a/compiler/bytecode/vm/type_resolver_test.go
+++ b/compiler/bytecode/vm/type_resolver_test.go
@@ -1,0 +1,28 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/akonwi/ard/checker"
+)
+
+func TestParseTypeNameNestedFunction(t *testing.T) {
+	parsed, err := parseTypeName("fn (fn(Int, Int) Int, Str) Bool")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	fn, ok := parsed.(*checker.FunctionDef)
+	if !ok {
+		t.Fatalf("expected function type, got %T", parsed)
+	}
+	if len(fn.Parameters) != 2 {
+		t.Fatalf("expected 2 params, got %d", len(fn.Parameters))
+	}
+	inner, ok := fn.Parameters[0].Type.(*checker.FunctionDef)
+	if !ok {
+		t.Fatalf("expected nested function param, got %T", fn.Parameters[0].Type)
+	}
+	if len(inner.Parameters) != 2 {
+		t.Fatalf("expected nested function to have 2 params, got %d", len(inner.Parameters))
+	}
+}

--- a/compiler/bytecode/vm/vm.go
+++ b/compiler/bytecode/vm/vm.go
@@ -39,7 +39,173 @@ func (vm *VM) Run(functionName string) (*runtime.Object, error) {
 	}
 	vm.Frames = append(vm.Frames, frame)
 
-	return nil, fmt.Errorf("bytecode VM not implemented")
+	for len(vm.Frames) > 0 {
+		curr := vm.Frames[len(vm.Frames)-1]
+		if curr.IP >= len(curr.Fn.Code) {
+			return nil, fmt.Errorf("instruction pointer out of range")
+		}
+		inst := curr.Fn.Code[curr.IP]
+		curr.IP++
+
+		switch inst.Op {
+		case bytecode.OpNoop:
+			continue
+		case bytecode.OpConstInt:
+			vm.push(curr, runtime.MakeInt(inst.Imm))
+		case bytecode.OpConstFloat:
+			c, err := vm.constAt(inst.A)
+			if err != nil {
+				return nil, err
+			}
+			if c.Kind != bytecode.ConstFloat {
+				return nil, fmt.Errorf("expected float constant, got %d", c.Kind)
+			}
+			vm.push(curr, runtime.MakeFloat(c.Float))
+		case bytecode.OpConstStr:
+			c, err := vm.constAt(inst.A)
+			if err != nil {
+				return nil, err
+			}
+			if c.Kind != bytecode.ConstStr {
+				return nil, fmt.Errorf("expected string constant, got %d", c.Kind)
+			}
+			vm.push(curr, runtime.MakeStr(c.Str))
+		case bytecode.OpConstBool:
+			vm.push(curr, runtime.MakeBool(inst.Imm != 0))
+		case bytecode.OpConstVoid:
+			vm.push(curr, runtime.Void())
+		case bytecode.OpConst:
+			c, err := vm.constAt(inst.A)
+			if err != nil {
+				return nil, err
+			}
+			obj, err := vm.objectFromConst(c)
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, obj)
+		case bytecode.OpLoadLocal:
+			if inst.A < 0 || inst.A >= len(curr.Locals) {
+				return nil, fmt.Errorf("local index out of range")
+			}
+			vm.push(curr, curr.Locals[inst.A])
+		case bytecode.OpStoreLocal:
+			if inst.A < 0 || inst.A >= len(curr.Locals) {
+				return nil, fmt.Errorf("local index out of range")
+			}
+			val, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			curr.Locals[inst.A] = val
+		case bytecode.OpPop:
+			if _, err := vm.pop(curr); err != nil {
+				return nil, err
+			}
+		case bytecode.OpDup:
+			val, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, val)
+			vm.push(curr, val)
+		case bytecode.OpSwap:
+			b, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			a, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, b)
+			vm.push(curr, a)
+		case bytecode.OpAdd, bytecode.OpSub, bytecode.OpMul, bytecode.OpDiv, bytecode.OpMod:
+			b, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			a, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			res, err := vm.evalBinary(inst.Op, a, b)
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, res)
+		case bytecode.OpNeg:
+			val, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			res, err := vm.evalUnary(inst.Op, val)
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, res)
+		case bytecode.OpNot:
+			val, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, runtime.MakeBool(!val.AsBool()))
+		case bytecode.OpEq, bytecode.OpNeq, bytecode.OpLt, bytecode.OpLte, bytecode.OpGt, bytecode.OpGte:
+			b, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			a, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			res, err := vm.evalCompare(inst.Op, a, b)
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, res)
+		case bytecode.OpJump:
+			curr.IP = inst.A
+		case bytecode.OpJumpIfFalse:
+			val, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			if !val.AsBool() {
+				curr.IP = inst.A
+			}
+		case bytecode.OpJumpIfTrue:
+			val, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			if val.AsBool() {
+				curr.IP = inst.A
+			}
+		case bytecode.OpReturn:
+			val, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			vm.Frames = vm.Frames[:len(vm.Frames)-1]
+			if len(vm.Frames) == 0 {
+				return val, nil
+			}
+			vm.push(vm.Frames[len(vm.Frames)-1], val)
+		case bytecode.OpCall, bytecode.OpCallExtern, bytecode.OpCallModule,
+			bytecode.OpMakeList, bytecode.OpMakeMap, bytecode.OpMakeStruct, bytecode.OpMakeEnum,
+			bytecode.OpGetField, bytecode.OpSetField, bytecode.OpCallMethod,
+			bytecode.OpMatchBool, bytecode.OpMatchInt, bytecode.OpMatchEnum, bytecode.OpMatchUnion,
+			bytecode.OpMatchMaybe, bytecode.OpMatchResult,
+			bytecode.OpTryResult, bytecode.OpTryMaybe,
+			bytecode.OpAsyncStart, bytecode.OpAsyncEval:
+			return nil, fmt.Errorf("opcode not implemented: %s", inst.Op)
+		default:
+			return nil, fmt.Errorf("unknown opcode: %d", inst.Op)
+		}
+	}
+
+	return nil, fmt.Errorf("no frames left")
 }
 
 func (vm *VM) lookupFunction(name string) (bytecode.Function, bool) {
@@ -49,4 +215,152 @@ func (vm *VM) lookupFunction(name string) (bytecode.Function, bool) {
 		}
 	}
 	return bytecode.Function{}, false
+}
+
+func (vm *VM) push(frame *Frame, obj *runtime.Object) {
+	frame.Stack = append(frame.Stack, obj)
+}
+
+func (vm *VM) pop(frame *Frame) (*runtime.Object, error) {
+	if len(frame.Stack) == 0 {
+		return nil, fmt.Errorf("stack underflow")
+	}
+	idx := len(frame.Stack) - 1
+	val := frame.Stack[idx]
+	frame.Stack = frame.Stack[:idx]
+	return val, nil
+}
+
+func (vm *VM) constAt(index int) (bytecode.Constant, error) {
+	if index < 0 || index >= len(vm.Program.Constants) {
+		return bytecode.Constant{}, fmt.Errorf("constant index out of range")
+	}
+	return vm.Program.Constants[index], nil
+}
+
+func (vm *VM) objectFromConst(c bytecode.Constant) (*runtime.Object, error) {
+	switch c.Kind {
+	case bytecode.ConstInt:
+		return runtime.MakeInt(c.Int), nil
+	case bytecode.ConstFloat:
+		return runtime.MakeFloat(c.Float), nil
+	case bytecode.ConstStr:
+		return runtime.MakeStr(c.Str), nil
+	case bytecode.ConstBool:
+		return runtime.MakeBool(c.Bool), nil
+	default:
+		return nil, fmt.Errorf("unknown constant kind: %d", c.Kind)
+	}
+}
+
+func (vm *VM) evalBinary(op bytecode.Opcode, left, right *runtime.Object) (*runtime.Object, error) {
+	if left.Kind() == runtime.KindInt && right.Kind() == runtime.KindInt {
+		a := left.AsInt()
+		b := right.AsInt()
+		switch op {
+		case bytecode.OpAdd:
+			return runtime.MakeInt(a + b), nil
+		case bytecode.OpSub:
+			return runtime.MakeInt(a - b), nil
+		case bytecode.OpMul:
+			return runtime.MakeInt(a * b), nil
+		case bytecode.OpDiv:
+			return runtime.MakeInt(a / b), nil
+		case bytecode.OpMod:
+			return runtime.MakeInt(a % b), nil
+		}
+	}
+	if left.Kind() == runtime.KindFloat && right.Kind() == runtime.KindFloat {
+		a := left.AsFloat()
+		b := right.AsFloat()
+		switch op {
+		case bytecode.OpAdd:
+			return runtime.MakeFloat(a + b), nil
+		case bytecode.OpSub:
+			return runtime.MakeFloat(a - b), nil
+		case bytecode.OpMul:
+			return runtime.MakeFloat(a * b), nil
+		case bytecode.OpDiv:
+			return runtime.MakeFloat(a / b), nil
+		}
+	}
+
+	return nil, fmt.Errorf("unsupported binary op %s for %s and %s", op, left.Kind(), right.Kind())
+}
+
+func (vm *VM) evalUnary(op bytecode.Opcode, val *runtime.Object) (*runtime.Object, error) {
+	if val.Kind() == runtime.KindInt {
+		switch op {
+		case bytecode.OpNeg:
+			return runtime.MakeInt(-val.AsInt()), nil
+		}
+	}
+	if val.Kind() == runtime.KindFloat {
+		switch op {
+		case bytecode.OpNeg:
+			return runtime.MakeFloat(-val.AsFloat()), nil
+		}
+	}
+	return nil, fmt.Errorf("unsupported unary op %s for %s", op, val.Kind())
+}
+
+func (vm *VM) evalCompare(op bytecode.Opcode, left, right *runtime.Object) (*runtime.Object, error) {
+	if left.Kind() == runtime.KindInt && right.Kind() == runtime.KindInt {
+		a := left.AsInt()
+		b := right.AsInt()
+		switch op {
+		case bytecode.OpEq:
+			return runtime.MakeBool(a == b), nil
+		case bytecode.OpNeq:
+			return runtime.MakeBool(a != b), nil
+		case bytecode.OpLt:
+			return runtime.MakeBool(a < b), nil
+		case bytecode.OpLte:
+			return runtime.MakeBool(a <= b), nil
+		case bytecode.OpGt:
+			return runtime.MakeBool(a > b), nil
+		case bytecode.OpGte:
+			return runtime.MakeBool(a >= b), nil
+		}
+	}
+	if left.Kind() == runtime.KindFloat && right.Kind() == runtime.KindFloat {
+		a := left.AsFloat()
+		b := right.AsFloat()
+		switch op {
+		case bytecode.OpEq:
+			return runtime.MakeBool(a == b), nil
+		case bytecode.OpNeq:
+			return runtime.MakeBool(a != b), nil
+		case bytecode.OpLt:
+			return runtime.MakeBool(a < b), nil
+		case bytecode.OpLte:
+			return runtime.MakeBool(a <= b), nil
+		case bytecode.OpGt:
+			return runtime.MakeBool(a > b), nil
+		case bytecode.OpGte:
+			return runtime.MakeBool(a >= b), nil
+		}
+	}
+	if left.Kind() == runtime.KindBool && right.Kind() == runtime.KindBool {
+		a := left.AsBool()
+		b := right.AsBool()
+		switch op {
+		case bytecode.OpEq:
+			return runtime.MakeBool(a == b), nil
+		case bytecode.OpNeq:
+			return runtime.MakeBool(a != b), nil
+		}
+	}
+	if left.Kind() == runtime.KindStr && right.Kind() == runtime.KindStr {
+		a := left.AsString()
+		b := right.AsString()
+		switch op {
+		case bytecode.OpEq:
+			return runtime.MakeBool(a == b), nil
+		case bytecode.OpNeq:
+			return runtime.MakeBool(a != b), nil
+		}
+	}
+
+	return nil, fmt.Errorf("unsupported comparison %s for %s and %s", op, left.Kind(), right.Kind())
 }

--- a/compiler/bytecode/vm/vm.go
+++ b/compiler/bytecode/vm/vm.go
@@ -450,6 +450,90 @@ func (vm *VM) Run(functionName string) (*runtime.Object, error) {
 				return nil, err
 			}
 			vm.push(curr, runtime.MakeInt(len(mapObj.AsMap())))
+		case bytecode.OpStrMethod:
+			args := make([]*runtime.Object, inst.B)
+			for i := inst.B - 1; i >= 0; i-- {
+				arg, err := vm.pop(curr)
+				if err != nil {
+					return nil, err
+				}
+				args[i] = arg
+			}
+			obj, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			res, err := vm.evalStrMethod(bytecodeToStrKind(inst.A), obj, args)
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, res)
+		case bytecode.OpIntMethod:
+			obj, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			res, err := vm.evalIntMethod(bytecodeToIntKind(inst.A), obj)
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, res)
+		case bytecode.OpFloatMethod:
+			obj, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			res, err := vm.evalFloatMethod(bytecodeToFloatKind(inst.A), obj)
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, res)
+		case bytecode.OpBoolMethod:
+			obj, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			res, err := vm.evalBoolMethod(bytecodeToBoolKind(inst.A), obj)
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, res)
+		case bytecode.OpMaybeMethod:
+			args := make([]*runtime.Object, inst.B)
+			for i := inst.B - 1; i >= 0; i-- {
+				arg, err := vm.pop(curr)
+				if err != nil {
+					return nil, err
+				}
+				args[i] = arg
+			}
+			subj, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			res, err := vm.evalMaybeMethod(bytecodeToMaybeKind(inst.A), subj, args, bytecode.TypeID(inst.Imm))
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, res)
+		case bytecode.OpResultMethod:
+			args := make([]*runtime.Object, inst.B)
+			for i := inst.B - 1; i >= 0; i-- {
+				arg, err := vm.pop(curr)
+				if err != nil {
+					return nil, err
+				}
+				args[i] = arg
+			}
+			subj, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			res, err := vm.evalResultMethod(bytecodeToResultKind(inst.A), subj, args)
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, res)
 		case bytecode.OpCallExtern, bytecode.OpCallModule,
 			bytecode.OpMakeStruct, bytecode.OpMakeEnum,
 			bytecode.OpGetField, bytecode.OpSetField, bytecode.OpCallMethod,

--- a/compiler/bytecode/vm/vm.go
+++ b/compiler/bytecode/vm/vm.go
@@ -1,0 +1,52 @@
+package vm
+
+import (
+	"fmt"
+
+	"github.com/akonwi/ard/bytecode"
+	"github.com/akonwi/ard/runtime"
+)
+
+type Frame struct {
+	Fn       bytecode.Function
+	IP       int
+	Locals   []*runtime.Object
+	Stack    []*runtime.Object
+	MaxStack int
+}
+
+type VM struct {
+	Program bytecode.Program
+	Frames  []*Frame
+}
+
+func New(program bytecode.Program) *VM {
+	return &VM{Program: program, Frames: []*Frame{}}
+}
+
+func (vm *VM) Run(functionName string) (*runtime.Object, error) {
+	fn, ok := vm.lookupFunction(functionName)
+	if !ok {
+		return nil, fmt.Errorf("function not found: %s", functionName)
+	}
+
+	frame := &Frame{
+		Fn:       fn,
+		IP:       0,
+		Locals:   make([]*runtime.Object, fn.Locals),
+		Stack:    []*runtime.Object{},
+		MaxStack: fn.MaxStack,
+	}
+	vm.Frames = append(vm.Frames, frame)
+
+	return nil, fmt.Errorf("bytecode VM not implemented")
+}
+
+func (vm *VM) lookupFunction(name string) (bytecode.Function, bool) {
+	for _, fn := range vm.Program.Functions {
+		if fn.Name == name {
+			return fn, true
+		}
+	}
+	return bytecode.Function{}, false
+}

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -322,3 +322,37 @@ func TestBytecodeResultMatch(t *testing.T) {
 		t.Fatalf("Expected 5, got %v", res)
 	}
 }
+
+func TestBytecodeTryResult(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`use ard/result`,
+		`fn compute() Int!Str {`,
+		`  let val = try Result::ok(4)`,
+		`  Result::ok(val + 1)`,
+		`}`,
+		`match compute() {`,
+		`  ok(n) => n,`,
+		`  err => 0`,
+		`}`,
+	}, "\n"))
+	if res != 5 {
+		t.Fatalf("Expected 5, got %v", res)
+	}
+}
+
+func TestBytecodeTryMaybe(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`use ard/maybe`,
+		`fn compute() Int? {`,
+		`  let val = try maybe::some(4)`,
+		`  maybe::some(val + 2)`,
+		`}`,
+		`match compute() {`,
+		`  n => n,`,
+		`  _ => 0`,
+		`}`,
+	}, "\n"))
+	if res != 6 {
+		t.Fatalf("Expected 6, got %v", res)
+	}
+}

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -787,6 +787,7 @@ func TestBytecodeSamples(t *testing.T) {
 		"fizzbuzz.ard",
 		"fibonacci.ard",
 		"collections.ard",
+		"type-unions.ard",
 	}
 	for _, name := range samples {
 		name := name

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -356,3 +356,47 @@ func TestBytecodeTryMaybe(t *testing.T) {
 		t.Fatalf("Expected 6, got %v", res)
 	}
 }
+
+func TestBytecodeStructAccess(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`struct Point { x: Int, y: Int }`,
+		`fn main() Int {`,
+		`  let p = Point{x: 1, y: 2}`,
+		`  p.x + p.y`,
+		`}`,
+		`main()`,
+	}, "\n"))
+	if res != 3 {
+		t.Fatalf("Expected 3, got %v", res)
+	}
+}
+
+func TestBytecodeStructMethod(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`struct Point { x: Int, y: Int }`,
+		`impl Point {`,
+		`  fn sum() Int { @x + @y }`,
+		`}`,
+		`fn main() Int {`,
+		`  let p = Point{x: 2, y: 3}`,
+		`  p.sum()`,
+		`}`,
+		`main()`,
+	}, "\n"))
+	if res != 5 {
+		t.Fatalf("Expected 5, got %v", res)
+	}
+}
+
+func TestBytecodeEnumMatch(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`enum Color { Red, Green }`,
+		`match Color::Red {`,
+		`  Color::Red => 1,`,
+		`  _ => 0`,
+		`}`,
+	}, "\n"))
+	if res != 1 {
+		t.Fatalf("Expected 1, got %v", res)
+	}
+}

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -256,4 +256,22 @@ func TestBytecodeMapMethods(t *testing.T) {
 	if res != true {
 		t.Fatalf("Expected true, got %v", res)
 	}
+	res = runBytecode(t, strings.Join([]string{
+		`let items = ["a": 1, "b": 2]`,
+		`items.get("a").or(0)`,
+	}, "\n"))
+	if res != 1 {
+		t.Fatalf("Expected 1, got %v", res)
+	}
+}
+
+func TestBytecodeStringMethods(t *testing.T) {
+	res := runBytecode(t, `"hello".size()`)
+	if res != 5 {
+		t.Fatalf("Expected 5, got %v", res)
+	}
+	res = runBytecode(t, `"hello".contains("ell")`)
+	if res != true {
+		t.Fatalf("Expected true, got %v", res)
+	}
 }

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -1,0 +1,93 @@
+package vm
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/akonwi/ard/bytecode"
+	"github.com/akonwi/ard/checker"
+	"github.com/akonwi/ard/parse"
+)
+
+func runBytecode(t *testing.T, input string) any {
+	t.Helper()
+	result := parse.Parse([]byte(input), "test.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("Parse errors: %v", result.Errors[0].Message)
+	}
+	tree := result.Program
+	c := checker.New("test.ard", tree, nil)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("Diagnostics found: %v", c.Diagnostics())
+	}
+
+	emitter := bytecode.NewEmitter()
+	program, err := emitter.EmitProgram(c.Module())
+	if err != nil {
+		t.Fatalf("Emit error: %v", err)
+	}
+
+	vm := New(program)
+	res, err := vm.Run("main")
+	if err != nil {
+		t.Fatalf("VM error: %v", err)
+	}
+	if res == nil {
+		return nil
+	}
+	return res.GoValue()
+}
+
+func TestBytecodeEmptyProgram(t *testing.T) {
+	res := runBytecode(t, "")
+	if res != nil {
+		t.Fatalf("Expected nil, got %v", res)
+	}
+}
+
+func TestBytecodeBindingVariables(t *testing.T) {
+	tests := []struct {
+		input string
+		want  any
+	}{
+		{input: `"Alice"`, want: "Alice"},
+		{input: `40`, want: 40},
+		{input: `true`, want: true},
+	}
+	for _, test := range tests {
+		res := runBytecode(t, strings.Join([]string{
+			fmt.Sprintf("let val = %s", test.input),
+			"val",
+		}, "\n"))
+		if res != test.want {
+			t.Fatalf("Expected %v, got %v", test.want, res)
+		}
+	}
+}
+
+func TestBytecodeArithmetic(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`let a = 2`,
+		`let b = 3`,
+		`a * b + 4`,
+	}, "\n"))
+	if res != 10 {
+		t.Fatalf("Expected 10, got %v", res)
+	}
+}
+
+func TestBytecodeStringConcat(t *testing.T) {
+	res := runBytecode(t, `"hello" + " world"`)
+	if res != "hello world" {
+		t.Fatalf("Expected hello world, got %v", res)
+	}
+}
+
+func TestBytecodeEquality(t *testing.T) {
+	res := runBytecode(t, `1 == 1`)
+	if res != true {
+		t.Fatalf("Expected true, got %v", res)
+	}
+}

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -195,3 +195,31 @@ func TestBytecodeForRangeLoop(t *testing.T) {
 		t.Fatalf("Expected 6, got %v", res)
 	}
 }
+
+func TestBytecodeForInListLoop(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`mut sum = 0`,
+		`let items = [1, 2, 3]`,
+		`for item in items {`,
+		`  sum = sum + item`,
+		`}`,
+		`sum`,
+	}, "\n"))
+	if res != 6 {
+		t.Fatalf("Expected 6, got %v", res)
+	}
+}
+
+func TestBytecodeForInMapLoop(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`mut sum = 0`,
+		`let items = ["a": 1, "b": 2]`,
+		`for key, val in items {`,
+		`  sum = sum + val`,
+		`}`,
+		`sum`,
+	}, "\n"))
+	if res != 3 {
+		t.Fatalf("Expected 3, got %v", res)
+	}
+}

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -147,3 +147,25 @@ func TestBytecodeFloatComparisons(t *testing.T) {
 		t.Fatalf("Expected false, got %v", res)
 	}
 }
+
+func TestBytecodeListLiteral(t *testing.T) {
+	res := runBytecode(t, `[1, 2, 3]`)
+	items, ok := res.([]any)
+	if !ok {
+		t.Fatalf("Expected list result, got %T", res)
+	}
+	if len(items) != 3 || items[0] != 1 || items[1] != 2 || items[2] != 3 {
+		t.Fatalf("Unexpected list result: %v", res)
+	}
+}
+
+func TestBytecodeMapLiteral(t *testing.T) {
+	res := runBytecode(t, `["a": 1, "b": 2]`)
+	m, ok := res.(map[string]any)
+	if !ok {
+		t.Fatalf("Expected map result, got %T", res)
+	}
+	if m["a"] != 1 || m["b"] != 2 {
+		t.Fatalf("Unexpected map result: %v", res)
+	}
+}

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -788,6 +788,7 @@ func TestBytecodeSamples(t *testing.T) {
 		"fibonacci.ard",
 		"collections.ard",
 		"type-unions.ard",
+		"concurrent_stress.ard",
 	}
 	for _, name := range samples {
 		name := name

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -122,3 +122,13 @@ func TestBytecodeFunctionCall(t *testing.T) {
 		t.Fatalf("Expected 5, got %v", res)
 	}
 }
+
+func TestBytecodeIfInFunction(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`fn pick(n: Int) Int { if n > 2 { 10 } else { 20 } }`,
+		`pick(3)`,
+	}, "\n"))
+	if res != 10 {
+		t.Fatalf("Expected 10, got %v", res)
+	}
+}

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -136,6 +136,295 @@ func TestBytecodeFunctionCall(t *testing.T) {
 	}
 }
 
+func TestBytecodeFirstClassFunction(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`let sub = fn(a: Int, b: Int) { a - b }`,
+		`sub(30, 8)`,
+	}, "\n"))
+	if res != 22 {
+		t.Fatalf("Expected 22, got %v", res)
+	}
+}
+
+func TestBytecodeClosureCapture(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`fn createAdder(base: Int) fn(Int) Int {`,
+		`  fn(x: Int) Int {`,
+		`    base + x`,
+		`  }`,
+		`}`,
+		`let addFive = createAdder(5)`,
+		`addFive(10)`,
+	}, "\n"))
+	if res != 15 {
+		t.Fatalf("Expected 15, got %v", res)
+	}
+}
+
+func TestBytecodeInferAnonymousFunctionTypes(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`fn process(f: fn(Str) Bool) Bool {`,
+		`  f("hello")`,
+		`}`,
+		`process(fn(x) { x.size() > 0 })`,
+	}, "\n"))
+	if res != true {
+		t.Fatalf("Expected true, got %v", res)
+	}
+
+	res = runBytecode(t, strings.Join([]string{
+		`fn check(f: fn(Str) Bool) Bool {`,
+		`  f("test")`,
+		`}`,
+		`check(fn(s) { true })`,
+	}, "\n"))
+	if res != true {
+		t.Fatalf("Expected true, got %v", res)
+	}
+}
+
+func TestBytecodeFunctionCallFeatures(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  any
+	}{
+		{
+			name: "noop function",
+			input: `
+				fn noop() {}
+				noop()`,
+			want: nil,
+		},
+		{
+			name: "returning with no args",
+			input: `
+				fn get_msg() { "Hello" }
+				get_msg()`,
+			want: "Hello",
+		},
+		{
+			name: "one arg",
+			input: `
+				fn greet(name: Str) { "Hello, {name}!" }
+				greet("Alice")`,
+			want: "Hello, Alice!",
+		},
+		{
+			name: "multiple args",
+			input: `
+				fn add(a: Int, b: Int) { a + b }
+				add(1, 2)`,
+			want: 3,
+		},
+		{
+			name: "named arguments on static function respect names",
+			input: `
+				fn Person::full(first: Str, last: Str) Str {
+				  "{first} {last}"
+				}
+				Person::full(last: "Doe", first: "Jane")`,
+			want: "Jane Doe",
+		},
+		{
+			name: "named arguments on instance method respect names",
+			input: `
+				struct Person {
+				  first: Str,
+				  last: Str,
+				}
+				impl Person {
+				  fn full(first: Str, last: Str) Str {
+				    "{first} {last}"
+				  }
+				}
+				let p = Person{first: "Ignored", last: "AlsoIgnored"}
+				p.full(last: "Doe", first: "Jane")`,
+			want: "Jane Doe",
+		},
+		{
+			name: "referencing module-level fn within method of same name",
+			input: `
+				fn process(x: Int) Int {
+				  x * 2
+				}
+				struct Handler { }
+				impl Handler {
+				  fn process(x: Int) Str {
+				    let result = process(5)
+				    "Result: {result}"
+				  }
+				}
+				let h = Handler{}
+				h.process(10)`,
+			want: "Result: 10",
+		},
+		{
+			name: "module-level fn and method with same name but different param types",
+			input: `
+				fn process(x: Str) Str {
+				  "string: {x}"
+				}
+				struct Handler { }
+				impl Handler {
+				  fn process(x: Int) Str {
+				    let result = process("hello")
+				    "handler: {result}"
+				  }
+				}
+				let h = Handler{}
+				h.process(42)`,
+			want: "handler: string: hello",
+		},
+		{
+			name: "calling Type::function static method defined with double colon syntax",
+			input: `
+				struct Fixture {
+				  id: Int,
+				  name: Str,
+				}
+				fn Fixture::from_entry(data: Str) Fixture {
+				  Fixture{id: 1, name: data}
+				}
+				let f = Fixture::from_entry("Test")
+				f.name`,
+			want: "Test",
+		},
+		{
+			name: "omitting nullable parameters",
+			input: `
+				use ard/maybe
+				fn add(a: Int, b: Int?) Int {
+					a + b.or(0)
+				}
+				add(1)`,
+			want: 1,
+		},
+		{
+			name: "omitting nullable parameters with explicit value",
+			input: `
+				use ard/maybe
+				fn add(a: Int, b: Int?) Int {
+					a + b.or(0)
+				}
+				add(1, maybe::some(5))`,
+			want: 6,
+		},
+		{
+			name: "automatic wrapping of non-nullable values for nullable parameters",
+			input: `
+				fn add(a: Int, b: Int?) Int {
+					a + b.or(0)
+				}
+				add(1, 5)`,
+			want: 6,
+		},
+		{
+			name: "automatic wrapping works with omitted args",
+			input: `
+				fn test(a: Int, b: Int?, c: Str?) Str {
+					let bval = b.or(0)
+					let cval = c.or("default")
+					"{a},{bval},{cval}"
+				}
+				test(42)`,
+			want: "42,0,default",
+		},
+		{
+			name: "automatic wrapping with one wrapped argument",
+			input: `
+				fn test(a: Int, b: Int?, c: Str?) Str {
+					let bval = b.or(0)
+					let cval = c.or("default")
+					"{a},{bval},{cval}"
+				}
+				test(42, 7)`,
+			want: "42,7,default",
+		},
+		{
+			name: "automatic wrapping with all arguments provided",
+			input: `
+				fn test(a: Int, b: Int?, c: Str?) Str {
+					let bval = b.or(0)
+					let cval = c.or("default")
+					"{a},{bval},{cval}"
+				}
+				test(42, 7, "hello")`,
+			want: "42,7,hello",
+		},
+		{
+			name: "automatic wrapping of list literals for nullable parameters",
+			input: `
+				fn process(items: [Int]?) Bool {
+					match items {
+						lst => true
+						_ => false
+					}
+				}
+				process([10, 20, 30])`,
+			want: true,
+		},
+		{
+			name: "automatic wrapping of map literals for nullable parameters",
+			input: `
+				fn process(data: [Str:Int]?) Bool {
+					match data {
+						m => true
+						_ => false
+					}
+				}
+				process(["count": 42])`,
+			want: true,
+		},
+		{
+			name: "automatic wrapping with labeled arguments",
+			input: `
+				fn test(a: Int, b: Int?, c: Str?) Str {
+					let bval = b.or(0)
+					let cval = c.or("default")
+					"{a},{bval},{cval}"
+				}
+				test(a: 42, b: 7, c: "hello")`,
+			want: "42,7,hello",
+		},
+		{
+			name: "automatic wrapping with labeled arguments and omitted values",
+			input: `
+				fn test(a: Int, b: Int?, c: Str?) Str {
+					let bval = b.or(0)
+					let cval = c.or("default")
+					"{a},{bval},{cval}"
+				}
+				test(a: 42, c: "world")`,
+			want: "42,0,world",
+		},
+		{
+			name: "automatic wrapping with labeled arguments in different order",
+			input: `
+				fn test(a: Int, b: Int?, c: Str?) Str {
+					let bval = b.or(0)
+					let cval = c.or("default")
+					"{a},{bval},{cval}"
+				}
+				test(c: "reorder", b: 99, a: 5)`,
+			want: "5,99,reorder",
+		},
+	}
+
+	for _, test := range tests {
+		res := runBytecode(t, test.input)
+		if test.want == nil {
+			if res != nil {
+				t.Fatalf("%s: expected nil, got %v", test.name, res)
+			}
+			continue
+		}
+		if res != test.want {
+			t.Fatalf("%s: expected %v, got %v", test.name, test.want, res)
+		}
+	}
+}
+
 func TestBytecodeIfInFunction(t *testing.T) {
 	res := runBytecode(t, strings.Join([]string{
 		`fn pick(n: Int) Int { if n > 2 { 10 } else { 20 } }`,

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -91,3 +91,24 @@ func TestBytecodeEquality(t *testing.T) {
 		t.Fatalf("Expected true, got %v", res)
 	}
 }
+
+func TestBytecodeIfExpression(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`let val = 3`,
+		`if val > 2 { 10 } else { 20 }`,
+	}, "\n"))
+	if res != 10 {
+		t.Fatalf("Expected 10, got %v", res)
+	}
+}
+
+func TestBytecodeLogicalOps(t *testing.T) {
+	res := runBytecode(t, `true and false`)
+	if res != false {
+		t.Fatalf("Expected false, got %v", res)
+	}
+	res = runBytecode(t, `true or false`)
+	if res != true {
+		t.Fatalf("Expected true, got %v", res)
+	}
+}

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -112,3 +112,13 @@ func TestBytecodeLogicalOps(t *testing.T) {
 		t.Fatalf("Expected true, got %v", res)
 	}
 }
+
+func TestBytecodeFunctionCall(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`fn add(a: Int, b: Int) Int { a + b }`,
+		`add(2, 3)`,
+	}, "\n"))
+	if res != 5 {
+		t.Fatalf("Expected 5, got %v", res)
+	}
+}

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -169,3 +169,29 @@ func TestBytecodeMapLiteral(t *testing.T) {
 		t.Fatalf("Unexpected map result: %v", res)
 	}
 }
+
+func TestBytecodeWhileLoop(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`mut count = 0`,
+		`while count < 3 {`,
+		`  count = count + 1`,
+		`}`,
+		`count`,
+	}, "\n"))
+	if res != 3 {
+		t.Fatalf("Expected 3, got %v", res)
+	}
+}
+
+func TestBytecodeForRangeLoop(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`mut sum = 0`,
+		`for i in 1..3 {`,
+		`  sum = sum + i`,
+		`}`,
+		`sum`,
+	}, "\n"))
+	if res != 6 {
+		t.Fatalf("Expected 6, got %v", res)
+	}
+}

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -90,6 +90,10 @@ func TestBytecodeEquality(t *testing.T) {
 	if res != true {
 		t.Fatalf("Expected true, got %v", res)
 	}
+	res = runBytecode(t, `"a" == "a"`)
+	if res != true {
+		t.Fatalf("Expected true, got %v", res)
+	}
 }
 
 func TestBytecodeIfExpression(t *testing.T) {
@@ -130,5 +134,16 @@ func TestBytecodeIfInFunction(t *testing.T) {
 	}, "\n"))
 	if res != 10 {
 		t.Fatalf("Expected 10, got %v", res)
+	}
+}
+
+func TestBytecodeFloatComparisons(t *testing.T) {
+	res := runBytecode(t, `3.5 > 2.1`)
+	if res != true {
+		t.Fatalf("Expected true, got %v", res)
+	}
+	res = runBytecode(t, `3.5 <= 2.1`)
+	if res != false {
+		t.Fatalf("Expected false, got %v", res)
 	}
 }

--- a/compiler/bytecode/vm/vm_test.go
+++ b/compiler/bytecode/vm/vm_test.go
@@ -223,3 +223,37 @@ func TestBytecodeForInMapLoop(t *testing.T) {
 		t.Fatalf("Expected 3, got %v", res)
 	}
 }
+
+func TestBytecodeListMethods(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`let items = [1, 2, 3]`,
+		`items.size()`,
+	}, "\n"))
+	if res != 3 {
+		t.Fatalf("Expected 3, got %v", res)
+	}
+	res = runBytecode(t, strings.Join([]string{
+		`let items = [1, 2, 3]`,
+		`items.at(1)`,
+	}, "\n"))
+	if res != 2 {
+		t.Fatalf("Expected 2, got %v", res)
+	}
+}
+
+func TestBytecodeMapMethods(t *testing.T) {
+	res := runBytecode(t, strings.Join([]string{
+		`let items = ["a": 1, "b": 2]`,
+		`items.size()`,
+	}, "\n"))
+	if res != 2 {
+		t.Fatalf("Expected 2, got %v", res)
+	}
+	res = runBytecode(t, strings.Join([]string{
+		`let items = ["a": 1, "b": 2]`,
+		`items.has("a")`,
+	}, "\n"))
+	if res != true {
+		t.Fatalf("Expected true, got %v", res)
+	}
+}

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -3165,6 +3165,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 		if unionType, ok := subject.Type().(*Union); ok {
 			// Track which union types we've seen and their corresponding bodies
 			typeCases := make(map[string]*Match)
+			typeCasesByType := make(map[Type]*Match)
 			var catchAllBody *Block
 
 			// Record all types in the union
@@ -3209,10 +3210,12 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 						body := c.checkBlock(matchCase.Body, func() {
 							c.scope.add(varName, matchedType, false)
 						})
-						typeCases[typeName] = &Match{
+						matchNode := &Match{
 							Pattern: &Identifier{Name: varName},
 							Body:    body,
 						}
+						typeCases[typeName] = matchNode
+						typeCasesByType[matchedType] = matchNode
 					}
 				}
 			}
@@ -3252,9 +3255,10 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 
 			// Create and return the UnionMatch
 			return &UnionMatch{
-				Subject:   subject,
-				TypeCases: typeCases,
-				CatchAll:  catchAllBody,
+				Subject:         subject,
+				TypeCases:       typeCases,
+				TypeCasesByType: typeCasesByType,
+				CatchAll:        catchAllBody,
 			}
 		}
 

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -2797,6 +2797,9 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				fn:         fnToUse,
 				ReturnType: fnToUse.ReturnType,
 			}
+			if extFn, ok := sym.Type.(*ExternalFunctionDef); ok {
+				call.ExternalBinding = extFn.ExternalBinding
+			}
 
 			// Special validation for async::start calls
 			if mod.Path() == "ard/async" && s.Function.Name == "start" {

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -3674,6 +3674,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 					return &TryOp{
 						expr:       expr,
 						ok:         _type.val, // Returns unwrapped value for continued execution
+						OkType:     _type.val,
 						CatchBlock: block,
 						CatchVar:   s.CatchVar.Name,
 						Kind:       TryResult,
@@ -3685,9 +3686,10 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 						c.addError("try without catch clause requires function to return a Result type", s.GetLocation())
 						// Return a try op with the unwrapped type to avoid cascading errors
 						return &TryOp{
-							expr: expr,
-							ok:   _type.val,
-							Kind: TryResult,
+							expr:   expr,
+							ok:     _type.val,
+							OkType: _type.val,
+							Kind:   TryResult,
 						}
 					}
 
@@ -3696,18 +3698,20 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 						c.addError(fmt.Sprintf("Error type mismatch: Expected %s, got %s", fnReturnResult.err.String(), _type.err.String()), s.Expression.GetLocation())
 						// Return a try op with the unwrapped type to avoid cascading errors
 						return &TryOp{
-							expr: expr,
-							ok:   _type.val,
-							Kind: TryResult,
+							expr:   expr,
+							ok:     _type.val,
+							OkType: _type.val,
+							Kind:   TryResult,
 						}
 					}
 
 					// Success: returns the unwrapped value
 					// Error: early returns the error wrapped in the function's Result type
 					return &TryOp{
-						expr: expr,
-						ok:   _type.val,
-						Kind: TryResult,
+						expr:   expr,
+						ok:     _type.val,
+						OkType: _type.val,
+						Kind:   TryResult,
 					}
 				}
 			case *Maybe:
@@ -3761,6 +3765,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 					return &TryOp{
 						expr:       expr,
 						ok:         _type.of, // Returns unwrapped value for continued execution
+						OkType:     _type.of,
 						CatchBlock: block,
 						CatchVar:   "", // No variable binding for Maybe catch
 						Kind:       TryMaybe,
@@ -3772,9 +3777,10 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 						c.addError("try without catch clause on Maybe requires function to return a Maybe type", s.GetLocation())
 						// Return a try op with the unwrapped type to avoid cascading errors
 						return &TryOp{
-							expr: expr,
-							ok:   _type.of,
-							Kind: TryMaybe,
+							expr:   expr,
+							ok:     _type.of,
+							OkType: _type.of,
+							Kind:   TryMaybe,
 						}
 					}
 
@@ -3786,18 +3792,20 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 					// Success: returns the unwrapped value
 					// None: early returns none wrapped in the function's Maybe type
 					return &TryOp{
-						expr: expr,
-						ok:   _type.of,
-						Kind: TryMaybe,
+						expr:   expr,
+						ok:     _type.of,
+						OkType: _type.of,
+						Kind:   TryMaybe,
 					}
 				}
 			default:
 				c.addError("try can only be used on Result or Maybe types, got: "+expr.Type().String(), s.Expression.GetLocation())
 				// Return a try op with the expr type to avoid cascading errors
 				return &TryOp{
-					expr: expr,
-					ok:   expr.Type(),
-					Kind: TryResult, // Default to Result, though this is an error path
+					expr:   expr,
+					ok:     expr.Type(),
+					OkType: expr.Type(),
+					Kind:   TryResult, // Default to Result, though this is an error path
 				}
 			}
 		}

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -1723,9 +1723,10 @@ func (c *Checker) createPrimitiveMethodNode(subject Expression, methodName strin
 	return &InstanceMethod{
 		Subject: subject,
 		Method: &FunctionCall{
-			Name: methodName,
-			Args: args,
-			fn:   fnDef,
+			Name:       methodName,
+			Args:       args,
+			fn:         fnDef,
+			ReturnType: fnDef.ReturnType,
 		},
 		ReceiverKind: receiverKind,
 		StructType:   structType,
@@ -1893,11 +1894,12 @@ func (c *Checker) createMaybeMethod(subject Expression, methodName string, args 
 		panic(fmt.Sprintf("Unknown Maybe method: %s", methodName))
 	}
 	return &MaybeMethod{
-		Subject:   subject,
-		Kind:      kind,
-		Args:      args,
-		InnerType: maybeType.Of(),
-		fn:        fnDef,
+		Subject:    subject,
+		Kind:       kind,
+		Args:       args,
+		InnerType:  maybeType.Of(),
+		fn:         fnDef,
+		ReturnType: fnDef.ReturnType,
 	}
 }
 
@@ -2133,9 +2135,10 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 
 			// Create and return the function call node
 			return &FunctionCall{
-				Name: s.Name,
-				Args: args,
-				fn:   fnToUse,
+				Name:       s.Name,
+				Args:       args,
+				fn:         fnToUse,
+				ReturnType: fnToUse.ReturnType,
 			}
 		}
 	case *parse.InstanceProperty:
@@ -2684,9 +2687,10 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				}
 
 				call := &FunctionCall{
-					Name: absolutePath,
-					Args: args,
-					fn:   fnDef,
+					Name:       absolutePath,
+					Args:       args,
+					fn:         fnDef,
+					ReturnType: fnDef.ReturnType,
 				}
 
 				// Use new generic resolution system
@@ -2698,6 +2702,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 					}
 
 					call.fn = specialized
+					call.ReturnType = specialized.ReturnType
 				}
 
 				return call
@@ -2783,9 +2788,10 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 
 			// Create function call
 			call := &FunctionCall{
-				Name: fnDef.Name,
-				Args: args,
-				fn:   fnToUse,
+				Name:       fnDef.Name,
+				Args:       args,
+				fn:         fnToUse,
+				ReturnType: fnToUse.ReturnType,
 			}
 
 			// Special validation for async::start calls
@@ -4030,9 +4036,10 @@ func (c *Checker) checkExprAs(expr parse.Expression, expectedType Type) Expressi
 			return &ModuleFunctionCall{
 				Module: mod.Path(),
 				Call: &FunctionCall{
-					Name: fnDef.name(),
-					Args: []Expression{arg},
-					fn:   fnDef,
+					Name:       fnDef.name(),
+					Args:       []Expression{arg},
+					fn:         fnDef,
+					ReturnType: fnDef.ReturnType,
 				},
 			}
 		}
@@ -4327,6 +4334,7 @@ func (c *Checker) synthesizeMaybeNone(paramType Type) Expression {
 				ReturnType: paramType, // The return type is the Maybe type we're filling in
 				Body:       nil,       // No body for synthesized calls
 			},
+			ReturnType: paramType,
 		},
 	}
 }
@@ -4352,6 +4360,7 @@ func (c *Checker) synthesizeMaybeSome(value Expression, maybeType Type) Expressi
 				ReturnType: maybeType,
 				Body:       nil, // No body for synthesized calls
 			},
+			ReturnType: maybeType,
 		},
 	}
 }

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -1705,6 +1705,21 @@ func (c *Checker) createPrimitiveMethodNode(subject Expression, methodName strin
 	}
 
 	// For user-defined types (structs, enums), use generic InstanceMethod
+	receiverKind := ReceiverUnknown
+	var structType *StructDef
+	var enumType *Enum
+	var traitType *Trait
+	switch receiver := subject.Type().(type) {
+	case *StructDef:
+		receiverKind = ReceiverStruct
+		structType = receiver
+	case *Enum:
+		receiverKind = ReceiverEnum
+		enumType = receiver
+	case *Trait:
+		receiverKind = ReceiverTrait
+		traitType = receiver
+	}
 	return &InstanceMethod{
 		Subject: subject,
 		Method: &FunctionCall{
@@ -1712,6 +1727,10 @@ func (c *Checker) createPrimitiveMethodNode(subject Expression, methodName strin
 			Args: args,
 			fn:   fnDef,
 		},
+		ReceiverKind: receiverKind,
+		StructType:   structType,
+		EnumType:     enumType,
+		TraitType:    traitType,
 	}
 }
 

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -2134,13 +2134,16 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				return nil
 			}
 
-			// Create and return the function call node
-			return &FunctionCall{
+			call := &FunctionCall{
 				Name:       s.Name,
 				Args:       args,
 				fn:         fnToUse,
 				ReturnType: fnToUse.ReturnType,
 			}
+			if extFnDef, ok := fnSym.Type.(*ExternalFunctionDef); ok {
+				call.ExternalBinding = extFnDef.ExternalBinding
+			}
+			return call
 		}
 	case *parse.InstanceProperty:
 		{

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -3707,6 +3707,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 						expr:       expr,
 						ok:         _type.val, // Returns unwrapped value for continued execution
 						OkType:     _type.val,
+						ErrType:    _type.err,
 						CatchBlock: block,
 						CatchVar:   s.CatchVar.Name,
 						Kind:       TryResult,
@@ -3718,10 +3719,11 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 						c.addError("try without catch clause requires function to return a Result type", s.GetLocation())
 						// Return a try op with the unwrapped type to avoid cascading errors
 						return &TryOp{
-							expr:   expr,
-							ok:     _type.val,
-							OkType: _type.val,
-							Kind:   TryResult,
+							expr:    expr,
+							ok:      _type.val,
+							OkType:  _type.val,
+							ErrType: _type.err,
+							Kind:    TryResult,
 						}
 					}
 
@@ -3730,20 +3732,22 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 						c.addError(fmt.Sprintf("Error type mismatch: Expected %s, got %s", fnReturnResult.err.String(), _type.err.String()), s.Expression.GetLocation())
 						// Return a try op with the unwrapped type to avoid cascading errors
 						return &TryOp{
-							expr:   expr,
-							ok:     _type.val,
-							OkType: _type.val,
-							Kind:   TryResult,
+							expr:    expr,
+							ok:      _type.val,
+							OkType:  _type.val,
+							ErrType: _type.err,
+							Kind:    TryResult,
 						}
 					}
 
 					// Success: returns the unwrapped value
 					// Error: early returns the error wrapped in the function's Result type
 					return &TryOp{
-						expr:   expr,
-						ok:     _type.val,
-						OkType: _type.val,
-						Kind:   TryResult,
+						expr:    expr,
+						ok:      _type.val,
+						OkType:  _type.val,
+						ErrType: _type.err,
+						Kind:    TryResult,
 					}
 				}
 			case *Maybe:
@@ -3834,10 +3838,11 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				c.addError("try can only be used on Result or Maybe types, got: "+expr.Type().String(), s.Expression.GetLocation())
 				// Return a try op with the expr type to avoid cascading errors
 				return &TryOp{
-					expr:   expr,
-					ok:     expr.Type(),
-					OkType: expr.Type(),
-					Kind:   TryResult, // Default to Result, though this is an error path
+					expr:    expr,
+					ok:      expr.Type(),
+					OkType:  expr.Type(),
+					ErrType: Void,
+					Kind:    TryResult, // Default to Result, though this is an error path
 				}
 			}
 		}

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -3339,6 +3339,8 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				Subject: subject,
 				Ok:      okCase,
 				Err:     errCase,
+				OkType:  resultType.Val(),
+				ErrType: resultType.Err(),
 			}
 		}
 

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -1919,12 +1919,13 @@ func (c *Checker) createResultMethod(subject Expression, methodName string, args
 		panic(fmt.Sprintf("Unknown Result method: %s", methodName))
 	}
 	return &ResultMethod{
-		Subject: subject,
-		Kind:    kind,
-		Args:    args,
-		OkType:  resultType.Val(),
-		ErrType: resultType.Err(),
-		fn:      fnDef,
+		Subject:    subject,
+		Kind:       kind,
+		Args:       args,
+		OkType:     resultType.Val(),
+		ErrType:    resultType.Err(),
+		fn:         fnDef,
+		ReturnType: fnDef.ReturnType,
 	}
 }
 

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -28,6 +28,7 @@ var compareOptions = cmp.Options{
 	cmpopts.IgnoreFields(checker.ModuleStructInstance{}, "StructType"),
 	cmpopts.IgnoreFields(checker.StructInstance{}, "StructType"),
 	cmpopts.IgnoreFields(checker.TryOp{}, "OkType"),
+	cmpopts.IgnoreFields(checker.UnionMatch{}, "TypeCasesByType"),
 	cmpopts.IgnoreUnexported(
 		checker.TypeVar{},
 		checker.BoolMethod{},

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -26,6 +26,8 @@ var compareOptions = cmp.Options{
 	cmpopts.IgnoreFields(checker.FiberEval{}, "FiberType"),
 	cmpopts.IgnoreFields(checker.FiberExecution{}, "FiberType"),
 	cmpopts.IgnoreFields(checker.ModuleStructInstance{}, "StructType"),
+	cmpopts.IgnoreFields(checker.FunctionCall{}, "ReturnType"),
+	cmpopts.IgnoreFields(checker.MaybeMethod{}, "ReturnType"),
 	cmpopts.IgnoreFields(checker.StructInstance{}, "StructType"),
 	cmpopts.IgnoreFields(checker.TryOp{}, "OkType"),
 	cmpopts.IgnoreFields(checker.UnionMatch{}, "TypeCasesByType"),

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -27,6 +27,7 @@ var compareOptions = cmp.Options{
 	cmpopts.IgnoreFields(checker.FiberExecution{}, "FiberType"),
 	cmpopts.IgnoreFields(checker.ModuleStructInstance{}, "StructType"),
 	cmpopts.IgnoreFields(checker.FunctionCall{}, "ReturnType"),
+	cmpopts.IgnoreFields(checker.FunctionCall{}, "ExternalBinding"),
 	cmpopts.IgnoreFields(checker.MaybeMethod{}, "ReturnType"),
 	cmpopts.IgnoreFields(checker.ResultMethod{}, "ReturnType"),
 	cmpopts.IgnoreFields(checker.ResultMatch{}, "OkType", "ErrType"),

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -28,6 +28,7 @@ var compareOptions = cmp.Options{
 	cmpopts.IgnoreFields(checker.ModuleStructInstance{}, "StructType"),
 	cmpopts.IgnoreFields(checker.FunctionCall{}, "ReturnType"),
 	cmpopts.IgnoreFields(checker.MaybeMethod{}, "ReturnType"),
+	cmpopts.IgnoreFields(checker.ResultMethod{}, "ReturnType"),
 	cmpopts.IgnoreFields(checker.StructInstance{}, "StructType"),
 	cmpopts.IgnoreFields(checker.TryOp{}, "OkType"),
 	cmpopts.IgnoreFields(checker.UnionMatch{}, "TypeCasesByType"),

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -29,6 +29,7 @@ var compareOptions = cmp.Options{
 	cmpopts.IgnoreFields(checker.FunctionCall{}, "ReturnType"),
 	cmpopts.IgnoreFields(checker.MaybeMethod{}, "ReturnType"),
 	cmpopts.IgnoreFields(checker.ResultMethod{}, "ReturnType"),
+	cmpopts.IgnoreFields(checker.ResultMatch{}, "OkType", "ErrType"),
 	cmpopts.IgnoreFields(checker.StructInstance{}, "StructType"),
 	cmpopts.IgnoreFields(checker.TryOp{}, "OkType"),
 	cmpopts.IgnoreFields(checker.UnionMatch{}, "TypeCasesByType"),

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -22,8 +22,11 @@ var compareOptions = cmp.Options{
 	cmpopts.IgnoreFields(checker.EnumMatch{}, "DiscriminantToIndex"),
 	cmpopts.IgnoreFields(checker.EnumVariant{}, "EnumType", "Discriminant"),
 	cmpopts.IgnoreFields(checker.ListLiteral{}, "ListType"),
+	cmpopts.IgnoreFields(checker.FiberEval{}, "FiberType"),
+	cmpopts.IgnoreFields(checker.FiberExecution{}, "FiberType"),
 	cmpopts.IgnoreFields(checker.ModuleStructInstance{}, "StructType"),
 	cmpopts.IgnoreFields(checker.StructInstance{}, "StructType"),
+	cmpopts.IgnoreFields(checker.TryOp{}, "OkType"),
 	cmpopts.IgnoreUnexported(
 		checker.TypeVar{},
 		checker.BoolMethod{},

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -22,6 +22,7 @@ var compareOptions = cmp.Options{
 	cmpopts.IgnoreFields(checker.EnumMatch{}, "DiscriminantToIndex"),
 	cmpopts.IgnoreFields(checker.EnumVariant{}, "EnumType", "Discriminant"),
 	cmpopts.IgnoreFields(checker.ListLiteral{}, "ListType"),
+	cmpopts.IgnoreFields(checker.InstanceMethod{}, "ReceiverKind", "StructType", "EnumType", "TraitType"),
 	cmpopts.IgnoreFields(checker.FiberEval{}, "FiberType"),
 	cmpopts.IgnoreFields(checker.FiberExecution{}, "FiberType"),
 	cmpopts.IgnoreFields(checker.ModuleStructInstance{}, "StructType"),

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -19,6 +19,11 @@ type test struct {
 
 var compareOptions = cmp.Options{
 	cmpopts.SortMaps(func(a, b string) bool { return a < b }),
+	cmpopts.IgnoreFields(checker.EnumMatch{}, "DiscriminantToIndex"),
+	cmpopts.IgnoreFields(checker.EnumVariant{}, "EnumType", "Discriminant"),
+	cmpopts.IgnoreFields(checker.ListLiteral{}, "ListType"),
+	cmpopts.IgnoreFields(checker.ModuleStructInstance{}, "StructType"),
+	cmpopts.IgnoreFields(checker.StructInstance{}, "StructType"),
 	cmpopts.IgnoreUnexported(
 		checker.TypeVar{},
 		checker.BoolMethod{},
@@ -1939,7 +1944,7 @@ func TestEnumValues(t *testing.T) {
 			},
 		},
 		{
-			name: "Enum variant values must be integer literals",
+			name:  "Enum variant values must be integer literals",
 			input: `enum Test { X = "not an int" }`,
 			diagnostics: []checker.Diagnostic{
 				{
@@ -2237,8 +2242,6 @@ func TestMatchingOnInts(t *testing.T) {
 		},
 	})
 }
-
-
 
 func TestGenerics(t *testing.T) {
 	run(t, []test{

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -30,6 +30,7 @@ var compareOptions = cmp.Options{
 	cmpopts.IgnoreFields(checker.MaybeMethod{}, "ReturnType"),
 	cmpopts.IgnoreFields(checker.ResultMethod{}, "ReturnType"),
 	cmpopts.IgnoreFields(checker.ResultMatch{}, "OkType", "ErrType"),
+	cmpopts.IgnoreFields(checker.TryOp{}, "OkType", "ErrType"),
 	cmpopts.IgnoreFields(checker.StructInstance{}, "StructType"),
 	cmpopts.IgnoreFields(checker.TryOp{}, "OkType"),
 	cmpopts.IgnoreFields(checker.UnionMatch{}, "TypeCasesByType"),

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -1342,6 +1342,8 @@ type ResultMatch struct {
 	Subject Expression
 	Ok      *Match
 	Err     *Match
+	OkType  Type // Pre-computed ok type
+	ErrType Type // Pre-computed err type
 }
 
 func (r ResultMatch) Type() Type {

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -188,8 +188,12 @@ func (i *InstanceProperty) String() string {
 }
 
 type InstanceMethod struct {
-	Subject Expression
-	Method  *FunctionCall
+	Subject      Expression
+	Method       *FunctionCall
+	ReceiverKind InstanceReceiverKind
+	StructType   *StructDef
+	EnumType     *Enum
+	TraitType    *Trait
 }
 
 func (i *InstanceMethod) Type() Type {
@@ -199,6 +203,15 @@ func (i *InstanceMethod) Type() Type {
 func (i *InstanceMethod) String() string {
 	return fmt.Sprintf("%s.%s", i.Subject, i.Method.Name)
 }
+
+type InstanceReceiverKind uint8
+
+const (
+	ReceiverUnknown InstanceReceiverKind = iota
+	ReceiverStruct
+	ReceiverEnum
+	ReceiverTrait
+)
 
 // Primitive method types with enum-based dispatch
 

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -466,16 +466,20 @@ const (
 )
 
 type ResultMethod struct {
-	Subject Expression
-	Kind    ResultMethodKind
-	Args    []Expression
-	OkType  Type         // Pre-computed OK type
-	ErrType Type         // Pre-computed Error type
-	fn      *FunctionDef // Function definition for return type resolution
+	Subject    Expression
+	Kind       ResultMethodKind
+	Args       []Expression
+	OkType     Type         // Pre-computed OK type
+	ErrType    Type         // Pre-computed Error type
+	fn         *FunctionDef // Function definition for return type resolution
+	ReturnType Type         // Pre-computed by checker
 }
 
 func (m *ResultMethod) Type() Type {
 	// Use function return type if available (handles generics properly)
+	if m.ReturnType != nil {
+		return m.ReturnType
+	}
 	if m.fn != nil {
 		return m.fn.ReturnType
 	}

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -1054,10 +1054,11 @@ func (f *FunctionDef) hasGenerics() bool {
 }
 
 type FunctionCall struct {
-	Name       string
-	Args       []Expression
-	fn         *FunctionDef
-	ReturnType Type // Pre-computed by checker
+	Name            string
+	Args            []Expression
+	fn              *FunctionDef
+	ReturnType      Type // Pre-computed by checker
+	ExternalBinding string
 }
 
 func CreateCall(name string, args []Expression, fn FunctionDef) *FunctionCall {

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -1352,6 +1352,7 @@ const (
 type TryOp struct {
 	expr       Expression
 	ok         Type
+	OkType     Type
 	CatchBlock *Block
 	CatchVar   string
 	Kind       TryKind // Pre-computed by checker: TryResult or TryMaybe

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -682,9 +682,10 @@ func (i *IntMatch) Type() Type {
 }
 
 type UnionMatch struct {
-	Subject   Expression
-	TypeCases map[string]*Match
-	CatchAll  *Block
+	Subject         Expression
+	TypeCases       map[string]*Match
+	TypeCasesByType map[Type]*Match // Pre-computed type lookup
+	CatchAll        *Block
 }
 
 func (u *UnionMatch) Type() Type {

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -1377,6 +1377,7 @@ type TryOp struct {
 	expr       Expression
 	ok         Type
 	OkType     Type
+	ErrType    Type
 	CatchBlock *Block
 	CatchVar   string
 	Kind       TryKind // Pre-computed by checker: TryResult or TryMaybe

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -95,6 +95,7 @@ func (f *FloatLiteral) Type() Type {
 type ListLiteral struct {
 	Elements []Expression
 	_type    Type
+	ListType Type // Pre-computed by checker
 }
 
 func (l *ListLiteral) Type() Type {
@@ -603,9 +604,10 @@ func (o *OptionMatch) Type() Type {
 }
 
 type EnumMatch struct {
-	Subject  Expression
-	Cases    []*Block
-	CatchAll *Block
+	Subject             Expression
+	Cases               []*Block
+	CatchAll            *Block
+	DiscriminantToIndex map[int]int8 // Pre-computed discriminant lookup
 }
 
 func (e *EnumMatch) Type() Type {
@@ -1053,6 +1055,7 @@ type ModuleStructInstance struct {
 	Module     string
 	Property   *StructInstance
 	FieldTypes map[string]Type // Pre-computed by checker
+	StructType Type            // Pre-computed by checker
 }
 
 func (p *ModuleStructInstance) Type() Type {
@@ -1146,8 +1149,10 @@ func (e Enum) hasTrait(trait *Trait) bool {
 }
 
 type EnumVariant struct {
-	enum    *Enum
-	Variant int8
+	enum         *Enum
+	Variant      int8
+	EnumType     Type // Pre-computed by checker
+	Discriminant int  // Pre-computed by checker
 }
 
 func (ev EnumVariant) Type() Type {
@@ -1304,6 +1309,7 @@ type StructInstance struct {
 	Fields     map[string]Expression
 	_type      *StructDef
 	FieldTypes map[string]Type // Pre-computed by checker
+	StructType Type            // Pre-computed by checker
 }
 
 func (s StructInstance) Type() Type {

--- a/compiler/checker/types.go
+++ b/compiler/checker/types.go
@@ -13,6 +13,13 @@ func areCompatible(expected Type, actual Type) bool {
 	return expected.equal(actual)
 }
 
+func HasTrait(t Type, trait *Trait) bool {
+	if t == nil || trait == nil {
+		return false
+	}
+	return t.hasTrait(trait)
+}
+
 type Type interface {
 	String() string
 	get(name string) Type

--- a/compiler/docs/for-loop-expressions.md
+++ b/compiler/docs/for-loop-expressions.md
@@ -1,0 +1,33 @@
+# For Loop Expressions (Deferred)
+
+This document records the decision to defer adding `for` loops as expressions.
+
+## Proposal Summary
+
+The idea was to allow `for` loops to return a list, similar to a comprehension:
+
+```
+let doubled: [Int] = for i in 1..10 { i * 2 }
+```
+
+Key properties discussed:
+- The loop would evaluate to a list of body results.
+- `break` would end the loop and return a partial list.
+
+## Decision
+
+We are not pursuing this feature right now.
+
+## Reasons
+
+- Allowing `for` as a full expression introduces usage in arbitrary expression positions.
+- Restricting usage to assignment or similar contexts is a special-case rule.
+- Either approach complicates parsing and type checking in ways that are not worth it right now.
+
+## Revisit Notes
+
+If reconsidered later, clarify the following first:
+
+- Whether `for` expressions are allowed in all expression positions.
+- Whether `break` can carry a value or only short-circuits list collection.
+- How the checker infers the element type when the result is not explicitly typed.

--- a/compiler/runtime/kind.go
+++ b/compiler/runtime/kind.go
@@ -1,0 +1,98 @@
+package runtime
+
+import "github.com/akonwi/ard/checker"
+
+type Kind uint8
+
+const (
+	KindUnknown Kind = iota
+	KindVoid
+	KindStr
+	KindInt
+	KindFloat
+	KindBool
+	KindList
+	KindMap
+	KindMaybe
+	KindResult
+	KindStruct
+	KindEnum
+	KindFunction
+	KindDynamic
+)
+
+func kindForType(t checker.Type) Kind {
+	if t == nil {
+		return KindUnknown
+	}
+	if t == checker.Void {
+		return KindVoid
+	}
+	if t == checker.Str {
+		return KindStr
+	}
+	if t == checker.Int {
+		return KindInt
+	}
+	if t == checker.Float {
+		return KindFloat
+	}
+	if t == checker.Bool {
+		return KindBool
+	}
+	if t == checker.Dynamic {
+		return KindDynamic
+	}
+
+	switch t.(type) {
+	case *checker.List:
+		return KindList
+	case *checker.Map:
+		return KindMap
+	case *checker.Maybe:
+		return KindMaybe
+	case *checker.Result:
+		return KindResult
+	case *checker.StructDef:
+		return KindStruct
+	case *checker.Enum:
+		return KindEnum
+	case *checker.FunctionDef:
+		return KindFunction
+	default:
+		return KindUnknown
+	}
+}
+
+func (k Kind) String() string {
+	switch k {
+	case KindVoid:
+		return "Void"
+	case KindStr:
+		return "Str"
+	case KindInt:
+		return "Int"
+	case KindFloat:
+		return "Float"
+	case KindBool:
+		return "Bool"
+	case KindList:
+		return "List"
+	case KindMap:
+		return "Map"
+	case KindMaybe:
+		return "Maybe"
+	case KindResult:
+		return "Result"
+	case KindStruct:
+		return "Struct"
+	case KindEnum:
+		return "Enum"
+	case KindFunction:
+		return "Function"
+	case KindDynamic:
+		return "Dynamic"
+	default:
+		return "Unknown"
+	}
+}

--- a/compiler/runtime/kind.go
+++ b/compiler/runtime/kind.go
@@ -64,6 +64,13 @@ func kindForType(t checker.Type) Kind {
 	}
 }
 
+func typeNameForType(t checker.Type) string {
+	if t == nil {
+		return KindUnknown.String()
+	}
+	return t.String()
+}
+
 func (k Kind) String() string {
 	switch k {
 	case KindVoid:

--- a/compiler/runtime/object.go
+++ b/compiler/runtime/object.go
@@ -15,6 +15,7 @@ type Object struct {
 	// Object should only be nested in raw for collections like List, Map.
 	raw   any
 	_type checker.Type
+	kind  Kind
 
 	// Results will set one of these to true
 	isErr bool
@@ -29,6 +30,10 @@ func (o Object) String() string {
 
 func (o Object) Type() checker.Type {
 	return o._type
+}
+
+func (o Object) Kind() Kind {
+	return o.kind
 }
 
 // simply compares the raw representations.
@@ -95,6 +100,7 @@ func (o *Object) SetRefinedType(declared checker.Type) {
 			}
 		}
 	}
+	o.kind = kindForType(o._type)
 }
 
 func deepCopy(data any) any {
@@ -126,6 +132,7 @@ func (o *Object) Copy() *Object {
 	copy := &Object{
 		raw:    o.raw,
 		_type:  o._type,
+		kind:   o.kind,
 		isErr:  o.isErr,
 		isOk:   o.isOk,
 		isNone: o.isNone,
@@ -244,7 +251,7 @@ func (o Object) AsBool() bool {
 }
 
 func (o Object) IsInt() (int, bool) {
-	if o._type == checker.Int {
+	if o.kind == KindInt {
 		return o.raw.(int), true
 	}
 	return 0, false
@@ -258,11 +265,11 @@ func (o Object) AsInt() int {
 }
 
 func (o Object) IsFloat() bool {
-	return o._type == checker.Float
+	return o.kind == KindFloat
 }
 
 func (o Object) AsFloat() float64 {
-	if o._type == checker.Float {
+	if o.kind == KindFloat {
 		return o.raw.(float64)
 	}
 	panic(fmt.Sprintf("%T is not a Float", o._type))
@@ -276,7 +283,7 @@ func (o Object) AsString() string {
 }
 
 func (o Object) IsStr() (string, bool) {
-	if o._type == checker.Str {
+	if o.kind == KindStr {
 		return o.raw.(string), true
 	}
 	return "", false
@@ -296,9 +303,40 @@ func (o *Object) AsMap() map[string]*Object {
 	panic(fmt.Sprintf("%T is not a Map", o._type))
 }
 
+func (o Object) MapType() *checker.Map {
+	if o.kind != KindMap {
+		return nil
+	}
+	if m, ok := o._type.(*checker.Map); ok {
+		return m
+	}
+	return nil
+}
+
+func (o Object) StructType() *checker.StructDef {
+	if o.kind != KindStruct {
+		return nil
+	}
+	if s, ok := o._type.(*checker.StructDef); ok {
+		return s
+	}
+	return nil
+}
+
+func (o Object) EnumType() *checker.Enum {
+	if o.kind != KindEnum {
+		return nil
+	}
+	if e, ok := o._type.(*checker.Enum); ok {
+		return e
+	}
+	return nil
+}
+
 func MakeStr(s string) *Object {
 	return &Object{
 		_type: checker.Str,
+		kind:  KindStr,
 		raw:   s,
 	}
 }
@@ -306,6 +344,7 @@ func MakeStr(s string) *Object {
 func MakeInt(i int) *Object {
 	return &Object{
 		_type: checker.Int,
+		kind:  KindInt,
 		raw:   i,
 	}
 }
@@ -313,6 +352,7 @@ func MakeInt(i int) *Object {
 func MakeFloat(f float64) *Object {
 	return &Object{
 		_type: checker.Float,
+		kind:  KindFloat,
 		raw:   f,
 	}
 }
@@ -320,6 +360,7 @@ func MakeFloat(f float64) *Object {
 func MakeBool(b bool) *Object {
 	return &Object{
 		_type: checker.Bool,
+		kind:  KindBool,
 		raw:   b,
 	}
 }
@@ -327,6 +368,7 @@ func MakeBool(b bool) *Object {
 func MakeNone(of checker.Type) *Object {
 	return &Object{
 		_type:  checker.MakeMaybe(of),
+		kind:   KindMaybe,
 		raw:    nil,
 		isNone: true,
 	}
@@ -357,6 +399,7 @@ func (o Object) IsNone() bool {
 func MakeList(of checker.Type, items ...*Object) *Object {
 	return &Object{
 		_type: checker.MakeList(of),
+		kind:  KindList,
 		raw:   items,
 	}
 }
@@ -369,6 +412,7 @@ func (o *Object) List_Push(item *Object) {
 func MakeMap(keyType, valueType checker.Type) *Object {
 	return &Object{
 		_type: checker.MakeMap(keyType, valueType),
+		kind:  KindMap,
 		raw:   make(map[string]*Object),
 	}
 }
@@ -477,14 +521,12 @@ func MakeStruct(of checker.Type, fields map[string]*Object) *Object {
 	return &Object{
 		raw:   fields,
 		_type: of,
+		kind:  KindStruct,
 	}
 }
 
 func (o Object) IsStruct() bool {
-	if _, ok := o._type.(*checker.StructDef); ok {
-		return true
-	}
-	return false
+	return o.kind == KindStruct
 }
 
 func (o Object) Struct_Get(key string) *Object {
@@ -504,6 +546,7 @@ func MakeDynamic(val any) *Object {
 	return &Object{
 		raw:   val,
 		_type: checker.Dynamic,
+		kind:  KindDynamic,
 	}
 }
 
@@ -511,12 +554,13 @@ func Make(val any, of checker.Type) *Object {
 	return &Object{
 		raw:   val,
 		_type: of,
+		kind:  kindForType(of),
 	}
 }
 
 // use a single instance of void. lame attempt at optimization
 var void = &Object{
-	raw: nil, _type: checker.Void,
+	raw: nil, _type: checker.Void, kind: KindVoid,
 }
 
 func Void() *Object {

--- a/compiler/runtime/object.go
+++ b/compiler/runtime/object.go
@@ -16,6 +16,7 @@ type Object struct {
 	raw   any
 	_type checker.Type
 	kind  Kind
+	name  string
 
 	// Results will set one of these to true
 	isErr bool
@@ -34,6 +35,10 @@ func (o Object) Type() checker.Type {
 
 func (o Object) Kind() Kind {
 	return o.kind
+}
+
+func (o Object) TypeName() string {
+	return o.name
 }
 
 // simply compares the raw representations.
@@ -101,6 +106,7 @@ func (o *Object) SetRefinedType(declared checker.Type) {
 		}
 	}
 	o.kind = kindForType(o._type)
+	o.name = typeNameForType(o._type)
 }
 
 func deepCopy(data any) any {
@@ -133,6 +139,7 @@ func (o *Object) Copy() *Object {
 		raw:    o.raw,
 		_type:  o._type,
 		kind:   o.kind,
+		name:   o.name,
 		isErr:  o.isErr,
 		isOk:   o.isOk,
 		isNone: o.isNone,
@@ -337,6 +344,7 @@ func MakeStr(s string) *Object {
 	return &Object{
 		_type: checker.Str,
 		kind:  KindStr,
+		name:  checker.Str.String(),
 		raw:   s,
 	}
 }
@@ -345,6 +353,7 @@ func MakeInt(i int) *Object {
 	return &Object{
 		_type: checker.Int,
 		kind:  KindInt,
+		name:  checker.Int.String(),
 		raw:   i,
 	}
 }
@@ -353,6 +362,7 @@ func MakeFloat(f float64) *Object {
 	return &Object{
 		_type: checker.Float,
 		kind:  KindFloat,
+		name:  checker.Float.String(),
 		raw:   f,
 	}
 }
@@ -361,6 +371,7 @@ func MakeBool(b bool) *Object {
 	return &Object{
 		_type: checker.Bool,
 		kind:  KindBool,
+		name:  checker.Bool.String(),
 		raw:   b,
 	}
 }
@@ -369,6 +380,7 @@ func MakeNone(of checker.Type) *Object {
 	return &Object{
 		_type:  checker.MakeMaybe(of),
 		kind:   KindMaybe,
+		name:   checker.MakeMaybe(of).String(),
 		raw:    nil,
 		isNone: true,
 	}
@@ -400,6 +412,7 @@ func MakeList(of checker.Type, items ...*Object) *Object {
 	return &Object{
 		_type: checker.MakeList(of),
 		kind:  KindList,
+		name:  checker.MakeList(of).String(),
 		raw:   items,
 	}
 }
@@ -413,6 +426,7 @@ func MakeMap(keyType, valueType checker.Type) *Object {
 	return &Object{
 		_type: checker.MakeMap(keyType, valueType),
 		kind:  KindMap,
+		name:  checker.MakeMap(keyType, valueType).String(),
 		raw:   make(map[string]*Object),
 	}
 }
@@ -522,6 +536,7 @@ func MakeStruct(of checker.Type, fields map[string]*Object) *Object {
 		raw:   fields,
 		_type: of,
 		kind:  KindStruct,
+		name:  of.String(),
 	}
 }
 
@@ -547,6 +562,7 @@ func MakeDynamic(val any) *Object {
 		raw:   val,
 		_type: checker.Dynamic,
 		kind:  KindDynamic,
+		name:  checker.Dynamic.String(),
 	}
 }
 
@@ -555,12 +571,13 @@ func Make(val any, of checker.Type) *Object {
 		raw:   val,
 		_type: of,
 		kind:  kindForType(of),
+		name:  typeNameForType(of),
 	}
 }
 
 // use a single instance of void. lame attempt at optimization
 var void = &Object{
-	raw: nil, _type: checker.Void, kind: KindVoid,
+	raw: nil, _type: checker.Void, kind: KindVoid, name: checker.Void.String(),
 }
 
 func Void() *Object {

--- a/compiler/vm/interpret.go
+++ b/compiler/vm/interpret.go
@@ -795,7 +795,7 @@ func (vm *VM) evalFunctionCall(scope *scope, call *checker.FunctionCall, _args .
 		return closure.Eval(args...)
 	}
 
-	panic(fmt.Errorf("Not a function: %s: %s", call.Name, sig.Type()))
+	panic(fmt.Errorf("Not a function: %s: %s", call.Name, sig.TypeName()))
 }
 
 func (vm *VM) evalBlock(scope *scope, block *checker.Block, init func(s *scope)) (*runtime.Object, bool) {

--- a/compiler/vm/interpret.go
+++ b/compiler/vm/interpret.go
@@ -686,11 +686,11 @@ func (vm *VM) eval(scp *scope, expr checker.Expression) *runtime.Object {
 					} else {
 						// No catch block: propagate none by early returning
 						scp.stop()
-						return runtime.MakeNone(e.Type())
+						return runtime.MakeNone(e.OkType)
 					}
 				}
 				// Some case: unwrap and continue execution
-				return runtime.Make(subj.Raw(), e.Type())
+				return runtime.Make(subj.Raw(), e.OkType)
 
 			default:
 				panic(fmt.Errorf("Unknown try kind: %d", e.Kind))
@@ -725,7 +725,7 @@ func (vm *VM) eval(scp *scope, expr checker.Expression) *runtime.Object {
 			}()
 			f.callMain(e.GetMainName(), fscope)
 		})
-		return runtime.MakeStruct(e.Type(), map[string]*runtime.Object{
+		return runtime.MakeStruct(e.FiberType, map[string]*runtime.Object{
 			"wg": runtime.MakeDynamic(wg),
 		})
 	case *checker.FiberEval:
@@ -767,7 +767,7 @@ func (vm *VM) eval(scp *scope, expr checker.Expression) *runtime.Object {
 			*resultContainer = *result
 		})
 
-		return runtime.MakeStruct(e.Type(), map[string]*runtime.Object{
+		return runtime.MakeStruct(e.FiberType, map[string]*runtime.Object{
 			"wg":     runtime.MakeDynamic(wg),
 			"result": resultContainer,
 		})

--- a/compiler/vm/interpret.go
+++ b/compiler/vm/interpret.go
@@ -532,14 +532,7 @@ func (vm *VM) eval(scp *scope, expr checker.Expression) *runtime.Object {
 	case *checker.UnionMatch:
 		{
 			subject := vm.eval(scp, e.Subject)
-			if len(e.TypeCasesByType) > 0 {
-				if arm, ok := e.TypeCasesByType[subject.Type()]; ok {
-					res, _ := vm.evalBlock(scp, arm.Body, func(sc *scope) {
-						sc.add(arm.Pattern.Name, subject)
-					})
-					return res
-				}
-			} else if arm, ok := e.TypeCases[subject.Type().String()]; ok {
+			if arm, ok := e.TypeCases[subject.TypeName()]; ok {
 				res, _ := vm.evalBlock(scp, arm.Body, func(sc *scope) {
 					sc.add(arm.Pattern.Name, subject)
 				})

--- a/compiler/vm/interpret.go
+++ b/compiler/vm/interpret.go
@@ -1291,7 +1291,7 @@ func (vm *VM) evalMaybeMethod(scope *scope, subj *runtime.Object, m *checker.Ins
 			panic(_msg)
 		}
 		// Return the unwrapped value for some
-		return runtime.Make(subj.Raw(), m.Type())
+		return runtime.Make(subj.Raw(), m.Method.ReturnType)
 	case "is_none":
 		return runtime.MakeBool(subj.Raw() == nil)
 	case "is_some":
@@ -1300,7 +1300,7 @@ func (vm *VM) evalMaybeMethod(scope *scope, subj *runtime.Object, m *checker.Ins
 		if subj.Raw() == nil {
 			return vm.eval(scope, m.Method.Args[0])
 		}
-		return runtime.Make(subj.Raw(), m.Type())
+		return runtime.Make(subj.Raw(), m.Method.ReturnType)
 	default:
 		panic(fmt.Errorf("Unimplemented: %s.%s()", subj.Kind(), m.Method.Name))
 	}

--- a/compiler/vm/maybe_module.go
+++ b/compiler/vm/maybe_module.go
@@ -25,13 +25,21 @@ func (m *MaybeModule) get(name string) *runtime.Object {
 func (m *MaybeModule) Handle(call *checker.FunctionCall, args []*runtime.Object) *runtime.Object {
 	switch call.Name {
 	case "none":
-		o := runtime.MakeNone(nil)
-		o.SetRefinedType(call.Type())
+		maybeType, ok := call.ReturnType.(*checker.Maybe)
+		if !ok {
+			panic(fmt.Errorf("maybe::none expected Maybe return type, got %s", call.ReturnType))
+		}
+		o := runtime.MakeNone(maybeType.Of())
+		o.SetRefinedType(call.ReturnType)
 		return o
 	case "some":
 		arg := args[0]
-		o := runtime.MakeNone(arg.Type()).ToSome(arg.Raw())
-		o.SetRefinedType(call.Type())
+		maybeType, ok := call.ReturnType.(*checker.Maybe)
+		if !ok {
+			panic(fmt.Errorf("maybe::some expected Maybe return type, got %s", call.ReturnType))
+		}
+		o := runtime.MakeNone(maybeType.Of()).ToSome(arg.Raw())
+		o.SetRefinedType(call.ReturnType)
 		return o
 	default:
 		panic(fmt.Errorf("Unimplemented: maybe::%s()", call.Name))


### PR DESCRIPTION
## Summary
- Add a full bytecode compiler pipeline (opcodes, emitter, verifier, serializer) and a bytecode VM runtime.
- Switch `ard run` to bytecode by default with `--legacy` for the interpreter, and `ard build --out` to emit self-contained executables.
- Add conformance tests (strict stdout), benchmarks, and expanded sample coverage to validate parity and performance.
- Update checker/runtime lowering metadata and HTTP handler execution so bytecode can run real services and stdlib modules.
- Update roadmap docs to reflect bytecode as the primary backend and interpreter as legacy.

## Testing
- `go test ./...`
- `go test ./bytecode -run TestBytecodeConformanceSamples -count=1`
- `go test ./bytecode/vm -count=1`
