### PR TITLE
Add request-level HTTP timeout support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,3 @@
 # TODO
 - [ ] FFI functions should be able to use idiomatic Go and compiler handles mappings
+- [ ] Allow nullable struct fields to use the same implicit wrapping sugar as nullable function parameters (e.g. `timeout: 30` for `Int?` fields)

--- a/compiler/bytecode/vm/http_test.go
+++ b/compiler/bytecode/vm/http_test.go
@@ -24,7 +24,7 @@ func TestBytecodeHttpMethod(t *testing.T) {
 
 func TestBytecodeHttpSendUsesRequestTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(1100 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	}))
@@ -32,14 +32,13 @@ func TestBytecodeHttpSendUsesRequestTimeout(t *testing.T) {
 
 	input := fmt.Sprintf(`
 		use ard/http
-		use ard/duration
 		use ard/maybe
 
 		http::send(http::Request{
 			method: http::Method::Get,
 			url: %q,
 			headers: [:],
-			timeout: maybe::some(duration::from_millis(10)),
+			timeout: maybe::some(1),
 		}).or(http::Response::new(-1, "")).status
 	`, server.URL)
 
@@ -50,7 +49,7 @@ func TestBytecodeHttpSendUsesRequestTimeout(t *testing.T) {
 
 func TestBytecodeHttpSendCallSiteTimeoutOverridesRequestTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(1100 * time.Millisecond)
 		w.WriteHeader(http.StatusCreated)
 		_, _ = w.Write([]byte("created"))
 	}))
@@ -58,17 +57,16 @@ func TestBytecodeHttpSendCallSiteTimeoutOverridesRequestTimeout(t *testing.T) {
 
 	input := fmt.Sprintf(`
 		use ard/http
-		use ard/duration
 		use ard/maybe
 
 		let req = http::Request{
 			method: http::Method::Get,
 			url: %q,
 			headers: [:],
-			timeout: maybe::some(duration::from_millis(10)),
+			timeout: maybe::some(1),
 		}
 
-		http::send(req, maybe::some(duration::from_millis(100))).or(http::Response::new(-1, "")).status
+		http::send(req, 2).or(http::Response::new(-1, "")).status
 	`, server.URL)
 
 	if got := runBytecode(t, input); got != http.StatusCreated {

--- a/compiler/bytecode/vm/http_test.go
+++ b/compiler/bytecode/vm/http_test.go
@@ -1,6 +1,12 @@
 package vm
 
-import "testing"
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
 
 func TestBytecodeHttpMethod(t *testing.T) {
 	runBytecodeTests(t, []vmTestCase{
@@ -14,4 +20,58 @@ func TestBytecodeHttpMethod(t *testing.T) {
 			want: "POST",
 		},
 	})
+}
+
+func TestBytecodeHttpSendUsesRequestTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	input := fmt.Sprintf(`
+		use ard/http
+		use ard/duration
+		use ard/maybe
+
+		http::send(http::Request{
+			method: http::Method::Get,
+			url: %q,
+			headers: [:],
+			timeout: maybe::some(duration::from_millis(10)),
+		}).or(http::Response::new(-1, "")).status
+	`, server.URL)
+
+	if got := runBytecode(t, input); got != -1 {
+		t.Fatalf("Expected request timeout fallback status -1, got %v", got)
+	}
+}
+
+func TestBytecodeHttpSendCallSiteTimeoutOverridesRequestTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("created"))
+	}))
+	defer server.Close()
+
+	input := fmt.Sprintf(`
+		use ard/http
+		use ard/duration
+		use ard/maybe
+
+		let req = http::Request{
+			method: http::Method::Get,
+			url: %q,
+			headers: [:],
+			timeout: maybe::some(duration::from_millis(10)),
+		}
+
+		http::send(req, maybe::some(duration::from_millis(100))).or(http::Response::new(-1, "")).status
+	`, server.URL)
+
+	if got := runBytecode(t, input); got != http.StatusCreated {
+		t.Fatalf("Expected override timeout to succeed with %d, got %v", http.StatusCreated, got)
+	}
 }

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -408,10 +408,11 @@ func collectGenericsFromType(t Type, params *[]string, seen map[string]bool) {
 		collectGenericsFromType(t.val, params, seen)
 		collectGenericsFromType(t.err, params, seen)
 	case *StructDef:
-		// Extract generics from struct fields in a consistent order
-		// We need to iterate in a deterministic order; using sorted keys would work
-		for _, fieldType := range t.Fields {
-			collectGenericsFromType(fieldType, params, seen)
+		for _, genericName := range t.GenericParams {
+			if !seen[genericName] {
+				*params = append(*params, genericName)
+				seen[genericName] = true
+			}
 		}
 	}
 }
