### PR TITLE
feat: expand fs module with directory, copy, rename, and path operations

### DIFF
--- a/compiler/bytecode/vm/fs_test.go
+++ b/compiler/bytecode/vm/fs_test.go
@@ -58,3 +58,128 @@ func TestBytecodeFS(t *testing.T) {
 		`, filePath), want: nil},
 	})
 }
+
+func TestBytecodeFS_Copy(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "ard_bytecode_fs_copy_")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	srcPath := filepath.Join(tmpDir, "source.txt")
+	dstPath := filepath.Join(tmpDir, "dest.txt")
+
+	runBytecodeTests(t, []vmTestCase{
+		{name: "setup: create source file", input: fmt.Sprintf(`
+			use ard/fs
+			fs::write(%q, "copy me")
+		`, srcPath), want: nil},
+		{name: "fs::copy", input: fmt.Sprintf(`
+			use ard/fs
+			fs::copy(%q, %q)
+		`, srcPath, dstPath), want: nil},
+		{name: "fs::copy preserves content", input: fmt.Sprintf(`
+			use ard/fs
+			fs::read(%q).expect("read failed")
+		`, dstPath), want: "copy me"},
+		{name: "fs::copy source still exists", input: fmt.Sprintf(`
+			use ard/fs
+			fs::exists(%q)
+		`, srcPath), want: true},
+	})
+}
+
+func TestBytecodeFS_Rename(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "ard_bytecode_fs_rename_")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	srcPath := filepath.Join(tmpDir, "before.txt")
+	dstPath := filepath.Join(tmpDir, "after.txt")
+
+	runBytecodeTests(t, []vmTestCase{
+		{name: "setup: create file", input: fmt.Sprintf(`
+			use ard/fs
+			fs::write(%q, "move me")
+		`, srcPath), want: nil},
+		{name: "fs::rename", input: fmt.Sprintf(`
+			use ard/fs
+			fs::rename(%q, %q)
+		`, srcPath, dstPath), want: nil},
+		{name: "fs::rename moved content", input: fmt.Sprintf(`
+			use ard/fs
+			fs::read(%q).expect("read failed")
+		`, dstPath), want: "move me"},
+		{name: "fs::rename removed source", input: fmt.Sprintf(`
+			use ard/fs
+			fs::exists(%q)
+		`, srcPath), want: false},
+	})
+}
+
+func TestBytecodeFS_FileSize(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "ard_bytecode_fs_size_")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	filePath := filepath.Join(tmpDir, "sized.txt")
+
+	runBytecodeTests(t, []vmTestCase{
+		{name: "setup: create file", input: fmt.Sprintf(`
+			use ard/fs
+			fs::write(%q, "hello")
+		`, filePath), want: nil},
+		{name: "fs::file_size", input: fmt.Sprintf(`
+			use ard/fs
+			fs::file_size(%q).expect("stat failed")
+		`, filePath), want: 5},
+	})
+}
+
+func TestBytecodeFS_DeleteDir(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "ard_bytecode_fs_deldir_")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	dirPath := filepath.Join(tmpDir, "removeme", "nested")
+	filePath := filepath.Join(dirPath, "file.txt")
+
+	runBytecodeTests(t, []vmTestCase{
+		{name: "setup: create nested dir", input: fmt.Sprintf(`
+			use ard/fs
+			fs::create_dir(%q)
+		`, dirPath), want: nil},
+		{name: "setup: create file in dir", input: fmt.Sprintf(`
+			use ard/fs
+			fs::write(%q, "data")
+		`, filePath), want: nil},
+		{name: "fs::delete_dir", input: fmt.Sprintf(`
+			use ard/fs
+			fs::delete_dir(%q)
+		`, filepath.Join(tmpDir, "removeme")), want: nil},
+		{name: "fs::delete_dir removed everything", input: fmt.Sprintf(`
+			use ard/fs
+			fs::exists(%q)
+		`, filepath.Join(tmpDir, "removeme")), want: false},
+	})
+}
+
+func TestBytecodeFS_CwdAndAbs(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runBytecodeTests(t, []vmTestCase{
+		{name: "fs::cwd", input: `
+			use ard/fs
+			fs::cwd().expect("cwd failed")
+		`, want: cwd},
+		{name: "fs::abs resolves relative path", input: fmt.Sprintf(`
+			use ard/fs
+			fs::abs(".").expect("abs failed")
+		`), want: cwd},
+	})
+}

--- a/compiler/bytecode/vm/fs_test.go
+++ b/compiler/bytecode/vm/fs_test.go
@@ -14,6 +14,7 @@ func TestBytecodeFS(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	filePath := filepath.Join(tmpDir, "fake.file")
+	dirPath := filepath.Join(tmpDir, "a", "b", "c")
 
 	runBytecodeTests(t, []vmTestCase{
 		{name: "fs::exists false for missing path", input: `
@@ -24,6 +25,14 @@ func TestBytecodeFS(t *testing.T) {
 			use ard/fs
 			fs::exists("../../main.go")
 		`, want: true},
+		{name: "fs::create_dir", input: fmt.Sprintf(`
+			use ard/fs
+			fs::create_dir(%q)
+		`, dirPath), want: nil},
+		{name: "fs::create_dir created nested dirs", input: fmt.Sprintf(`
+			use ard/fs
+			fs::is_dir(%q)
+		`, dirPath), want: true},
 		{name: "fs::create_file", input: fmt.Sprintf(`
 			use ard/fs
 			fs::create_file(%q).expect("Failed to create file")

--- a/compiler/bytecode/vm/fs_test.go
+++ b/compiler/bytecode/vm/fs_test.go
@@ -117,26 +117,6 @@ func TestBytecodeFS_Rename(t *testing.T) {
 	})
 }
 
