### PR TITLE
fix: formatter corrupting chained method calls with string arguments

### DIFF
--- a/compiler/formatter/doc_printer.go
+++ b/compiler/formatter/doc_printer.go
@@ -64,7 +64,9 @@ func (p printer) printDoc(root doc) string {
 			}
 			column = cmd.indent
 		case docGroup:
-			if p.fits(p.maxLineWidth-column, append(stack, printCmd{indent: cmd.indent, mode: modeFlat, doc: node.content})) {
+			testStack := append([]printCmd(nil), stack...)
+			testStack = append(testStack, printCmd{indent: cmd.indent, mode: modeFlat, doc: node.content})
+			if p.fits(p.maxLineWidth-column, testStack) {
 				stack = append(stack, printCmd{indent: cmd.indent, mode: modeFlat, doc: node.content})
 			} else {
 				stack = append(stack, printCmd{indent: cmd.indent, mode: modeBreak, doc: node.content})

--- a/compiler/formatter/formatter_test.go
+++ b/compiler/formatter/formatter_test.go
@@ -139,6 +139,11 @@ func TestFormat(t *testing.T) {
 			input: "fn broken( {",
 			error: true,
 		},
+		{
+			name:   "preserves chained method calls with string arguments",
+			input:  "fn test() {\n  let url = get(\"DATABASE_URL\").expect(\"DATABASE_URL is required\").trim().replace(\"'\", \"\")\n}\n",
+			output: "fn test() {\n  let url = get(\"DATABASE_URL\").expect(\"DATABASE_URL is required\").trim().replace(\"'\", \"\")\n}\n",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixed a bug in doc_printer.go where the stack was being mutated during the fits() check for docGroup nodes. This caused subsequent print commands to be lost, resulting in corrupted output for chained method calls with multiple string arguments.

The fix creates a copy of the stack before appending the test command, preventing the mutation from affecting subsequent group evaluations.

Also added a regression test case.

Amp-Thread-ID: https://ampcode.com/threads/T-019cac61-5bf5-704d-8dbb-f3b3ccf0e72b