### PR TITLE
fix: Enum type comparison with TypeVar and Block.Type() with trailing blank lines

### DIFF
--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -830,9 +830,11 @@ func (b *Block) Type() Type {
 	if len(b.Stmts) == 0 {
 		return Void
 	}
-	last := b.Stmts[len(b.Stmts)-1]
-	if last.Expr != nil {
-		return last.Expr.Type()
+	// Find the last non-empty statement (skip trailing empty statements from blank lines)
+	for i := len(b.Stmts) - 1; i >= 0; i-- {
+		if b.Stmts[i].Expr != nil {
+			return b.Stmts[i].Expr.Type()
+		}
 	}
 	return Void
 }
@@ -1130,6 +1132,12 @@ func (e Enum) String() string {
 func (e Enum) equal(other Type) bool {
 	o, ok := other.(*Enum)
 	if !ok {
+		if tv, ok := other.(*TypeVar); ok {
+			if tv.actual == nil {
+				return true
+			}
+			return e.equal(tv.actual)
+		}
 		return false
 	}
 	if e.Name != o.Name {

--- a/compiler/checker/results_test.go
+++ b/compiler/checker/results_test.go
@@ -385,6 +385,86 @@ func TestTry(t *testing.T) {
 			`,
 			diagnostics: []checker.Diagnostic{},
 		},
+		{
+			name: "Result with enum value type in bool match branches",
+			input: `
+				enum Command { init, create, help }
+
+				fn command_from_index(index: Int) Command {
+					match index {
+						0 => Command::init,
+						1 => Command::create,
+						_ => Command::help,
+					}
+				}
+
+				fn parse_command(name: Str) Command!Str {
+					let index = 0
+					match index >= 0 {
+						true => Result::ok(command_from_index(index)),
+						false => Result::err("Unknown command"),
+					}
+				}
+			`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Result with enum value type in bool match with map lookup",
+			input: `
+				enum Command { init, create, help }
+
+				fn command_map() [Str: Int] {
+					let cmds: [Str: Int] = [
+						"init": 0,
+						"create": 1,
+						"help": 2,
+					]
+					cmds
+				}
+
+				fn command_from_index(index: Int) Command {
+					match index {
+						0 => Command::init,
+						1 => Command::create,
+						_ => Command::help,
+					}
+				}
+
+				fn parse_command(name: Str) Command!Str {
+					let cmds = command_map()
+					let index = cmds.get(name).or(-1)
+					match index >= 0 {
+						true => Result::ok(command_from_index(index)),
+						false => Result::err("Unknown command: {name}"),
+					}
+				}
+			`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Result with enum in bool match with trailing blank line",
+			input: `
+				enum Command { init, create, help }
+
+				fn command_from_index(index: Int) Command {
+					match index {
+						0 => Command::init,
+						1 => Command::create,
+						_ => Command::help,
+					}
+				}
+
+				fn parse_command(name: Str) Command!Str {
+					let index = 0
+					match index >= 0 {
+						true => Result::ok(command_from_index(index)),
+						false => Result::err("Unknown command"),
+					}
+
+				}
+			`,
+			diagnostics: []checker.Diagnostic{},
+		},
 	})
 }
 


### PR DESCRIPTION
## Problem

Two bugs caused type-checking failures when using `Result::ok()` / `Result::err()` with enum types in bool match branches:

1. **`Enum.equal()` missing `TypeVar` handling** — When comparing Result branch types like `Command!$Err` vs `$Val!Str`, `Enum.equal($Val)` returned false because it didn't handle `TypeVar`, unlike all other types (`Str`, `Int`, `List`, `Map`, `StructDef`, etc.).

2. **`Block.Type()` returning `Void` for blocks with trailing blank lines** — The parser creates nil statement entries for blank lines (used by the formatter). `Block.Type()` only checked the very last statement, so a trailing blank line made the block's type `Void`.

## Fix

- Added `TypeVar` handling to `Enum.equal()` — if the other type is an unresolved TypeVar, return true; if resolved, compare against the actual type.
- Changed `Block.Type()` to scan backwards, skipping empty statements to find the last meaningful expression.

## Tests

Added three test cases in `results_test.go`:
- Result with enum value type in bool match branches (basic)
- Result with enum value type with map lookup (real-world pattern)
- Result with enum in bool match with trailing blank line