-func TestBytecodeFS_FileSize(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "ard_bytecode_fs_size_")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-	filePath := filepath.Join(tmpDir, "sized.txt")
-
-	runBytecodeTests(t, []vmTestCase{
-		{name: "setup: create file", input: fmt.Sprintf(`
-			use ard/fs
-			fs::write(%q, "hello")
-		`, filePath), want: nil},
-		{name: "fs::file_size", input: fmt.Sprintf(`
-			use ard/fs
-			fs::file_size(%q).expect("stat failed")
-		`, filePath), want: 5},
-	})
-}
-
 func TestBytecodeFS_DeleteDir(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "ard_bytecode_fs_deldir_")
 	if err != nil {

--- a/compiler/bytecode/vm/registry.gen.go
+++ b/compiler/bytecode/vm/registry.gen.go
@@ -106,8 +106,26 @@ func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
 	if err := r.Register("FS_IsDir", ffi.FS_IsDir); err != nil {
 		return fmt.Errorf("failed to register FS_IsDir: %w", err)
 	}
+	if err := r.Register("FS_Copy", ffi.FS_Copy); err != nil {
+		return fmt.Errorf("failed to register FS_Copy: %w", err)
+	}
+	if err := r.Register("FS_Rename", ffi.FS_Rename); err != nil {
+		return fmt.Errorf("failed to register FS_Rename: %w", err)
+	}
+	if err := r.Register("FS_FileSize", ffi.FS_FileSize); err != nil {
+		return fmt.Errorf("failed to register FS_FileSize: %w", err)
+	}
+	if err := r.Register("FS_Cwd", ffi.FS_Cwd); err != nil {
+		return fmt.Errorf("failed to register FS_Cwd: %w", err)
+	}
+	if err := r.Register("FS_Abs", ffi.FS_Abs); err != nil {
+		return fmt.Errorf("failed to register FS_Abs: %w", err)
+	}
 	if err := r.Register("FS_CreateDir", ffi.FS_CreateDir); err != nil {
 		return fmt.Errorf("failed to register FS_CreateDir: %w", err)
+	}
+	if err := r.Register("FS_DeleteDir", ffi.FS_DeleteDir); err != nil {
+		return fmt.Errorf("failed to register FS_DeleteDir: %w", err)
 	}
 	if err := r.Register("FS_ListDir", ffi.FS_ListDir); err != nil {
 		return fmt.Errorf("failed to register FS_ListDir: %w", err)

--- a/compiler/bytecode/vm/registry.gen.go
+++ b/compiler/bytecode/vm/registry.gen.go
@@ -112,9 +112,6 @@ func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
 	if err := r.Register("FS_Rename", ffi.FS_Rename); err != nil {
 		return fmt.Errorf("failed to register FS_Rename: %w", err)
 	}
-	if err := r.Register("FS_FileSize", ffi.FS_FileSize); err != nil {
-		return fmt.Errorf("failed to register FS_FileSize: %w", err)
-	}
 	if err := r.Register("FS_Cwd", ffi.FS_Cwd); err != nil {
 		return fmt.Errorf("failed to register FS_Cwd: %w", err)
 	}

--- a/compiler/bytecode/vm/registry.gen.go
+++ b/compiler/bytecode/vm/registry.gen.go
@@ -106,6 +106,9 @@ func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
 	if err := r.Register("FS_IsDir", ffi.FS_IsDir); err != nil {
 		return fmt.Errorf("failed to register FS_IsDir: %w", err)
 	}
+	if err := r.Register("FS_CreateDir", ffi.FS_CreateDir); err != nil {
+		return fmt.Errorf("failed to register FS_CreateDir: %w", err)
+	}
 	if err := r.Register("FS_ListDir", ffi.FS_ListDir); err != nil {
 		return fmt.Errorf("failed to register FS_ListDir: %w", err)
 	}

--- a/compiler/ffi/fs.go
+++ b/compiler/ffi/fs.go
@@ -123,15 +123,6 @@ func FS_Rename(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeOk(runtime.Void())
 }
 
-func FS_FileSize(args []*runtime.Object, _ checker.Type) *runtime.Object {
-	path := args[0].Raw().(string)
-	info, err := os.Stat(path)
-	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
-	}
-	return runtime.MakeOk(runtime.MakeInt(int(info.Size())))
-}
-
 func FS_Cwd(_ []*runtime.Object, _ checker.Type) *runtime.Object {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/compiler/ffi/fs.go
+++ b/compiler/ffi/fs.go
@@ -2,7 +2,9 @@ package ffi
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/akonwi/ard/checker"
 	"github.com/akonwi/ard/runtime"
@@ -90,9 +92,74 @@ func FS_IsDir(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeBool(info.IsDir())
 }
 
+func FS_Copy(args []*runtime.Object, _ checker.Type) *runtime.Object {
+	from := args[0].Raw().(string)
+	to := args[1].Raw().(string)
+
+	src, err := os.Open(from)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	defer src.Close()
+
+	dst, err := os.Create(to)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.Void())
+}
+
+func FS_Rename(args []*runtime.Object, _ checker.Type) *runtime.Object {
+	from := args[0].Raw().(string)
+	to := args[1].Raw().(string)
+	if err := os.Rename(from, to); err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.Void())
+}
+
+func FS_FileSize(args []*runtime.Object, _ checker.Type) *runtime.Object {
+	path := args[0].Raw().(string)
+	info, err := os.Stat(path)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeInt(int(info.Size())))
+}
+
+func FS_Cwd(_ []*runtime.Object, _ checker.Type) *runtime.Object {
+	dir, err := os.Getwd()
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeStr(dir))
+}
+
+func FS_Abs(args []*runtime.Object, _ checker.Type) *runtime.Object {
+	path := args[0].Raw().(string)
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeStr(absPath))
+}
+
 func FS_CreateDir(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	path := args[0].Raw().(string)
 	if err := os.MkdirAll(path, 0755); err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.Void())
