### PR TITLE
feat: use project name from ard.toml as default build output name

### DIFF
--- a/compiler/checker/module_resolver.go
+++ b/compiler/checker/module_resolver.go
@@ -26,8 +26,8 @@ type ModuleResolver struct {
 	loadingChain []string                // track import paths currently being loaded for circular dependency detection
 }
 
-// findProjectRoot walks up the directory tree to find ard.toml or falls back to directory name
-func findProjectRoot(startPath string) (*ProjectInfo, error) {
+// FindProjectRoot walks up the directory tree to find ard.toml or falls back to directory name
+func FindProjectRoot(startPath string) (*ProjectInfo, error) {
 	absPath, err := filepath.Abs(startPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get absolute path: %w", err)
@@ -83,7 +83,7 @@ func parseProjectName(tomlPath string) (string, error) {
 
 // NewModuleResolver creates a new module resolver for the given working directory
 func NewModuleResolver(workingDir string) (*ModuleResolver, error) {
-	project, err := findProjectRoot(workingDir)
+	project, err := FindProjectRoot(workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/main.go
+++ b/compiler/main.go
@@ -224,7 +224,21 @@ func parseBuildArgs(args []string) (string, string, error) {
 		return "", "", fmt.Errorf("expected filepath argument")
 	}
 	if outputPath == "" {
-		outputPath = strings.TrimSuffix(inputPath, filepath.Ext(inputPath))
+		// Try to use the project name from ard.toml
+		inputDir := filepath.Dir(inputPath)
+		if inputDir == "" {
+			inputDir = "."
+		}
+		if project, err := checker.FindProjectRoot(inputDir); err == nil && project.ProjectName != "" {
+			// Check if the project name came from ard.toml (not just directory fallback)
+			tomlPath := filepath.Join(project.RootPath, "ard.toml")
+			if _, statErr := os.Stat(tomlPath); statErr == nil {
+				outputPath = project.ProjectName
+			}
+		}
+		if outputPath == "" {
+			outputPath = strings.TrimSuffix(inputPath, filepath.Ext(inputPath))
+		}
 	}
 	return inputPath, outputPath, nil
 }


### PR DESCRIPTION
When no `--out` flag is provided, the `build` command now uses the project name from `ard.toml` as the output binary name. Falls back to the input filename (minus extension) when no `ard.toml` is found.

## Behavior

| Command | ard.toml | Output |
|---|---|---|
| `ard build main.ard --out foo` | any | `foo` |
| `ard build main.ard` | `name = "migr"` | `migr` |
| `ard build main.ard` | not found | `main` |

## Changes

- **`checker/module_resolver.go`** — Export `FindProjectRoot` for use outside the checker package
- **`main.go`** — Look up `ard.toml` project name in `parseBuildArgs` when `--out` is not provided