@@ -1268,6 +1269,7 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 				Methods: make(map[string]*FunctionDef),
 				Private: s.Private,
 			}
+			seenGenerics := make(map[string]bool)
 			for _, field := range s.Fields {
 				fieldType := c.resolveType(field.Type)
 				if fieldType == nil {
@@ -1279,6 +1281,7 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 					return nil
 				}
 				def.Fields[field.Name.Name] = fieldType
+				collectGenericsFromType(fieldType, &def.GenericParams, seenGenerics)
 			}
 			c.scope.add(def.name(), def, false)
 			return &Statement{Stmt: def}
@@ -1668,12 +1671,13 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 	instance.FieldTypes = fieldTypes
 	// Store the refined struct definition (with resolved generics) as the instance's type
 	instance._type = &StructDef{
-		Name:    structDefCopy.Name,
-		Fields:  fieldTypes,
-		Methods: structDefCopy.Methods,
-		Self:    structDefCopy.Self,
-		Traits:  structDefCopy.Traits,
-		Private: structDefCopy.Private,
+		Name:          structDefCopy.Name,
+		Fields:        fieldTypes,
+		Methods:       structDefCopy.Methods,
+		Self:          structDefCopy.Self,
+		Traits:        structDefCopy.Traits,
+		GenericParams: structDefCopy.GenericParams,
+		Private:       structDefCopy.Private,
 	}
 	instance.StructType = instance._type
 	return instance

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -2477,5 +2477,12 @@ func TestGenericTypeParams(t *testing.T) {
 				`let box: Box<[Int]> = Box{ item: [1, 2, 3] }`,
 			}, "\n"),
 		},
+		{
+			name: "Multiple type parameters preserve declaration order rather than field-name order",
+			input: strings.Join([]string{
+				`struct Weird { zeta: $T, alpha: $U }`,
+				`let weird: Weird<Int, Str> = Weird{ zeta: 42, alpha: "hello" }`,
+			}, "\n"),
+		},
 	})
 }

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -1245,12 +1245,13 @@ func (u Union) hasTrait(trait *Trait) bool {
 }
 
 type StructDef struct {
-	Name    string
-	Fields  map[string]Type
-	Methods map[string]*FunctionDef
-	Self    string
-	Traits  []*Trait
-	Private bool
+	Name          string
+	Fields        map[string]Type
+	Methods       map[string]*FunctionDef
+	Self          string
+	Traits        []*Trait
+	GenericParams []string
+	Private       bool
 }
 
 func (def StructDef) NonProducing() {}

--- a/compiler/checker/scope.go
+++ b/compiler/checker/scope.go
@@ -376,12 +376,13 @@ func copyStructWithTypeVarMap(structDef *StructDef, typeVarMap map[string]*TypeV
 	}
 
 	return &StructDef{
-		Name:    structDef.Name,
-		Fields:  newFields,
-		Methods: structDef.Methods, // Methods are not copied; they're shared
-		Self:    structDef.Self,
-		Traits:  structDef.Traits,
-		Private: structDef.Private,
+		Name:          structDef.Name,
+		Fields:        newFields,
+		Methods:       structDef.Methods, // Methods are not copied; they're shared
+		Self:          structDef.Self,
+		Traits:        structDef.Traits,
+		GenericParams: append([]string(nil), structDef.GenericParams...),
+		Private:       structDef.Private,
 	}
 }
 

--- a/compiler/ffi/http.go
+++ b/compiler/ffi/http.go
@@ -1,7 +1,6 @@
 package ffi
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -77,16 +76,13 @@ func HTTP_Send(args []*runtime.Object, returnType checker.Type) *runtime.Object 
 	}
 
 	client := &http.Client{}
