### PR TITLE
feat: implicit Maybe wrapping for nullable struct fields

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,3 @@
 # TODO
 - [ ] FFI functions should be able to use idiomatic Go and compiler handles mappings
-- [ ] Allow nullable struct fields to use the same implicit wrapping sugar as nullable function parameters (e.g. `timeout: 30` for `Int?` fields)
+

--- a/compiler/bytecode/vm/struct_test.go
+++ b/compiler/bytecode/vm/struct_test.go
@@ -70,6 +70,104 @@ func TestBytecodeStructs(t *testing.T) {
 	}
 }
 
+func TestBytecodeStructMaybeFieldImplicitWrapping(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  any
+	}{
+		{
+			name: "implicit wrapping of non-nullable value for nullable struct field",
+			input: `
+				struct Config {
+					name: Str,
+					timeout: Int?,
+				}
+				let c = Config{name: "app", timeout: 30}
+				c.timeout.or(0)
+			`,
+			want: 30,
+		},
+		{
+			name: "omitting nullable struct field still works",
+			input: `
+				struct Config {
+					name: Str,
+					timeout: Int?,
+				}
+				let c = Config{name: "app"}
+				c.timeout.or(0)
+			`,
+			want: 0,
+		},
+		{
+			name: "explicit maybe::some still works for struct fields",
+			input: `
+				use ard/maybe
+				struct Config {
+					name: Str,
+					timeout: Int?,
+				}
+				let c = Config{name: "app", timeout: maybe::some(30)}
+				c.timeout.or(0)
+			`,
+			want: 30,
+		},
+		{
+			name: "implicit wrapping of list literal for nullable struct field",
+			input: `
+				struct Data {
+					items: [Int]?,
+				}
+				let d = Data{items: [1, 2, 3]}
+				match d.items {
+					lst => lst.size()
+					_ => 0
+				}
+			`,
+			want: 3,
+		},
+		{
+			name: "implicit wrapping of map literal for nullable struct field",
+			input: `
+				struct Data {
+					meta: [Str:Int]?,
+				}
+				let d = Data{meta: ["count": 42]}
+				match d.meta {
+					m => true
+					_ => false
+				}
+			`,
+			want: true,
+		},
+		{
+			name: "implicit wrapping with multiple nullable fields",
+			input: `
+				struct Options {
+					a: Int?,
+					b: Str?,
+					c: Bool?,
+				}
+				let o = Options{a: 1, b: "hi", c: true}
+				let av = o.a.or(0)
+				let bv = o.b.or("")
+				let cv = o.c.or(false)
+				"{av},{bv},{cv}"
+			`,
+			want: "1,hi,true",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := runBytecode(t, test.input); got != test.want {
+				t.Fatalf("Expected %v, got %v", test.want, got)
+			}
+		})
+	}
+}
+
 func TestBytecodeStaticFunctions(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -1622,6 +1622,15 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 					continue
 				}
 
+				// Implicit Maybe wrapping: if field is Maybe<T> and value is T, wrap in maybe::some()
+				if maybeField, isMaybe := field.(*Maybe); isMaybe {
+					if valType := checkVal.Type(); !valType.equal(field) {
+						if maybeField.Of().equal(valType) {
+							checkVal = c.synthesizeMaybeSome(checkVal, field)
+						}
+					}
+				}
+
 				if err := c.unifyTypes(field, checkVal.Type(), genericScope); err != nil {
 					c.addError(err.Error(), property.GetLocation())
 					continue
@@ -1632,8 +1641,30 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 				fields[fieldName] = checkVal
 				fieldTypes[fieldName] = field
 			} else {
-				// For non-generic structs, use the original checkExprAs which provides type context
-				if val := c.checkExprAs(property.Value, field); val != nil {
+				// For non-generic structs, handle nullable fields with implicit wrapping
+				var val Expression
+				if maybeField, isMaybe := field.(*Maybe); isMaybe {
+					// For literals and anonymous functions, use inner type for type inference context
+					switch property.Value.(type) {
+					case *parse.ListLiteral, *parse.MapLiteral, *parse.AnonymousFunction:
+						val = c.checkExprAs(property.Value, maybeField.Of())
+					default:
+						val = c.checkExpr(property.Value)
+					}
+					// Implicit Maybe wrapping: if value is T, wrap in maybe::some(T)
+					if val != nil && !val.Type().equal(field) {
+						if maybeField.Of().equal(val.Type()) {
+							val = c.synthesizeMaybeSome(val, field)
+						} else {
+							c.addError(typeMismatch(field, val.Type()), property.GetLocation())
+							val = nil
+						}
+					}
+				} else {
+					// Non-nullable fields use checkExprAs which provides type context
+					val = c.checkExprAs(property.Value, field)
+				}
+				if val != nil {
 					fields[fieldName] = val
 					fieldTypes[fieldName] = field
 				}

--- a/website/src/content/docs/guide/structs.md
+++ b/website/src/content/docs/guide/structs.md
@@ -35,6 +35,30 @@ let age = person.age          // 30
 io::print("Hello, {person.name}!")
 ```
 
+## Nullable Fields
+
+Struct fields can be nullable using the `?` suffix. Nullable fields can be omitted when creating an instance, in which case they default to `none`:
+
+```ard
+struct Config {
+  name: Str,
+  timeout: Int?,
+  retries: Int?,
+}
+
+// Omit nullable fields — they become none
+let config = Config{name: "app"}
+
+// Provide values directly — they are automatically wrapped
+let config = Config{name: "app", timeout: 30, retries: 3}
+
+// You can still use maybe::some() explicitly if you prefer
+use ard/maybe
+let config = Config{name: "app", timeout: maybe::some(30)}
+```
+
+This is the same implicit wrapping behavior available for [nullable function parameters](/guide/functions#nullable-parameters).
+
 ## Methods
 
 Methods are like normal functions and are only available on instances of a struct.

--- a/website/src/content/docs/stdlib/maybe.md
+++ b/website/src/content/docs/stdlib/maybe.md
@@ -142,18 +142,19 @@ fn main() {
 
 ### Process Optional Data
 
-```ard
-use ard/maybe
+Nullable struct fields accept unwrapped values directly — they are automatically wrapped in `maybe::some()`:
 
+```ard
 struct User {
   name: Str,
   bio: Str?
 }
 
 fn main() {
+  // bio is automatically wrapped in maybe::some()
   let user = User {
     name: "Alice",
-    bio: maybe::some("Software engineer")
+    bio: "Software engineer"
   }
   
   match user.bio {


### PR DESCRIPTION
Nullable struct fields (`T?`) now accept unwrapped `T` values, automatically wrapping them in `maybe::some()`. This matches the existing behavior for nullable function parameters.

## Example

```ard
struct Config {
  name: Str,
  timeout: Int?,
}

// Before: required explicit wrapping
let c = Config{name: "app", timeout: maybe::some(30)}

// Now: implicit wrapping
let c = Config{name: "app", timeout: 30}

// Omitting nullable fields still works
let c = Config{name: "app"}
```

## Changes
- **compiler/checker/checker.go** — Added implicit `T` → `Maybe<T>` wrapping in `validateStructInstance` for both generic and non-generic structs
- **compiler/bytecode/vm/struct_test.go** — 6 new VM test cases covering plain values, literals, omission, and explicit wrapping
- **website docs** — Added "Nullable Fields" section to structs guide; updated maybe stdlib example to use implicit syntax
- **TODO.md** — Removed completed item