+}
+
+func FS_DeleteDir(args []*runtime.Object, _ checker.Type) *runtime.Object {
+	path := args[0].Raw().(string)
+	if err := os.RemoveAll(path); err != nil {
 		return runtime.MakeErr(runtime.MakeStr(err.Error()))
 	}
 	return runtime.MakeOk(runtime.Void())

--- a/compiler/ffi/fs.go
+++ b/compiler/ffi/fs.go
@@ -90,6 +90,14 @@ func FS_IsDir(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeBool(info.IsDir())
 }
 
+func FS_CreateDir(args []*runtime.Object, _ checker.Type) *runtime.Object {
+	path := args[0].Raw().(string)
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.Void())
+}
+
 func FS_ListDir(args []*runtime.Object, outType checker.Type) *runtime.Object {
 	path := args[0].Raw().(string)
 	entries, err := os.ReadDir(path)

--- a/compiler/std_lib/fs.ard
+++ b/compiler/std_lib/fs.ard
@@ -18,8 +18,6 @@ extern fn copy(from: Str, to: Str) Void!Str = "FS_Copy"
 
 extern fn rename(from: Str, to: Str) Void!Str = "FS_Rename"
 
-extern fn file_size(path: Str) Int!Str = "FS_FileSize"
-
 extern fn cwd() Str!Str = "FS_Cwd"
 
 extern fn abs(path: Str) Str!Str = "FS_Abs"

--- a/compiler/std_lib/fs.ard
+++ b/compiler/std_lib/fs.ard
@@ -14,11 +14,23 @@ extern fn read(path: Str) Str!Str = "FS_ReadFile"
 
 extern fn delete(path: Str) Void!Str = "FS_DeleteFile"
 
+extern fn copy(from: Str, to: Str) Void!Str = "FS_Copy"
+
+extern fn rename(from: Str, to: Str) Void!Str = "FS_Rename"
+
+extern fn file_size(path: Str) Int!Str = "FS_FileSize"
+
+extern fn cwd() Str!Str = "FS_Cwd"
+
+extern fn abs(path: Str) Str!Str = "FS_Abs"
+
 struct DirEntry {
   name: Str,
   is_file: Bool,
 }
 
 extern fn create_dir(path: Str) Void!Str = "FS_CreateDir"
+
+extern fn delete_dir(path: Str) Void!Str = "FS_DeleteDir"
 
 extern fn list_dir(path: Str) [DirEntry]!Str = "FS_ListDir"

--- a/compiler/std_lib/fs.ard
+++ b/compiler/std_lib/fs.ard
@@ -19,4 +19,6 @@ struct DirEntry {
   is_file: Bool,
 }
 
+extern fn create_dir(path: Str) Void!Str = "FS_CreateDir"
+
 extern fn list_dir(path: Str) [DirEntry]!Str = "FS_ListDir"

--- a/website/src/content/docs/stdlib/fs.md
+++ b/website/src/content/docs/stdlib/fs.md
@@ -6,9 +6,10 @@ description: Read, write, and manage files and directories using Ard's filesyste
 The `ard/fs` module provides functions for working with files and directories in a safe, error-aware manner.
 
 The filesystem module provides:
-- **File operations** for reading, writing, and deleting files
-- **File inspection** to check if paths are files or directories
-- **Directory operations** for creating and listing directories
+- **File operations** for reading, writing, copying, and deleting files
+- **File inspection** to check existence, type, and size of paths
+- **Directory operations** for creating, listing, and deleting directories
+- **Path utilities** for resolving the current working directory and absolute paths
 - **Result types** for proper error handling
 
 ```ard
@@ -122,6 +123,58 @@ use ard/fs
 fs::delete("tempfile.txt").expect("Failed to delete")
 ```
 
+### `fn copy(from: Str, to: Str) Void!Str`
+
+Copy a file from one path to another. Creates the destination file if it doesn't exist, or overwrites it if it does.
+
+```ard
+use ard/fs
+
+fs::copy("original.txt", "backup.txt").expect("Failed to copy")
+```
+
+### `fn rename(from: Str, to: Str) Void!Str`
+
+Move or rename a file or directory. The source is removed after a successful rename.
+
+```ard
+use ard/fs
+
+fs::rename("old_name.txt", "new_name.txt").expect("Failed to rename")
+```
+
+### `fn file_size(path: Str) Int!Str`
+
+Get the size of a file in bytes.
+
+```ard
+use ard/fs
+
+let size = fs::file_size("data.bin").expect("Failed to get size")
+```
+
+## Path Utilities
+
+### `fn cwd() Str!Str`
+
+Get the current working directory.
+
+```ard
+use ard/fs
+
+let dir = fs::cwd().expect("Failed to get cwd")
+```
+
+### `fn abs(path: Str) Str!Str`
+
+Resolve a relative path to an absolute path.
+
+```ard
+use ard/fs
+
+let full_path = fs::abs("./src").expect("Failed to resolve path")
+```
+
 ## Directory Operations
 
 ### `fn create_dir(path: Str) Void!Str`
@@ -132,6 +185,16 @@ Create a directory at the given path, including any missing parent directories. 
 use ard/fs
 
 fs::create_dir("output/reports/2024").expect("Failed to create directory")
+```
+
+### `fn delete_dir(path: Str) Void!Str`
+
+Delete a directory and all its contents recursively. Returns an error if the operation fails.
+
+```ard
+use ard/fs
+
+fs::delete_dir("build/output").expect("Failed to delete directory")
 ```
 
 ## Directory Listing

--- a/website/src/content/docs/stdlib/fs.md
+++ b/website/src/content/docs/stdlib/fs.md
@@ -7,7 +7,7 @@ The `ard/fs` module provides functions for working with files and directories in
 
 The filesystem module provides:
 - **File operations** for reading, writing, copying, and deleting files
-- **File inspection** to check existence, type, and size of paths
+- **File inspection** to check existence and type of paths
 - **Directory operations** for creating, listing, and deleting directories
 - **Path utilities** for resolving the current working directory and absolute paths
 - **Result types** for proper error handling
@@ -141,16 +141,6 @@ Move or rename a file or directory. The source is removed after a successful ren
 use ard/fs
 
 fs::rename("old_name.txt", "new_name.txt").expect("Failed to rename")
-```
-
-### `fn file_size(path: Str) Int!Str`
-
-Get the size of a file in bytes.
-
-```ard
-use ard/fs
-
-let size = fs::file_size("data.bin").expect("Failed to get size")
 ```
 
 ## Path Utilities

--- a/website/src/content/docs/stdlib/fs.md
+++ b/website/src/content/docs/stdlib/fs.md
@@ -8,7 +8,7 @@ The `ard/fs` module provides functions for working with files and directories in
 The filesystem module provides:
 - **File operations** for reading, writing, and deleting files
 - **File inspection** to check if paths are files or directories
-- **Directory listing** to discover directory contents
+- **Directory operations** for creating and listing directories
 - **Result types** for proper error handling
 
 ```ard
@@ -120,6 +120,18 @@ Delete a file. Returns an error if the file doesn't exist.
 use ard/fs
 
 fs::delete("tempfile.txt").expect("Failed to delete")
+```
+
+## Directory Operations
+
+### `fn create_dir(path: Str) Void!Str`
+
+Create a directory at the given path, including any missing parent directories. Returns an error if the operation fails.
+
+```ard
+use ard/fs
+
+fs::create_dir("output/reports/2024").expect("Failed to create directory")
 ```
 
 ## Directory Listing


### PR DESCRIPTION
## Summary

Adds several new functions to the `ard/fs` standard library module to cover common filesystem operations.

## New functions

| Function | Signature | Description |
|---|---|---|
| `create_dir` | `(path: Str) Void!Str` | Create directories recursively (like `mkdir -p`) |
| `delete_dir` | `(path: Str) Void!Str` | Recursively delete a directory and its contents |
| `copy` | `(from: Str, to: Str) Void!Str` | Copy a file to a new path |
| `rename` | `(from: Str, to: Str) Void!Str` | Move or rename a file or directory |
| `cwd` | `() Str!Str` | Get the current working directory |
| `abs` | `(path: Str) Str!Str` | Resolve a path to an absolute path |

## Changes

- `compiler/std_lib/fs.ard` — extern fn declarations
- `compiler/ffi/fs.go` — FFI implementations
- `compiler/bytecode/vm/registry.gen.go` — regenerated registry
- `compiler/bytecode/vm/fs_test.go` — VM tests for all new functions
- `website/src/content/docs/stdlib/fs.md` — updated module documentation