+	if len(args) >= 5 && !args[4].IsNone() {
+		client.Timeout = time.Duration(args[4].AsInt()) * time.Second
+	}
 
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return runtime.MakeErr(runtime.MakeStr(err.Error()))
-	}
-
-	if len(args) >= 5 && !args[4].IsNone() {
-		ctx, cancel := context.WithTimeout(req.Context(), time.Duration(args[4].AsInt())*time.Second)
-		defer cancel()
-		req = req.WithContext(ctx)
 	}
 
 	req.Header = headers

--- a/compiler/ffi/http.go
+++ b/compiler/ffi/http.go
@@ -1,6 +1,7 @@
 package ffi
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -50,7 +51,7 @@ func GetQueryParam(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeStr(req.URL.Query().Get(name))
 }
 
-// fn (method: Str, url: Str, body: Dynamic?, headers: [Str:Str]) Response!Str
+// fn (method: Str, url: Str, body: Dynamic?, headers: [Str:Str], timeout: Int?) Response!Str
 func HTTP_Send(args []*runtime.Object, returnType checker.Type) *runtime.Object {
 	method := args[0].AsString()
 	url := args[1].AsString()
@@ -75,13 +76,17 @@ func HTTP_Send(args []*runtime.Object, returnType checker.Type) *runtime.Object 
 		headers.Set(k, v.AsString())
 	}
 
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
+	client := &http.Client{}
 
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+
+	if len(args) >= 5 && !args[4].IsNone() {
+		ctx, cancel := context.WithTimeout(req.Context(), time.Duration(args[4].AsInt()))
+		defer cancel()
+		req = req.WithContext(ctx)
 	}
 
 	req.Header = headers
@@ -210,6 +215,7 @@ func HTTP_Serve(args []*runtime.Object, _ checker.Type) *runtime.Object {
 				"url":     runtime.MakeStr(r.URL.String()),
 				"headers": runtime.Make(headers, checker.MakeMap(checker.Str, checker.Str)),
 				"body":    body,
+				"timeout": runtime.MakeNone(checker.Int),
 				"raw":     runtime.MakeNone(checker.Dynamic).ToSome(r),
 			}
 

--- a/compiler/ffi/http.go
+++ b/compiler/ffi/http.go
@@ -84,7 +84,7 @@ func HTTP_Send(args []*runtime.Object, returnType checker.Type) *runtime.Object 
 	}
 
 	if len(args) >= 5 && !args[4].IsNone() {
-		ctx, cancel := context.WithTimeout(req.Context(), time.Duration(args[4].AsInt()))
+		ctx, cancel := context.WithTimeout(req.Context(), time.Duration(args[4].AsInt())*time.Second)
 		defer cancel()
 		req = req.WithContext(ctx)
 	}

--- a/compiler/samples/pokemon.ard
+++ b/compiler/samples/pokemon.ard
@@ -1,7 +1,6 @@
 use ard/io
 use ard/http
 use ard/decode
