### PR TITLE
Fix argv handling for standalone binaries

### DIFF
--- a/compiler/ffi/runtime.go
+++ b/compiler/ffi/runtime.go
@@ -11,11 +11,39 @@ import (
 	"github.com/akonwi/ard/runtime"
 )
 
+var (
+	osArgsMu       sync.RWMutex
+	osArgsOverride []string
+)
+
+func SetOSArgs(args []string) {
+	osArgsMu.Lock()
+	defer osArgsMu.Unlock()
+
+	if args == nil {
+		osArgsOverride = nil
+		return
+	}
+
+	osArgsOverride = append([]string(nil), args...)
+}
+
+func currentOSArgs() []string {
+	osArgsMu.RLock()
+	override := append([]string(nil), osArgsOverride...)
+	osArgsMu.RUnlock()
+	if override != nil {
+		return override
+	}
+	return append([]string(nil), os.Args...)
+}
+
 // Runtime module FFI functions
 
 func OsArgs(_ []*runtime.Object, _ checker.Type) *runtime.Object {
-	var out []*runtime.Object = make([]*runtime.Object, len(os.Args))
-	for i, a := range os.Args {
+	args := currentOSArgs()
+	var out []*runtime.Object = make([]*runtime.Object, len(args))
+	for i, a := range args {
 		out[i] = runtime.MakeStr(a)
 	}
 	return runtime.MakeList(checker.Str, out...)

--- a/compiler/main.go
+++ b/compiler/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/akonwi/ard/bytecode"
 	bytecodevm "github.com/akonwi/ard/bytecode/vm"
 	"github.com/akonwi/ard/checker"
+	"github.com/akonwi/ard/ffi"
 	"github.com/akonwi/ard/formatter"
 	"github.com/akonwi/ard/parse"
 	"github.com/akonwi/ard/version"
@@ -68,8 +69,11 @@ func main() {
 				fmt.Println(err)
 				os.Exit(1)
 			}
-			if _, err := bytecodevm.New(program).Run("main"); err != nil {
-				fmt.Println(err)
+			ffi.SetOSArgs(os.Args)
+			_, runErr := bytecodevm.New(program).Run("main")
+			ffi.SetOSArgs(nil)
+			if runErr != nil {
+				fmt.Println(runErr)
 				os.Exit(1)
 			}
 		}
@@ -338,10 +342,17 @@ func buildBytecodeBinary(inputPath string, outputPath string) (string, error) {
 	return outputPath, nil
 }
 
-func maybeRunEmbedded() bool {
-	if len(os.Args) > 1 && os.Args[1] != "run-embedded" {
-		return false
+func argsForEmbeddedProgram(args []string) []string {
+	if len(args) > 1 && args[1] == "run-embedded" {
+		out := make([]string, 0, len(args)-1)
+		out = append(out, args[0])
+		out = append(out, args[2:]...)
+		return out
 	}
+	return append([]string(nil), args...)
+}
+
+func maybeRunEmbedded() bool {
 	data, err := readEmbeddedBytecode()
 	if err != nil || data == nil {
 		return false
@@ -355,8 +366,11 @@ func maybeRunEmbedded() bool {
 		fmt.Fprintln(os.Stderr, "Invalid bytecode:", err)
 		os.Exit(1)
 	}
-	if _, err := bytecodevm.New(program).Run("main"); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	ffi.SetOSArgs(argsForEmbeddedProgram(os.Args))
+	_, runErr := bytecodevm.New(program).Run("main")
+	ffi.SetOSArgs(nil)
+	if runErr != nil {
+		fmt.Fprintln(os.Stderr, runErr)
 		os.Exit(1)
 	}
 	return true

--- a/compiler/main_test.go
+++ b/compiler/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -150,6 +151,65 @@ func TestFormatPath(t *testing.T) {
 		}
 		if changedPaths[0] != first && changedPaths[0] != second {
 			t.Fatalf("unexpected changed path %q", changedPaths[0])
+		}
+	})
+}
+
+func TestStandaloneBuildPreservesRuntimeArgs(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "argv.ard")
+	source := `use ard/argv
+use ard/io
+
+fn main() {
+  let args = argv::load()
+  match args.arguments.size() {
+    0 => io::print("missing"),
+    _ => io::print(args.arguments.at(0)),
+  }
+}
+`
+	if err := os.WriteFile(sourcePath, []byte(source), 0o644); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	compilerBin := filepath.Join(dir, "ard-test")
+	buildCompiler := exec.Command("go", "build", "-tags=goexperiment.jsonv2", "-o", compilerBin, ".")
+	buildCompiler.Dir = "."
+	out, err := buildCompiler.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build compiler: %v\n%s", err, out)
+	}
+
+	t.Run("interpreter mode", func(t *testing.T) {
+		cmd := exec.Command(compilerBin, "run", sourcePath, "up")
+		cmd.Dir = "."
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("interpreter run failed: %v\n%s", err, out)
+		}
+		if string(out) != "up\n" {
+			t.Fatalf("expected interpreter output %q, got %q", "up\\n", string(out))
+		}
+	})
+
+	t.Run("compiled binary mode", func(t *testing.T) {
+		programBin := filepath.Join(dir, "argv-bin")
+		buildProgram := exec.Command(compilerBin, "build", sourcePath, "--out", programBin)
+		buildProgram.Dir = "."
+		out, err := buildProgram.CombinedOutput()
+		if err != nil {
+			t.Fatalf("failed to build standalone binary: %v\n%s", err, out)
+		}
+
+		cmd := exec.Command(programBin, "up")
+		cmd.Dir = "."
+		out, err = cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("compiled binary failed: %v\n%s", err, out)
+		}
+		if string(out) != "up\n" {
+			t.Fatalf("expected compiled output %q, got %q", "up\\n", string(out))
 		}
 	})
 }

--- a/compiler/std_lib/argv.ard
+++ b/compiler/std_lib/argv.ard
@@ -9,5 +9,16 @@ struct Argv {
 
 fn load() Argv {
   let args = os_args()
-  Argv{program: args.at(2), arguments: List::drop(from: args, till: 3)}
+
+  match {
+    args.size() >= 3 and args.at(1) == "run" => Argv{
+      program: args.at(2),
+      arguments: List::drop(from: args, till: 3),
+    },
+    args.size() >= 1 => Argv{
+      program: args.at(0),
+      arguments: List::drop(from: args, till: 1),
+    },
+    _ => Argv{program: "", arguments: []},
+  }
 }


### PR DESCRIPTION
## Summary
- run embedded bytecode binaries even when they are invoked with runtime arguments
- normalize runtime argv for embedded binaries and interpreter runs
- update `argv::load()` and add a regression test for interpreter and standalone execution

## Validation
- `cd compiler && go test -run TestStandaloneBuildPreservesRuntimeArgs -count=1`
- `cd compiler && go test ./...`