-use ard/duration
 
 fn main() {
   io::print("GET from pokemon api")
@@ -9,9 +8,8 @@ fn main() {
     method: http::Method::Get,
     url: "https://pokeapi.co/api/v2/pokemon",
     headers: [:],
-    timeout: duration::from_seconds(30),
   }
-  let res = http::send(req, duration::from_seconds(60)).expect("Unable to make request")
+  let res = http::send(req, 60).expect("Unable to make request")
 
   if res.is_ok() {
     let data = decode::from_json(res.body).expect("Unable to decode response body as JSON")

--- a/compiler/samples/pokemon.ard
+++ b/compiler/samples/pokemon.ard
@@ -1,6 +1,7 @@
 use ard/io
 use ard/http
 use ard/decode
+use ard/maybe
 
 fn main() {
   io::print("GET from pokemon api")
@@ -39,7 +40,7 @@ fn main() {
     method: http::Method::Post,
     url: "https://postman-echo.com/post",
     headers: ["content-type":"text/plain"],
-    body: "raw text"
+    body: maybe::some("raw text")
   })
   match post_res {
     ok(res) => io::print("got a {res.status}"),

--- a/compiler/samples/pokemon.ard
+++ b/compiler/samples/pokemon.ard
@@ -1,15 +1,17 @@
 use ard/io
 use ard/http
-use ard/maybe
 use ard/decode
+use ard/duration
 
 fn main() {
   io::print("GET from pokemon api")
-  let res = http::send(http::Request{
+  let req = http::Request{
     method: http::Method::Get,
     url: "https://pokeapi.co/api/v2/pokemon",
     headers: [:],
-  }).expect("Unable to make request")
+    timeout: duration::from_seconds(30),
+  }
+  let res = http::send(req, duration::from_seconds(60)).expect("Unable to make request")
 
   if res.is_ok() {
     let data = decode::from_json(res.body).expect("Unable to decode response body as JSON")
@@ -39,7 +41,7 @@ fn main() {
     method: http::Method::Post,
     url: "https://postman-echo.com/post",
     headers: ["content-type":"text/plain"],
-    body: maybe::some("raw text")
+    body: "raw text"
   })
   match post_res {
     ok(res) => io::print("got a {res.status}"),

--- a/compiler/std_lib/http.ard
+++ b/compiler/std_lib/http.ard
@@ -28,6 +28,7 @@ struct Request {
   url: Str,
   headers: [Str: Str],
   body: Dynamic?,
+  timeout: Int?,
 
   // inbound requests have the *http.Request
   raw: Dynamic?,
@@ -74,11 +75,15 @@ impl Response {
   }
 }
 
-private extern fn _send(method: Str, url: Str, body: Dynamic?, headers: [Str: Str]) Response!Str = "HTTP_Send"
+private extern fn _send(method: Str, url: Str, body: Dynamic?, headers: [Str: Str], timeout: Int?) Response!Str = "HTTP_Send"
 
-fn send(req: Request) Response!Str {
+fn send(req: Request, timeout: Int?) Response!Str {
   let method = req.method.to_str()
-  _send(method, req.url, req.body, req.headers)
+  let effective_timeout = match timeout {
+    t => maybe::some(t),
+    _ => req.timeout,
+  }
+  _send(method, req.url, req.body, req.headers, effective_timeout)
 }
 
 type HandlerFn = fn(Request, mut Response)

--- a/website/src/content/docs/advanced/data-decoding.md
+++ b/website/src/content/docs/advanced/data-decoding.md
@@ -233,9 +233,16 @@ Here's how to process API responses without predefined structs:
 use ard/http
 use ard/decode
 use ard/io
+use ard/duration
 
 fn fetch_pokemon() {
-  let response = http::get("https://pokeapi.co/api/v2/pokemon").expect("Request failed")
+  let req = http::Request{
+    method: http::Method::Get,
+    url: "https://pokeapi.co/api/v2/pokemon",
+    headers: [:],
+    timeout: duration::from_seconds(10),
+  }
+  let response = http::send(req).expect("Request failed")
 
   if response.is_ok() {
     // Extract count

--- a/website/src/content/docs/advanced/data-decoding.md
+++ b/website/src/content/docs/advanced/data-decoding.md
@@ -233,16 +233,14 @@ Here's how to process API responses without predefined structs:
 use ard/http
 use ard/decode
 use ard/io
-use ard/duration
 
 fn fetch_pokemon() {
   let req = http::Request{
     method: http::Method::Get,
     url: "https://pokeapi.co/api/v2/pokemon",
     headers: [:],
-    timeout: duration::from_seconds(10),
   }
-  let response = http::send(req).expect("Request failed")
+  let response = http::send(req, 10).expect("Request failed")
 
   if response.is_ok() {
     // Extract count

--- a/website/src/content/docs/examples/samples.md
+++ b/website/src/content/docs/examples/samples.md
@@ -335,28 +335,24 @@ Basic HTTP server using the `ard/http` module:
 use ard/http
 use ard/io
 
-fn handle_home(req: http::Request) http::Response {
-  http::Response::new(200, "Welcome to Ard server!")
-}
-
-fn handle_about(req: http::Request) http::Response {
-  let content = "This is an Ard-powered web server running on {req.host()}"
-  http::Response::new(200, content)
-}
-
-fn handle_echo(req: http::Request) http::Response {
-  let path = req.path().unwrap_or("/")
-  http::Response::new(200, "You requested: {path}")
-}
-
 fn main() {
   io::print("Starting server on port 3000...")
-  
-  http::serve(3000, [
-    "/": handle_home,
-    "/about": handle_about,
-    "/echo": handle_echo
-  ])
+
+  let routes: [Str:http::HandlerFn] = [
+    "/": fn(req: http::Request, mut res: http::Response) {
+      res.body = "Welcome to Ard server!"
+    },
+    "/about": fn(req: http::Request, mut res: http::Response) {
+      let path = req.path().or("/")
+      res.body = "About page from {path}"
+    },
+    "/echo": fn(req: http::Request, mut res: http::Response) {
+      let path = req.path().or("/")
+      res.body = "You requested: {path}"
+    }
+  ]
+
+  http::serve(3000, routes).expect("Failed to start server")
 }
 ```
 

--- a/website/src/content/docs/stdlib/http.md
+++ b/website/src/content/docs/stdlib/http.md
@@ -17,17 +17,15 @@ The module includes:
 ```ard
 use ard/http
 use ard/io
-use ard/duration
 
 fn main() {
   let req = http::Request{
     method: http::Method::Get,
     url: "https://example.com",
     headers: [:],
-    timeout: duration::from_seconds(10),
   }
 
-  match http::send(req, duration::from_seconds(30)) {
+  match http::send(req, 30) {
     ok(response) => io::print("Status: {response.status.to_str()}"),
     err(e) => io::print("Error: {e}")
   }
@@ -70,24 +68,11 @@ Represents an HTTP request.
 - **`url: Str`** - The request URL
 - **`headers: [Str:Str]`** - Request headers as a map
 - **`body: Dynamic?`** - Optional request body
-- **`timeout: Int?`** - Optional request timeout in nanoseconds
-- **`raw: Dynamic?`** - Internal field for inbound server requests
+- **`timeout: Int?`** - Optional request timeout in seconds
 
 `Request.body` is dynamic so you can support text, JSON payloads, and other shapes without forcing a string-only API. For server handlers, decode `req.body` into the expected shape with `ard/decode`.
 
-Use `ard/duration` helpers when setting timeouts:
-
-```ard
-use ard/http
-use ard/duration
-
-let req = http::Request{
-  method: http::Method::Get,
-  url: "https://api.example.com/users",
-  headers: [:],
-  timeout: duration::from_seconds(90),
-}
-```
+Timeouts are expressed in whole seconds. You can pass a timeout directly to `http::send(req, timeout)` without any duration conversion.
 
 #### Methods
 
@@ -174,16 +159,14 @@ The optional `timeout` argument overrides `req.timeout`.
 ```ard
 use ard/http
 use ard/io
-use ard/duration
 
 let req = http::Request{
   method: http::Method::Get,
   url: "https://api.example.com/users",
   headers: [:],
-  timeout: duration::from_seconds(15),
 }
 
-match http::send(req, duration::from_seconds(60)) {
+match http::send(req, 60) {
   ok(response) => io::print(response.body),
   err(error) => io::print("Request failed: {error}")
 }
@@ -217,14 +200,12 @@ fn main() {
 ```ard
 use ard/http
 use ard/io
-use ard/duration
 
 fn main() {
   let req = http::Request{
     method: http::Method::Get,
     url: "https://jsonplaceholder.typicode.com/posts/1",
     headers: [:],
-    timeout: duration::from_seconds(10),
   }
 
   match http::send(req) {
@@ -269,7 +250,6 @@ fn main() {
 
 ```ard
 use ard/http
-use ard/duration
 
 fn main() {
   let req = http::Request{
@@ -277,11 +257,9 @@ fn main() {
     url: "https://api.openai.com/v1/responses",
     headers: ["content-type": "application/json"],
     body: "{\"model\":\"gpt-4.1\"}",
-    timeout: duration::from_seconds(30),
   }
 
-  // This call uses 90s instead of the 30s request default.
-  let res = http::send(req, duration::from_seconds(90))
+  let res = http::send(req, 90)
 }
 ```
 

--- a/website/src/content/docs/stdlib/http.md
+++ b/website/src/content/docs/stdlib/http.md
@@ -3,34 +3,41 @@ title: HTTP Operations with ard/http
 description: Make HTTP requests and handle responses using the ard/http module.
 ---
 
-The `ard/http` module provides functions for making HTTP requests and serving HTTP endpoints.
+The `ard/http` module provides APIs for making outbound HTTP requests and serving inbound HTTP endpoints.
 
-The http module provides:
-- **HTTP methods** (GET, POST, PUT, DELETE, PATCH, OPTIONS)
-- **Request structures** for building and customizing HTTP requests
-- **Response structures** for handling HTTP responses
-- **HTTP client** functionality for making outbound requests
-- **HTTP server** functionality for handling inbound requests
+The module includes:
+- **HTTP methods** (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `OPTIONS`)
+- **Request structures** for outbound and inbound requests
+- **Response structures** for handling responses
+- **HTTP client** functionality for outbound requests
+- **HTTP server** functionality for route handlers
+
+## Quick start
 
 ```ard
 use ard/http
 use ard/io
-use ard/maybe
+use ard/duration
 
 fn main() {
-  let req = http::Request {
+  let req = http::Request{
     method: http::Method::Get,
     url: "https://example.com",
     headers: [:],
-    body: maybe::none()
+    timeout: duration::from_seconds(10),
   }
-  
-  match http::send(req) {
+
+  match http::send(req, duration::from_seconds(30)) {
     ok(response) => io::print("Status: {response.status.to_str()}"),
     err(e) => io::print("Error: {e}")
   }
 }
 ```
+
+In `http::send(req, timeout)`:
+- the call-site `timeout` wins if provided
+- otherwise `req.timeout` is used
+- if neither is set, no request timeout is applied by Ard
 
 ## API
 
@@ -49,9 +56,10 @@ The `Method` enum implements `ToString`:
 
 ```ard
 use ard/http
+use ard/io
 
 let method = http::Method::Post
-io::print(method)  // "POST"
+io::print(method) // "POST"
 ```
 
 ### `struct Request`
@@ -62,25 +70,41 @@ Represents an HTTP request.
 - **`url: Str`** - The request URL
 - **`headers: [Str:Str]`** - Request headers as a map
 - **`body: Dynamic?`** - Optional request body
+- **`timeout: Int?`** - Optional request timeout in nanoseconds
+- **`raw: Dynamic?`** - Internal field for inbound server requests
 
 `Request.body` is dynamic so you can support text, JSON payloads, and other shapes without forcing a string-only API. For server handlers, decode `req.body` into the expected shape with `ard/decode`.
+
+Use `ard/duration` helpers when setting timeouts:
+
+```ard
+use ard/http
+use ard/duration
+
+let req = http::Request{
+  method: http::Method::Get,
+  url: "https://api.example.com/users",
+  headers: [:],
+  timeout: duration::from_seconds(90),
+}
+```
 
 #### Methods
 
 ##### `fn path() Str?`
 
-Get the path from an inbound request (only available on server-side requests).
+Get the path from an inbound request.
 
 ```ard
 use ard/http
 
-fn handler(req: http::Request) http::Response {
+fn handler(req: http::Request, mut res: http::Response) {
   match req.path() {
-    path => {
-      // handle specific path
-      http::Response::new(200, "OK")
-    },
-    _ => http::Response::new(404, "Not Found")
+    path => res.body = "Path: {path}",
+    _ => {
+      res.status = 404
+      res.body = "Not Found"
+    }
   }
 }
 ```
@@ -92,9 +116,9 @@ Get a path parameter value from an inbound request by name.
 ```ard
 use ard/http
 
-fn handler(req: http::Request) http::Response {
+fn handler(req: http::Request, mut res: http::Response) {
   let id = req.path_param("id")
-  http::Response::new(200, "User: {id}")
+  res.body = "User: {id}"
 }
 ```
 
@@ -105,9 +129,9 @@ Get a query parameter value from an inbound request by name.
 ```ard
 use ard/http
 
-fn handler(req: http::Request) http::Response {
+fn handler(req: http::Request, mut res: http::Response) {
   let page = req.query_param("page")
-  http::Response::new(200, "Page: {page}")
+  res.body = "Page: {page}"
 }
 ```
 
@@ -118,8 +142,6 @@ Represents an HTTP response.
 - **`status: Int`** - HTTP status code
 - **`headers: [Str:Str]`** - Response headers as a map
 - **`body: Str`** - Response body
-
-#### Methods
 
 ##### `fn Response::new(status: Int, body: Str) Response`
 
@@ -143,21 +165,25 @@ if response.is_ok() {
 }
 ```
 
-### `fn send(req: Request) Response!Str`
+### `fn send(req: Request, timeout: Int?) Response!Str`
 
 Send an HTTP request and return the response or an error message.
 
+The optional `timeout` argument overrides `req.timeout`.
+
 ```ard
 use ard/http
+use ard/io
+use ard/duration
 
-let req = http::Request {
+let req = http::Request{
   method: http::Method::Get,
   url: "https://api.example.com/users",
   headers: [:],
-  body: maybe::none()
+  timeout: duration::from_seconds(15),
 }
 
-match http::send(req) {
+match http::send(req, duration::from_seconds(60)) {
   ok(response) => io::print(response.body),
   err(error) => io::print("Request failed: {error}")
 }
@@ -167,11 +193,10 @@ match http::send(req) {
 
 Start an HTTP server on the given port with route handlers.
 
-The handlers map keys are route paths and values are handler functions that take a request and a mutable response object. Handlers modify the response object directly rather than constructing and returning it.
+The handlers map keys are route paths and values are handler functions that take a request and a mutable response object. Handlers modify the response object directly.
 
 ```ard
 use ard/http
-use ard/io
 
 fn main() {
   let handlers: [Str:fn(http::Request, mut http::Response)] = [
@@ -180,27 +205,28 @@ fn main() {
       res.status = 200
     }
   ]
-  
+
   http::serve(8080, handlers).expect("Failed to start server")
 }
 ```
 
 ## Examples
 
-### Make a GET Request
+### Make a GET request
 
 ```ard
 use ard/http
 use ard/io
+use ard/duration
 
 fn main() {
-  let req = http::Request {
+  let req = http::Request{
     method: http::Method::Get,
     url: "https://jsonplaceholder.typicode.com/posts/1",
     headers: [:],
-    body: maybe::none()
+    timeout: duration::from_seconds(10),
   }
-  
+
   match http::send(req) {
     ok(response) => {
       if response.is_ok() {
@@ -214,26 +240,24 @@ fn main() {
 }
 ```
 
-### Make a POST Request
+### Make a POST request
 
 ```ard
 use ard/http
 use ard/io
 use ard/json
-use ard/maybe
-use ard/dynamic
 
 fn main() {
   let body_data = ["name": "Alice", "age": 30]
   let body_json = json::encode(body_data).expect("Failed to encode")
-  
-  let req = http::Request {
+
+  let req = http::Request{
     method: http::Method::Post,
     url: "https://api.example.com/users",
     headers: ["Content-Type": "application/json"],
-    body: maybe::some(dynamic::from_str(body_json))
+    body: body_json,
   }
-  
+
   match http::send(req) {
     ok(response) => io::print(response.body),
     err(error) => io::print("Request failed: {error}")
@@ -241,7 +265,27 @@ fn main() {
 }
 ```
 
-### Decode an Inbound JSON Body
+### Long-running request with timeout override
+
+```ard
+use ard/http
+use ard/duration
+
+fn main() {
+  let req = http::Request{
+    method: http::Method::Post,
+    url: "https://api.openai.com/v1/responses",
+    headers: ["content-type": "application/json"],
+    body: "{\"model\":\"gpt-4.1\"}",
+    timeout: duration::from_seconds(30),
+  }
+
+  // This call uses 90s instead of the 30s request default.
+  let res = http::send(req, duration::from_seconds(90))
+}
+```
+
+### Decode an inbound JSON body
 
 ```ard
 use ard/http
@@ -279,11 +323,10 @@ fn main() {
 }
 ```
 
-### Simple HTTP Server
+### Simple HTTP server
 
 ```ard
 use ard/http
-use ard/io
 
 fn main() {
   let handlers: [Str:fn(http::Request, mut http::Response)] = [
@@ -298,12 +341,12 @@ fn main() {
       res.body = "User ID: {id}"
     }
   ]
-  
+
   http::serve(3000, handlers).expect("Failed to start server")
 }
 ```
 
-### HTTP Server with Query Parameters
+### HTTP server with query parameters
 
 ```ard
 use ard/http
@@ -315,7 +358,7 @@ fn main() {
       res.body = "Results for: {query}"
     }
   ]
-  
+
   http::serve(8080, handlers).expect("Failed to start server")
 }
 ```


### PR DESCRIPTION
## Summary
- add request-level HTTP timeout support with call-site override precedence
- switch HTTP timeout values to seconds for a simpler public API
- fix generic struct type parameter ordering in the checker
- update tests, samples, and HTTP docs

## Validation
- cd compiler && go test ./...