### PR TITLE
refactor: idiomatic Go FFI with generated wrappers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,11 @@
 # TODO
 - [ ] FFI functions should be able to use idiomatic Go and compiler handles mappings
 - [ ] Generic type variables emit KindDynamic at runtime instead of the resolved concrete kind. When a generic function like `list::find` returns a value, the emitter/VM wraps it as KindDynamic even though the checker has resolved the type variable to a concrete type (e.g. Int). This required a workaround in `evalCompare` (vm.go) to compare underlying Go values when either operand is KindDynamic. The proper fix is to thread the resolved type through emission so the runtime object gets the correct kind (e.g. KindInt) rather than KindDynamic.
-
+- [ ] allow FFI in user land
+- [ ] Dependency system
+  * needs more thought
+  * likely just a vendoring system
+  * add dependencies section to ard.toml
+  * `ard add [git-path]` to install from git repo
+    * optionally add `@[version]` for a particular tag
+- [ ] build Agent sdk

--- a/TODO.md
+++ b/TODO.md
@@ -9,3 +9,5 @@
   * `ard add [git-path]` to install from git repo
     * optionally add `@[version]` for a particular tag
 - [ ] build Agent sdk
+- [ ] Opaque types — explicit language support for opaque FFI handles (e.g., SQL connections, HTTP requests) instead of using Dynamic
+- [ ] Idiomatic FFI `any` type support — map Go `any`/`interface{}` to Ard Dynamic for FFI functions (see backlog/idiomatic-ffi-any-type.md)

--- a/backlog/idiomatic-ffi-any-type.md
+++ b/backlog/idiomatic-ffi-any-type.md
@@ -1,0 +1,69 @@
+# Idiomatic FFI: `any` type support
+
+## Summary
+
+Add `any` (Go's `interface{}`) as a supported idiomatic FFI type, mapping to Ard's `Dynamic`. This would let more FFI functions drop the raw `func([]*runtime.Object) *runtime.Object` signature in favor of plain Go types.
+
+## Proposed rules
+
+| Go type | Ard type | Unwrap (param) | Wrap (return) |
+|---|---|---|---|
+| `any` | `Dynamic` | `args[i].Raw()` | `runtime.MakeDynamic(result)` |
+
+`any` works as the idiomatic way to pass/receive Ard `Dynamic` values. The Go function gets the raw underlying Go value and does its own type assertions internally.
+
+Supported in the same positions as other idiomatic types: params, returns, `(any, error)`, etc.
+
+## Functions that could migrate
+
+With just `any` support (11 functions, raw count 27 → 16):
+
+| Function | New signature | Notes |
+|---|---|---|
+| `IsNil` | `(any) bool` | just checks `arg == nil` |
+| `GetReqPath` | `(any) string` | type-asserts `*http.Request` from Dynamic |
+| `GetPathValue` | `(any, string) string` | same |
+| `GetQueryParam` | `(any, string) string` | same |
+| `WaitFor` | `(any)` | type-asserts `*sync.WaitGroup` |
+| `JsonToDynamic` | `(string) (any, error)` | parses JSON, returns raw `any` |
+| `SqlCreateConnection` | `(string) (any, error)` | returns `*sqlConnection` as opaque handle |
+| `SqlClose` | `(any) error` | type-asserts `*sqlConnection` |
+| `SqlBeginTx` | `(any) (any, error)` | takes connection, returns transaction |
+| `SqlCommit` | `(any) error` | type-asserts `*sqlTransaction` |
+| `SqlRollback` | `(any) error` | same |
+
+### Potential `[]any` extension
+
+Adding `[]any` (maps to `[Dynamic]`) could additionally convert:
+
+- `ListToDynamic` → `([]any) any`
+- `SqlQuery` → `(any, string, []any) ([]any, error)` (needs care with nested Object unwrapping in `sqlArgValue`)
+- `SqlExecute` → `(any, string, []any) error` (same caveat)
+
+## Functions that would remain raw regardless
+
+These need capabilities beyond `any`:
+
+- `DecodeString/Int/Float/Bool` — return custom error struct from embedded module lookup
+- `DynamicToList`, `DynamicToMap`, `ExtractField` — return Dynamic collections + need Object for error formatting
+- `MapToDynamic` — needs `map[string]any` support
+- `HTTP_Send`, `HTTP_Serve` — complex multi-type with closures/structs
+- `FS_ListDir` — embedded module struct construction
+- `Join` — iterates Fiber struct list, extracts WaitGroups
+- `JsonEncode` — generic `$T` input needs full Object for marshaling
+
+## Relationship to opaque types
+
+Many of the `any`-eligible functions use Dynamic as an **opaque handle** — the Ard code never inspects the value, it just passes it back to other FFI functions (e.g., SQL connection/transaction handles, HTTP request objects). If Ard gains explicit language-level support for opaque types, those would be a better fit than Dynamic, and the FFI `any` mapping might change or narrow.
+
+## Generator implementation notes
+
+In `ffi_generate.go`:
+
+- `parseGoType`: recognize `*ast.Ident{Name: "any"}` or `*ast.InterfaceType` (empty interface) → `GoType{Base: "any"}`
+- `generateParamUnwrap`: `any` param → `arg{i} := args[{i}].Raw()`
+- `generateReturnWrap`: `any` return → `runtime.MakeDynamic(result)`
+- `checkerTypeStr`: not needed for `any` unless used in `*any` or `[]any`
+- For `[]any` param: iterate `.AsList()`, call `.Raw()` on each
+- For `[]any` return: iterate, `MakeDynamic` each, `MakeList(checker.Dynamic, ...)`
+- Import: `checker` needed for `[]any` (uses `checker.Dynamic`)

--- a/compiler/bytecode/emitter.go
+++ b/compiler/bytecode/emitter.go
@@ -487,13 +487,26 @@ func (e *Emitter) emitExternWrapper(name string, def *checker.ExternalFunctionDe
 	for _, param := range def.Parameters {
 		fnEmitter.defineLocal(param.Name)
 	}
-	for i := range def.Parameters {
-		fnEmitter.emit(Instruction{Op: OpLoadLocal, A: i})
+
+	// Emit scalar-to-Dynamic conversions as OpToDynamic instead of FFI calls
+	switch def.ExternalBinding {
+	case "StrToDynamic", "IntToDynamic", "FloatToDynamic", "BoolToDynamic":
+		fnEmitter.emit(Instruction{Op: OpLoadLocal, A: 0})
+		fnEmitter.emit(Instruction{Op: OpToDynamic})
+		fnEmitter.adjustStack(0, 1)
+	case "VoidToDynamic":
+		fnEmitter.emit(Instruction{Op: OpConstVoid})
+		fnEmitter.emit(Instruction{Op: OpToDynamic})
+		fnEmitter.adjustStack(0, 1)
+	default:
+		for i := range def.Parameters {
+			fnEmitter.emit(Instruction{Op: OpLoadLocal, A: i})
+		}
+		bindingIdx := e.addConst(Constant{Kind: ConstStr, Str: def.ExternalBinding})
+		retID := e.addType(def.ReturnType)
+		fnEmitter.emit(Instruction{Op: OpCallExtern, A: bindingIdx, Imm: len(def.Parameters), C: int(retID)})
+		fnEmitter.adjustStack(len(def.Parameters), 1)
 	}
-	bindingIdx := e.addConst(Constant{Kind: ConstStr, Str: def.ExternalBinding})
-	retID := e.addType(def.ReturnType)
-	fnEmitter.emit(Instruction{Op: OpCallExtern, A: bindingIdx, Imm: len(def.Parameters), C: int(retID)})
-	fnEmitter.adjustStack(len(def.Parameters), 1)
 	fnEmitter.ensureReturn()
 	index := len(e.program.Functions)
 	e.funcIndex[name] = index
@@ -1354,6 +1367,20 @@ func (f *funcEmitter) ensureReturn() {
 func (f *funcEmitter) emitFunctionCall(call *checker.FunctionCall) error {
 	argc := len(call.Args)
 	if call.ExternalBinding != "" {
+		// Emit scalar-to-Dynamic conversions as OpToDynamic instead of FFI calls
+		switch call.ExternalBinding {
+		case "StrToDynamic", "IntToDynamic", "FloatToDynamic", "BoolToDynamic":
+			if err := f.emitExpr(call.Args[0]); err != nil {
+				return err
+			}
+			f.emit(Instruction{Op: OpToDynamic})
+			return nil
+		case "VoidToDynamic":
+			f.emit(Instruction{Op: OpConstVoid})
+			f.emit(Instruction{Op: OpToDynamic})
+			f.adjustStack(0, 1)
+			return nil
+		}
 		for i := range call.Args {
 			if err := f.emitExpr(call.Args[i]); err != nil {
 				return err
@@ -1406,6 +1433,22 @@ func (f *funcEmitter) emitModuleFunctionCall(call *checker.ModuleFunctionCall) e
 			}
 			typeID := f.emitter.addType(listType)
 			f.emit(Instruction{Op: OpMakeList, A: int(typeID), B: 0})
+			f.adjustStack(0, 1)
+			return nil
+		}
+
+		// Emit scalar-to-Dynamic conversions as OpToDynamic instead of FFI calls
+		switch call.Call.ExternalBinding {
+		case "StrToDynamic", "IntToDynamic", "FloatToDynamic", "BoolToDynamic":
+			if err := f.emitExpr(call.Call.Args[0]); err != nil {
+				return err
+			}
+			f.emit(Instruction{Op: OpToDynamic})
+			// emitExpr pushed 1, OpToDynamic pops 1 and pushes 1 → net 0 adjustment
+			return nil
+		case "VoidToDynamic":
+			f.emit(Instruction{Op: OpConstVoid})
+			f.emit(Instruction{Op: OpToDynamic})
 			f.adjustStack(0, 1)
 			return nil
 		}

--- a/compiler/bytecode/emitter.go
+++ b/compiler/bytecode/emitter.go
@@ -1398,6 +1398,17 @@ func (f *funcEmitter) emitFunctionCall(call *checker.FunctionCall) error {
 func (f *funcEmitter) emitModuleFunctionCall(call *checker.ModuleFunctionCall) error {
 	argc := len(call.Call.Args)
 	if call.Call.ExternalBinding != "" {
+		// Emit list::new() as OpMakeList with 0 elements instead of an FFI call
+		if call.Call.ExternalBinding == "NewList" {
+			listType, ok := call.Call.ReturnType.(*checker.List)
+			if !ok {
+				return fmt.Errorf("NewList return type is not a list: %T", call.Call.ReturnType)
+			}
+			typeID := f.emitter.addType(listType)
+			f.emit(Instruction{Op: OpMakeList, A: int(typeID), B: 0})
+			f.adjustStack(0, 1)
+			return nil
+		}
 		for i := range call.Call.Args {
 			if err := f.emitExpr(call.Call.Args[i]); err != nil {
 				return err

--- a/compiler/bytecode/opcode.go
+++ b/compiler/bytecode/opcode.go
@@ -78,6 +78,7 @@ const (
 	OpMatchResult
 	OpTryResult
 	OpTryMaybe
+	OpToDynamic
 	OpAsyncStart
 	OpAsyncEval
 	OpPanic

--- a/compiler/bytecode/opcode_meta.go
+++ b/compiler/bytecode/opcode_meta.go
@@ -157,6 +157,8 @@ func (o Opcode) String() string {
 		return "TRY_RESULT"
 	case OpTryMaybe:
 		return "TRY_MAYBE"
+	case OpToDynamic:
+		return "TO_DYNAMIC"
 	case OpAsyncStart:
 		return "ASYNC_START"
 	case OpAsyncEval:
@@ -233,6 +235,8 @@ func (o Opcode) StackEffect() StackEffect {
 	case OpMakeNone:
 		return StackEffect{Pop: 0, Push: 1}
 	case OpTryResult, OpTryMaybe:
+		return StackEffect{Pop: 1, Push: 1}
+	case OpToDynamic:
 		return StackEffect{Pop: 1, Push: 1}
 	case OpAsyncStart, OpAsyncEval:
 		return StackEffect{Pop: 1, Push: 1}

--- a/compiler/bytecode/vm/ffi_generate.go
+++ b/compiler/bytecode/vm/ffi_generate.go
@@ -13,25 +13,53 @@ import (
 	"strings"
 )
 
+type FFIKind int
+
+const (
+	FFIRaw FFIKind = iota
+	FFIIdiomatic
+)
+
+// GoType represents a supported Go type for idiomatic FFI functions.
+type GoType struct {
+	Base        string // "string", "int", "float64", "bool", "error"
+	IsPtr       bool   // *string, *int, etc. → maps to Maybe
+	IsSlice     bool   // []string, []int, etc. → maps to List
+	IsStringMap bool   // map[string]string → maps to [Str:Str]
+}
+
 type FFIFunction struct {
-	Name   string
-	Module string
-	File   string
+	Name    string
+	Module  string
+	File    string
+	Kind    FFIKind
+	Params  []GoType // only set for idiomatic
+	Returns []GoType // only set for idiomatic
 }
 
 func main() {
 	ffiDir := "../../ffi"
 	functions, err := discoverFFIFunctions(ffiDir)
 	if err != nil {
-		log.Fatalf("Failed to discover FFI functions: %v", err)
+		log.Fatalf("Error: %v", err)
 	}
 
 	if err := generateRegistry(functions); err != nil {
 		log.Fatalf("Failed to generate registry: %v", err)
 	}
 
-	fmt.Printf("Generated registry with %d FFI functions\n", len(functions))
+	raw, idiomatic := 0, 0
+	for _, f := range functions {
+		if f.Kind == FFIRaw {
+			raw++
+		} else {
+			idiomatic++
+		}
+	}
+	fmt.Printf("Generated registry with %d FFI functions (%d raw, %d idiomatic)\n", len(functions), raw, idiomatic)
 }
+
+// --- Discovery ---
 
 func discoverFFIFunctions(dir string) ([]FFIFunction, error) {
 	var functions []FFIFunction
@@ -40,20 +68,17 @@ func discoverFFIFunctions(dir string) ([]FFIFunction, error) {
 		if err != nil {
 			return err
 		}
-
 		if info.IsDir() || !strings.HasSuffix(path, ".go") {
 			return nil
 		}
-
-		if strings.HasSuffix(path, "ffi_generate.go") || strings.HasSuffix(path, ".gen.go") {
+		if strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".gen.go") {
 			return nil
 		}
 
 		fileFunctions, err := parseFFIFunctions(path)
 		if err != nil {
-			return fmt.Errorf("failed to parse %s: %w", path, err)
+			return err
 		}
-
 		functions = append(functions, fileFunctions...)
 		return nil
 	})
@@ -68,55 +93,78 @@ func parseFFIFunctions(filename string) ([]FFIFunction, error) {
 		return nil, err
 	}
 
-	var functions []FFIFunction
-
 	base := filepath.Base(filename)
-	if !strings.HasSuffix(base, ".go") {
-		return functions, nil
-	}
 	module := strings.TrimSuffix(base, ".go")
 
+	var functions []FFIFunction
+	var errors []string
+
 	ast.Inspect(node, func(n ast.Node) bool {
-		if fn, ok := n.(*ast.FuncDecl); ok {
-			if isFFIFunction(fn) {
-				functions = append(functions, FFIFunction{
-					Name:   fn.Name.Name,
-					Module: module,
-					File:   filename,
-				})
-			}
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok {
+			return true
 		}
+
+		// Skip unexported, underscore-prefixed, and receiver methods
+		if fn.Name == nil || !fn.Name.IsExported() || strings.HasPrefix(fn.Name.Name, "_") || fn.Recv != nil {
+			return true
+		}
+
+		kind, params, returns, classErr := classifyFunction(fn)
+		if classErr != nil {
+			errors = append(errors, fmt.Sprintf(
+				"%s:%d: %s: %v",
+				filename, fset.Position(fn.Pos()).Line, fn.Name.Name, classErr,
+			))
+			return true
+		}
+
+		functions = append(functions, FFIFunction{
+			Name:    fn.Name.Name,
+			Module:  module,
+			File:    filename,
+			Kind:    kind,
+			Params:  params,
+			Returns: returns,
+		})
 		return true
 	})
+
+	if len(errors) > 0 {
+		return nil, fmt.Errorf("unsupported FFI function signatures:\n  %s", strings.Join(errors, "\n  "))
+	}
 
 	return functions, nil
 }
 
-func isFFIFunction(fn *ast.FuncDecl) bool {
-	if strings.HasPrefix(fn.Name.Name, "_") {
-		return false
+// --- Classification ---
+
+func classifyFunction(fn *ast.FuncDecl) (FFIKind, []GoType, []GoType, error) {
+	if isRawFFIFunction(fn) {
+		return FFIRaw, nil, nil, nil
 	}
 
-	// Check function signature: func(args []*runtime.Object) *runtime.Object
+	params, paramsOk := parseIdiomaticParams(fn)
+	returns, returnsOk := parseIdiomaticReturns(fn)
+
+	if paramsOk && returnsOk {
+		return FFIIdiomatic, params, returns, nil
+	}
+
+	return 0, nil, nil, fmt.Errorf(
+		"unsupported signature — must be either raw (func([]*runtime.Object) *runtime.Object) or idiomatic (plain Go types: string, int, float64, bool, error, pointers, slices of scalars, map[string]string)",
+	)
+}
+
+func isRawFFIFunction(fn *ast.FuncDecl) bool {
 	if fn.Type.Params == nil || len(fn.Type.Params.List) != 1 {
 		return false
 	}
-
 	if fn.Type.Results == nil || len(fn.Type.Results.List) != 1 {
 		return false
 	}
-
-	firstParam := fn.Type.Params.List[0]
-	if !isSliceOfPointerToRuntimeObject(firstParam.Type) {
-		return false
-	}
-
-	firstReturn := fn.Type.Results.List[0]
-	if !isPointerToRuntimeObject(firstReturn.Type) {
-		return false
-	}
-
-	return true
+	return isSliceOfPointerToRuntimeObject(fn.Type.Params.List[0].Type) &&
+		isPointerToRuntimeObject(fn.Type.Results.List[0].Type)
 }
 
 func isPointerToRuntimeObject(expr ast.Expr) bool {
@@ -124,15 +172,14 @@ func isPointerToRuntimeObject(expr ast.Expr) bool {
 	if !ok {
 		return false
 	}
-
-	sel, ok := star.X.(*ast.SelectorExpr)
-	if ok {
+	if sel, ok := star.X.(*ast.SelectorExpr); ok {
 		pkg, ok := sel.X.(*ast.Ident)
 		return ok && pkg.Name == "runtime" && sel.Sel.Name == "Object"
 	}
-
-	ident, ok := star.X.(*ast.Ident)
-	return ok && ident.Name == "Object"
+	if ident, ok := star.X.(*ast.Ident); ok {
+		return ident.Name == "Object"
+	}
+	return false
 }
 
 func isSliceOfPointerToRuntimeObject(expr ast.Expr) bool {
@@ -143,35 +190,323 @@ func isSliceOfPointerToRuntimeObject(expr ast.Expr) bool {
 	return isPointerToRuntimeObject(array.Elt)
 }
 
+// --- Idiomatic Type Parsing ---
+
+func parseIdiomaticParams(fn *ast.FuncDecl) ([]GoType, bool) {
+	if fn.Type.Params == nil || len(fn.Type.Params.List) == 0 {
+		return nil, true
+	}
+
+	var params []GoType
+	for _, field := range fn.Type.Params.List {
+		t, ok := parseGoType(field.Type)
+		if !ok || t.Base == "error" {
+			return nil, false
+		}
+		nameCount := len(field.Names)
+		if nameCount == 0 {
+			nameCount = 1
+		}
+		for i := 0; i < nameCount; i++ {
+			params = append(params, t)
+		}
+	}
+	return params, true
+}
+
+func parseIdiomaticReturns(fn *ast.FuncDecl) ([]GoType, bool) {
+	if fn.Type.Results == nil || len(fn.Type.Results.List) == 0 {
+		return nil, true // void
+	}
+
+	var returns []GoType
+	for _, field := range fn.Type.Results.List {
+		t, ok := parseGoType(field.Type)
+		if !ok {
+			return nil, false
+		}
+		nameCount := len(field.Names)
+		if nameCount == 0 {
+			nameCount = 1
+		}
+		for i := 0; i < nameCount; i++ {
+			returns = append(returns, t)
+		}
+	}
+
+	// Valid return patterns:
+	//   1 return:  any supported type (scalar, ptr, slice, error)
+	//   2 returns: (T, error) where T is not error
+	switch len(returns) {
+	case 1:
+		return returns, true
+	case 2:
+		if returns[1].Base != "error" || returns[0].Base == "error" {
+			return nil, false
+		}
+		return returns, true
+	default:
+		return nil, false
+	}
+}
+
+func parseGoType(expr ast.Expr) (GoType, bool) {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		switch t.Name {
+		case "string", "int", "float64", "bool", "error":
+			return GoType{Base: t.Name}, true
+		}
+	case *ast.StarExpr:
+		if ident, ok := t.X.(*ast.Ident); ok {
+			switch ident.Name {
+			case "string", "int", "float64", "bool":
+				return GoType{Base: ident.Name, IsPtr: true}, true
+			}
+		}
+	case *ast.ArrayType:
+		if t.Len == nil { // slice, not fixed-size array
+			if ident, ok := t.Elt.(*ast.Ident); ok {
+				switch ident.Name {
+				case "string", "int", "float64", "bool":
+					return GoType{Base: ident.Name, IsSlice: true}, true
+				}
+			}
+		}
+	case *ast.MapType:
+		keyIdent, keyOK := t.Key.(*ast.Ident)
+		valueIdent, valueOK := t.Value.(*ast.Ident)
+		if keyOK && valueOK && keyIdent.Name == "string" && valueIdent.Name == "string" {
+			return GoType{IsStringMap: true}, true
+		}
+	}
+	return GoType{}, false
+}
+
+// --- Code Generation ---
+
 func generateRegistry(functions []FFIFunction) error {
 	var sb strings.Builder
 
-	sb.WriteString(`// Code generated by generate.go; DO NOT EDIT.
+	// Determine needed imports
+	hasIdiomatic := false
+	needsChecker := false
+	for _, fn := range functions {
+		if fn.Kind != FFIIdiomatic {
+			continue
+		}
+		hasIdiomatic = true
+		for _, t := range fn.Returns {
+			if t.IsPtr || t.IsSlice || t.IsStringMap {
+				needsChecker = true
+			}
+		}
+		for _, t := range fn.Params {
+			if t.IsPtr || t.IsSlice || t.IsStringMap {
+				needsChecker = true
+			}
+		}
+	}
 
-package vm
+	sb.WriteString("// Code generated by generate.go; DO NOT EDIT.\n\npackage vm\n\nimport (\n")
+	sb.WriteString("\t\"fmt\"\n\n")
+	if needsChecker {
+		sb.WriteString("\t\"github.com/akonwi/ard/checker\"\n")
+	}
+	sb.WriteString("\t\"github.com/akonwi/ard/ffi\"\n")
+	if hasIdiomatic {
+		sb.WriteString("\t\"github.com/akonwi/ard/runtime\"\n")
+	}
+	sb.WriteString(")\n\n")
 
-import (
-	"fmt"
+	// Generate wrapper functions for idiomatic functions
+	for _, fn := range functions {
+		if fn.Kind == FFIIdiomatic {
+			generateWrapper(&sb, fn)
+		}
+	}
 
-	"github.com/akonwi/ard/ffi"
-)
-
-// RegisterGeneratedFFIFunctions registers all discovered FFI functions
-func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
-`)
+	// Generate registration function
+	sb.WriteString("// RegisterGeneratedFFIFunctions registers all discovered FFI functions\n")
+	sb.WriteString("func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {\n")
 
 	for _, fn := range functions {
-		binding := fn.Name
-		functionRef := fmt.Sprintf("ffi.%s", fn.Name)
-		sb.WriteString(fmt.Sprintf("\tif err := r.Register(%q, %s); err != nil {\n", binding, functionRef))
-		sb.WriteString(fmt.Sprintf("\t\treturn fmt.Errorf(\"failed to register %s: %%w\", err)\n", binding))
+		ref := fmt.Sprintf("ffi.%s", fn.Name)
+		if fn.Kind == FFIIdiomatic {
+			ref = fmt.Sprintf("_ffi_%s", fn.Name)
+		}
+		sb.WriteString(fmt.Sprintf("\tif err := r.Register(%q, %s); err != nil {\n", fn.Name, ref))
+		sb.WriteString(fmt.Sprintf("\t\treturn fmt.Errorf(\"failed to register %s: %%w\", err)\n", fn.Name))
 		sb.WriteString("\t}\n")
 	}
 
-	sb.WriteString(`
-	return nil
-}
-`)
+	sb.WriteString("\n\treturn nil\n}\n")
 
 	return os.WriteFile("registry.gen.go", []byte(sb.String()), 0644)
+}
+
+func generateWrapper(sb *strings.Builder, fn FFIFunction) {
+	sb.WriteString(fmt.Sprintf("func _ffi_%s(args []*runtime.Object) *runtime.Object {\n", fn.Name))
+
+	// 1. Unwrap params
+	for i, p := range fn.Params {
+		generateParamUnwrap(sb, i, p)
+	}
+
+	// 2. Build call expression
+	argNames := make([]string, len(fn.Params))
+	for i := range fn.Params {
+		argNames[i] = fmt.Sprintf("arg%d", i)
+	}
+	callExpr := fmt.Sprintf("ffi.%s(%s)", fn.Name, strings.Join(argNames, ", "))
+
+	// 3. Call + return wrapping
+	hasError := len(fn.Returns) > 0 && fn.Returns[len(fn.Returns)-1].Base == "error"
+
+	switch {
+	case len(fn.Returns) == 0:
+		// Void
+		sb.WriteString(fmt.Sprintf("\t%s\n", callExpr))
+		sb.WriteString("\treturn runtime.Void()\n")
+
+	case len(fn.Returns) == 1 && !hasError:
+		// Single value return
+		sb.WriteString(fmt.Sprintf("\tresult := %s\n", callExpr))
+		generateReturnWrap(sb, fn.Returns[0], "result", false)
+
+	case len(fn.Returns) == 1 && hasError:
+		// error-only → Result<Void, Str>
+		sb.WriteString(fmt.Sprintf("\terr := %s\n", callExpr))
+		sb.WriteString("\tif err != nil {\n")
+		sb.WriteString("\t\treturn runtime.MakeErr(runtime.MakeStr(err.Error()))\n")
+		sb.WriteString("\t}\n")
+		sb.WriteString("\treturn runtime.MakeOk(runtime.Void())\n")
+
+	case len(fn.Returns) == 2 && hasError:
+		// (T, error) → Result<T, Str>
+		sb.WriteString(fmt.Sprintf("\tresult, err := %s\n", callExpr))
+		sb.WriteString("\tif err != nil {\n")
+		sb.WriteString("\t\treturn runtime.MakeErr(runtime.MakeStr(err.Error()))\n")
+		sb.WriteString("\t}\n")
+		generateReturnWrap(sb, fn.Returns[0], "result", true)
+	}
+
+	sb.WriteString("}\n\n")
+}
+
+func generateParamUnwrap(sb *strings.Builder, idx int, t GoType) {
+	argRef := fmt.Sprintf("args[%d]", idx)
+	varName := fmt.Sprintf("arg%d", idx)
+
+	switch {
+	case t.IsPtr:
+		sb.WriteString(fmt.Sprintf("\tvar %s *%s\n", varName, t.Base))
+		sb.WriteString(fmt.Sprintf("\tif !%s.IsNone() {\n", argRef))
+		sb.WriteString(fmt.Sprintf("\t\t_v%d := %s\n", idx, unwrapScalar(argRef, t.Base)))
+		sb.WriteString(fmt.Sprintf("\t\t%s = &_v%d\n", varName, idx))
+		sb.WriteString("\t}\n")
+
+	case t.IsSlice:
+		sb.WriteString(fmt.Sprintf("\t_sl%d := %s.AsList()\n", idx, argRef))
+		sb.WriteString(fmt.Sprintf("\t%s := make([]%s, len(_sl%d))\n", varName, t.Base, idx))
+		sb.WriteString(fmt.Sprintf("\tfor _i%d, _e%d := range _sl%d {\n", idx, idx, idx))
+		sb.WriteString(fmt.Sprintf("\t\t%s[_i%d] = %s\n", varName, idx, unwrapScalar(fmt.Sprintf("_e%d", idx), t.Base)))
+		sb.WriteString("\t}\n")
+
+	case t.IsStringMap:
+		sb.WriteString(fmt.Sprintf("\t_rawMap%d := %s.AsMap()\n", idx, argRef))
+		sb.WriteString(fmt.Sprintf("\t%s := make(map[string]string, len(_rawMap%d))\n", varName, idx))
+		sb.WriteString(fmt.Sprintf("\tfor _k%d, _v%d := range _rawMap%d {\n", idx, idx, idx))
+		sb.WriteString(fmt.Sprintf("\t\t%s[_k%d] = _v%d.AsString()\n", varName, idx, idx))
+		sb.WriteString("\t}\n")
+
+	default:
+		sb.WriteString(fmt.Sprintf("\t%s := %s\n", varName, unwrapScalar(argRef, t.Base)))
+	}
+}
+
+func unwrapScalar(expr, base string) string {
+	switch base {
+	case "string":
+		return expr + ".AsString()"
+	case "int":
+		return expr + ".AsInt()"
+	case "float64":
+		return expr + ".AsFloat()"
+	case "bool":
+		return expr + ".AsBool()"
+	default:
+		panic("unsupported base type for unwrap: " + base)
+	}
+}
+
+func generateReturnWrap(sb *strings.Builder, t GoType, varName string, isResult bool) {
+	wrap := func(inner string) {
+		if isResult {
+			sb.WriteString(fmt.Sprintf("\treturn runtime.MakeOk(%s)\n", inner))
+		} else {
+			sb.WriteString(fmt.Sprintf("\treturn %s\n", inner))
+		}
+	}
+
+	switch {
+	case t.IsPtr:
+		checkerType := checkerTypeStr(t.Base)
+		sb.WriteString(fmt.Sprintf("\tif %s == nil {\n", varName))
+		if isResult {
+			sb.WriteString(fmt.Sprintf("\t\treturn runtime.MakeOk(runtime.MakeNone(%s))\n", checkerType))
+		} else {
+			sb.WriteString(fmt.Sprintf("\t\treturn runtime.MakeNone(%s)\n", checkerType))
+		}
+		sb.WriteString("\t}\n")
+		wrap(fmt.Sprintf("runtime.MakeNone(%s).ToSome(*%s)", checkerType, varName))
+
+	case t.IsSlice:
+		checkerType := checkerTypeStr(t.Base)
+		sb.WriteString(fmt.Sprintf("\t_items := make([]*runtime.Object, len(%s))\n", varName))
+		sb.WriteString(fmt.Sprintf("\tfor _i, _v := range %s {\n", varName))
+		sb.WriteString(fmt.Sprintf("\t\t_items[_i] = %s\n", wrapScalar("_v", t.Base)))
+		sb.WriteString("\t}\n")
+		wrap(fmt.Sprintf("runtime.MakeList(%s, _items...)", checkerType))
+
+	case t.IsStringMap:
+		sb.WriteString(fmt.Sprintf("\t_map := runtime.MakeMap(checker.Str, checker.Str)\n"))
+		sb.WriteString(fmt.Sprintf("\tfor _k, _v := range %s {\n", varName))
+		sb.WriteString("\t\t_map.Map_Set(runtime.MakeStr(_k), runtime.MakeStr(_v))\n")
+		sb.WriteString("\t}\n")
+		wrap("_map")
+
+	default:
+		wrap(wrapScalar(varName, t.Base))
+	}
+}
+
+func wrapScalar(expr, base string) string {
+	switch base {
+	case "string":
+		return fmt.Sprintf("runtime.MakeStr(%s)", expr)
+	case "int":
+		return fmt.Sprintf("runtime.MakeInt(%s)", expr)
+	case "float64":
+		return fmt.Sprintf("runtime.MakeFloat(%s)", expr)
+	case "bool":
+		return fmt.Sprintf("runtime.MakeBool(%s)", expr)
+	default:
+		panic("unsupported base type for wrap: " + base)
+	}
+}
+
+func checkerTypeStr(base string) string {
+	switch base {
+	case "string":
+		return "checker.Str"
+	case "int":
+		return "checker.Int"
+	case "float64":
+		return "checker.Float"
+	case "bool":
+		return "checker.Bool"
+	default:
+		panic("unsupported base type for checker type: " + base)
+	}
 }

--- a/compiler/bytecode/vm/ffi_generate.go
+++ b/compiler/bytecode/vm/ffi_generate.go
@@ -97,7 +97,8 @@ func isFFIFunction(fn *ast.FuncDecl) bool {
 		return false
 	}
 
-	if fn.Type.Params == nil || len(fn.Type.Params.List) != 2 {
+	// Check function signature: func(args []*runtime.Object) *runtime.Object
+	if fn.Type.Params == nil || len(fn.Type.Params.List) != 1 {
 		return false
 	}
 
@@ -108,12 +109,6 @@ func isFFIFunction(fn *ast.FuncDecl) bool {
 	firstParam := fn.Type.Params.List[0]
 	if !isSliceOfPointerToRuntimeObject(firstParam.Type) {
 		return false
-	}
-
-	secondParam := fn.Type.Params.List[1]
-	if sel, isSelector := secondParam.Type.(*ast.SelectorExpr); isSelector {
-		pkg, ok := sel.X.(*ast.Ident)
-		return ok && pkg.Name == "checker" && sel.Sel.Name == "Type"
 	}
 
 	firstReturn := fn.Type.Results.List[0]

--- a/compiler/bytecode/vm/ffi_registry.go
+++ b/compiler/bytecode/vm/ffi_registry.go
@@ -10,7 +10,7 @@ import (
 	"github.com/akonwi/ard/runtime"
 )
 
-type FFIFunc func(args []*runtime.Object, returnType checker.Type) *runtime.Object
+type FFIFunc func(args []*runtime.Object) *runtime.Object
 
 type RuntimeFFIRegistry struct {
 	functions map[string]FFIFunc
@@ -53,7 +53,7 @@ func (r *RuntimeFFIRegistry) Call(binding string, args []*runtime.Object, return
 		}
 	}()
 
-	result = fn(args, returnType)
+	result = fn(args)
 	return result, nil
 }
 

--- a/compiler/bytecode/vm/ffi_registry_test.go
+++ b/compiler/bytecode/vm/ffi_registry_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/akonwi/ard/runtime"
 )
 
-func panicTestFFI(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func panicTestFFI(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("panicTestFFI expects 1 arg, got %d", len(args)))
 	}

--- a/compiler/bytecode/vm/registry.gen.go
+++ b/compiler/bytecode/vm/registry.gen.go
@@ -361,21 +361,6 @@ func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
 	if err := r.Register("CryptoUUID", _ffi_CryptoUUID); err != nil {
 		return fmt.Errorf("failed to register CryptoUUID: %w", err)
 	}
-	if err := r.Register("StrToDynamic", ffi.StrToDynamic); err != nil {
-		return fmt.Errorf("failed to register StrToDynamic: %w", err)
-	}
-	if err := r.Register("IntToDynamic", ffi.IntToDynamic); err != nil {
-		return fmt.Errorf("failed to register IntToDynamic: %w", err)
-	}
-	if err := r.Register("FloatToDynamic", ffi.FloatToDynamic); err != nil {
-		return fmt.Errorf("failed to register FloatToDynamic: %w", err)
-	}
-	if err := r.Register("BoolToDynamic", ffi.BoolToDynamic); err != nil {
-		return fmt.Errorf("failed to register BoolToDynamic: %w", err)
-	}
-	if err := r.Register("VoidToDynamic", ffi.VoidToDynamic); err != nil {
-		return fmt.Errorf("failed to register VoidToDynamic: %w", err)
-	}
 	if err := r.Register("ListToDynamic", ffi.ListToDynamic); err != nil {
 		return fmt.Errorf("failed to register ListToDynamic: %w", err)
 	}

--- a/compiler/bytecode/vm/registry.gen.go
+++ b/compiler/bytecode/vm/registry.gen.go
@@ -157,9 +157,6 @@ func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
 	if err := r.Register("IntFromStr", ffi.IntFromStr); err != nil {
 		return fmt.Errorf("failed to register IntFromStr: %w", err)
 	}
-	if err := r.Register("NewList", ffi.NewList); err != nil {
-		return fmt.Errorf("failed to register NewList: %w", err)
-	}
 	if err := r.Register("OsArgs", ffi.OsArgs); err != nil {
 		return fmt.Errorf("failed to register OsArgs: %w", err)
 	}

--- a/compiler/bytecode/vm/registry.gen.go
+++ b/compiler/bytecode/vm/registry.gen.go
@@ -5,33 +5,360 @@ package vm
 import (
 	"fmt"
 
+	"github.com/akonwi/ard/checker"
 	"github.com/akonwi/ard/ffi"
+	"github.com/akonwi/ard/runtime"
 )
+
+func _ffi_CryptoMd5(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result := ffi.CryptoMd5(arg0)
+	return runtime.MakeStr(result)
+}
+
+func _ffi_CryptoSha256(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result := ffi.CryptoSha256(arg0)
+	return runtime.MakeStr(result)
+}
+
+func _ffi_CryptoSha512(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result := ffi.CryptoSha512(arg0)
+	return runtime.MakeStr(result)
+}
+
+func _ffi_CryptoHashPassword(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	var arg1 *int
+	if !args[1].IsNone() {
+		_v1 := args[1].AsInt()
+		arg1 = &_v1
+	}
+	result, err := ffi.CryptoHashPassword(arg0, arg1)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeStr(result))
+}
+
+func _ffi_CryptoVerifyPassword(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	arg1 := args[1].AsString()
+	result, err := ffi.CryptoVerifyPassword(arg0, arg1)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeBool(result))
+}
+
+func _ffi_CryptoScryptHash(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	var arg1 *string
+	if !args[1].IsNone() {
+		_v1 := args[1].AsString()
+		arg1 = &_v1
+	}
+	var arg2 *int
+	if !args[2].IsNone() {
+		_v2 := args[2].AsInt()
+		arg2 = &_v2
+	}
+	var arg3 *int
+	if !args[3].IsNone() {
+		_v3 := args[3].AsInt()
+		arg3 = &_v3
+	}
+	var arg4 *int
+	if !args[4].IsNone() {
+		_v4 := args[4].AsInt()
+		arg4 = &_v4
+	}
+	var arg5 *int
+	if !args[5].IsNone() {
+		_v5 := args[5].AsInt()
+		arg5 = &_v5
+	}
+	result, err := ffi.CryptoScryptHash(arg0, arg1, arg2, arg3, arg4, arg5)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeStr(result))
+}
+
+func _ffi_CryptoScryptVerify(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	arg1 := args[1].AsString()
+	var arg2 *int
+	if !args[2].IsNone() {
+		_v2 := args[2].AsInt()
+		arg2 = &_v2
+	}
+	var arg3 *int
+	if !args[3].IsNone() {
+		_v3 := args[3].AsInt()
+		arg3 = &_v3
+	}
+	var arg4 *int
+	if !args[4].IsNone() {
+		_v4 := args[4].AsInt()
+		arg4 = &_v4
+	}
+	var arg5 *int
+	if !args[5].IsNone() {
+		_v5 := args[5].AsInt()
+		arg5 = &_v5
+	}
+	result, err := ffi.CryptoScryptVerify(arg0, arg1, arg2, arg3, arg4, arg5)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeBool(result))
+}
+
+func _ffi_CryptoUUID(args []*runtime.Object) *runtime.Object {
+	result := ffi.CryptoUUID()
+	return runtime.MakeStr(result)
+}
+
+func _ffi_FS_Exists(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result := ffi.FS_Exists(arg0)
+	return runtime.MakeBool(result)
+}
+
+func _ffi_FS_CreateFile(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result, err := ffi.FS_CreateFile(arg0)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeBool(result))
+}
+
+func _ffi_FS_WriteFile(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	arg1 := args[1].AsString()
+	err := ffi.FS_WriteFile(arg0, arg1)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.Void())
+}
+
+func _ffi_FS_AppendFile(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	arg1 := args[1].AsString()
+	err := ffi.FS_AppendFile(arg0, arg1)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.Void())
+}
+
+func _ffi_FS_ReadFile(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result, err := ffi.FS_ReadFile(arg0)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeStr(result))
+}
+
+func _ffi_FS_DeleteFile(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	err := ffi.FS_DeleteFile(arg0)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.Void())
+}
+
+func _ffi_FS_IsFile(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result := ffi.FS_IsFile(arg0)
+	return runtime.MakeBool(result)
+}
+
+func _ffi_FS_IsDir(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result := ffi.FS_IsDir(arg0)
+	return runtime.MakeBool(result)
+}
+
+func _ffi_FS_Copy(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	arg1 := args[1].AsString()
+	err := ffi.FS_Copy(arg0, arg1)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.Void())
+}
+
+func _ffi_FS_Rename(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	arg1 := args[1].AsString()
+	err := ffi.FS_Rename(arg0, arg1)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.Void())
+}
+
+func _ffi_FS_Cwd(args []*runtime.Object) *runtime.Object {
+	result, err := ffi.FS_Cwd()
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeStr(result))
+}
+
+func _ffi_FS_Abs(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result, err := ffi.FS_Abs(arg0)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeStr(result))
+}
+
+func _ffi_FS_CreateDir(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	err := ffi.FS_CreateDir(arg0)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.Void())
+}
+
+func _ffi_FS_DeleteDir(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	err := ffi.FS_DeleteDir(arg0)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.Void())
+}
+
+func _ffi_FloatFromStr(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result := ffi.FloatFromStr(arg0)
+	if result == nil {
+		return runtime.MakeNone(checker.Float)
+	}
+	return runtime.MakeNone(checker.Float).ToSome(*result)
+}
+
+func _ffi_FloatFromInt(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsInt()
+	result := ffi.FloatFromInt(arg0)
+	return runtime.MakeFloat(result)
+}
+
+func _ffi_FloatFloor(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsFloat()
+	result := ffi.FloatFloor(arg0)
+	return runtime.MakeFloat(result)
+}
+
+func _ffi_IntFromStr(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result := ffi.IntFromStr(arg0)
+	if result == nil {
+		return runtime.MakeNone(checker.Int)
+	}
+	return runtime.MakeNone(checker.Int).ToSome(*result)
+}
+
+func _ffi_OsArgs(args []*runtime.Object) *runtime.Object {
+	result := ffi.OsArgs()
+	_items := make([]*runtime.Object, len(result))
+	for _i, _v := range result {
+		_items[_i] = runtime.MakeStr(_v)
+	}
+	return runtime.MakeList(checker.Str, _items...)
+}
+
+func _ffi_Print(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	ffi.Print(arg0)
+	return runtime.Void()
+}
+
+func _ffi_ReadLine(args []*runtime.Object) *runtime.Object {
+	result, err := ffi.ReadLine()
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeStr(result))
+}
+
+func _ffi_PanicWithMessage(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	ffi.PanicWithMessage(arg0)
+	return runtime.Void()
+}
+
+func _ffi_EnvGet(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result := ffi.EnvGet(arg0)
+	if result == nil {
+		return runtime.MakeNone(checker.Str)
+	}
+	return runtime.MakeNone(checker.Str).ToSome(*result)
+}
+
+func _ffi_GetTodayString(args []*runtime.Object) *runtime.Object {
+	result := ffi.GetTodayString()
+	return runtime.MakeStr(result)
+}
+
+func _ffi_Now(args []*runtime.Object) *runtime.Object {
+	result := ffi.Now()
+	return runtime.MakeInt(result)
+}
+
+func _ffi_Sleep(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsInt()
+	ffi.Sleep(arg0)
+	return runtime.Void()
+}
+
+func _ffi_SqlExtractParams(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result := ffi.SqlExtractParams(arg0)
+	_items := make([]*runtime.Object, len(result))
+	for _i, _v := range result {
+		_items[_i] = runtime.MakeStr(_v)
+	}
+	return runtime.MakeList(checker.Str, _items...)
+}
 
 // RegisterGeneratedFFIFunctions registers all discovered FFI functions
 func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
-	if err := r.Register("CryptoMd5", ffi.CryptoMd5); err != nil {
+	if err := r.Register("CryptoMd5", _ffi_CryptoMd5); err != nil {
 		return fmt.Errorf("failed to register CryptoMd5: %w", err)
 	}
-	if err := r.Register("CryptoSha256", ffi.CryptoSha256); err != nil {
+	if err := r.Register("CryptoSha256", _ffi_CryptoSha256); err != nil {
 		return fmt.Errorf("failed to register CryptoSha256: %w", err)
 	}
-	if err := r.Register("CryptoSha512", ffi.CryptoSha512); err != nil {
+	if err := r.Register("CryptoSha512", _ffi_CryptoSha512); err != nil {
 		return fmt.Errorf("failed to register CryptoSha512: %w", err)
 	}
-	if err := r.Register("CryptoHashPassword", ffi.CryptoHashPassword); err != nil {
+	if err := r.Register("CryptoHashPassword", _ffi_CryptoHashPassword); err != nil {
 		return fmt.Errorf("failed to register CryptoHashPassword: %w", err)
 	}
-	if err := r.Register("CryptoVerifyPassword", ffi.CryptoVerifyPassword); err != nil {
+	if err := r.Register("CryptoVerifyPassword", _ffi_CryptoVerifyPassword); err != nil {
 		return fmt.Errorf("failed to register CryptoVerifyPassword: %w", err)
 	}
-	if err := r.Register("CryptoScryptHash", ffi.CryptoScryptHash); err != nil {
+	if err := r.Register("CryptoScryptHash", _ffi_CryptoScryptHash); err != nil {
 		return fmt.Errorf("failed to register CryptoScryptHash: %w", err)
 	}
-	if err := r.Register("CryptoScryptVerify", ffi.CryptoScryptVerify); err != nil {
+	if err := r.Register("CryptoScryptVerify", _ffi_CryptoScryptVerify); err != nil {
 		return fmt.Errorf("failed to register CryptoScryptVerify: %w", err)
 	}
-	if err := r.Register("CryptoUUID", ffi.CryptoUUID); err != nil {
+	if err := r.Register("CryptoUUID", _ffi_CryptoUUID); err != nil {
 		return fmt.Errorf("failed to register CryptoUUID: %w", err)
 	}
 	if err := r.Register("StrToDynamic", ffi.StrToDynamic); err != nil {
@@ -82,46 +409,46 @@ func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
 	if err := r.Register("ExtractField", ffi.ExtractField); err != nil {
 		return fmt.Errorf("failed to register ExtractField: %w", err)
 	}
-	if err := r.Register("FS_Exists", ffi.FS_Exists); err != nil {
+	if err := r.Register("FS_Exists", _ffi_FS_Exists); err != nil {
 		return fmt.Errorf("failed to register FS_Exists: %w", err)
 	}
-	if err := r.Register("FS_CreateFile", ffi.FS_CreateFile); err != nil {
+	if err := r.Register("FS_CreateFile", _ffi_FS_CreateFile); err != nil {
 		return fmt.Errorf("failed to register FS_CreateFile: %w", err)
 	}
-	if err := r.Register("FS_WriteFile", ffi.FS_WriteFile); err != nil {
+	if err := r.Register("FS_WriteFile", _ffi_FS_WriteFile); err != nil {
 		return fmt.Errorf("failed to register FS_WriteFile: %w", err)
 	}
-	if err := r.Register("FS_AppendFile", ffi.FS_AppendFile); err != nil {
+	if err := r.Register("FS_AppendFile", _ffi_FS_AppendFile); err != nil {
 		return fmt.Errorf("failed to register FS_AppendFile: %w", err)
 	}
-	if err := r.Register("FS_ReadFile", ffi.FS_ReadFile); err != nil {
+	if err := r.Register("FS_ReadFile", _ffi_FS_ReadFile); err != nil {
 		return fmt.Errorf("failed to register FS_ReadFile: %w", err)
 	}
-	if err := r.Register("FS_DeleteFile", ffi.FS_DeleteFile); err != nil {
+	if err := r.Register("FS_DeleteFile", _ffi_FS_DeleteFile); err != nil {
 		return fmt.Errorf("failed to register FS_DeleteFile: %w", err)
 	}
-	if err := r.Register("FS_IsFile", ffi.FS_IsFile); err != nil {
+	if err := r.Register("FS_IsFile", _ffi_FS_IsFile); err != nil {
 		return fmt.Errorf("failed to register FS_IsFile: %w", err)
 	}
-	if err := r.Register("FS_IsDir", ffi.FS_IsDir); err != nil {
+	if err := r.Register("FS_IsDir", _ffi_FS_IsDir); err != nil {
 		return fmt.Errorf("failed to register FS_IsDir: %w", err)
 	}
-	if err := r.Register("FS_Copy", ffi.FS_Copy); err != nil {
+	if err := r.Register("FS_Copy", _ffi_FS_Copy); err != nil {
 		return fmt.Errorf("failed to register FS_Copy: %w", err)
 	}
-	if err := r.Register("FS_Rename", ffi.FS_Rename); err != nil {
+	if err := r.Register("FS_Rename", _ffi_FS_Rename); err != nil {
 		return fmt.Errorf("failed to register FS_Rename: %w", err)
 	}
-	if err := r.Register("FS_Cwd", ffi.FS_Cwd); err != nil {
+	if err := r.Register("FS_Cwd", _ffi_FS_Cwd); err != nil {
 		return fmt.Errorf("failed to register FS_Cwd: %w", err)
 	}
-	if err := r.Register("FS_Abs", ffi.FS_Abs); err != nil {
+	if err := r.Register("FS_Abs", _ffi_FS_Abs); err != nil {
 		return fmt.Errorf("failed to register FS_Abs: %w", err)
 	}
-	if err := r.Register("FS_CreateDir", ffi.FS_CreateDir); err != nil {
+	if err := r.Register("FS_CreateDir", _ffi_FS_CreateDir); err != nil {
 		return fmt.Errorf("failed to register FS_CreateDir: %w", err)
 	}
-	if err := r.Register("FS_DeleteDir", ffi.FS_DeleteDir); err != nil {
+	if err := r.Register("FS_DeleteDir", _ffi_FS_DeleteDir); err != nil {
 		return fmt.Errorf("failed to register FS_DeleteDir: %w", err)
 	}
 	if err := r.Register("FS_ListDir", ffi.FS_ListDir); err != nil {
@@ -145,40 +472,40 @@ func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
 	if err := r.Register("JsonEncode", ffi.JsonEncode); err != nil {
 		return fmt.Errorf("failed to register JsonEncode: %w", err)
 	}
-	if err := r.Register("FloatFromStr", ffi.FloatFromStr); err != nil {
+	if err := r.Register("FloatFromStr", _ffi_FloatFromStr); err != nil {
 		return fmt.Errorf("failed to register FloatFromStr: %w", err)
 	}
-	if err := r.Register("FloatFromInt", ffi.FloatFromInt); err != nil {
+	if err := r.Register("FloatFromInt", _ffi_FloatFromInt); err != nil {
 		return fmt.Errorf("failed to register FloatFromInt: %w", err)
 	}
-	if err := r.Register("FloatFloor", ffi.FloatFloor); err != nil {
+	if err := r.Register("FloatFloor", _ffi_FloatFloor); err != nil {
 		return fmt.Errorf("failed to register FloatFloor: %w", err)
 	}
-	if err := r.Register("IntFromStr", ffi.IntFromStr); err != nil {
+	if err := r.Register("IntFromStr", _ffi_IntFromStr); err != nil {
 		return fmt.Errorf("failed to register IntFromStr: %w", err)
 	}
-	if err := r.Register("OsArgs", ffi.OsArgs); err != nil {
+	if err := r.Register("OsArgs", _ffi_OsArgs); err != nil {
 		return fmt.Errorf("failed to register OsArgs: %w", err)
 	}
-	if err := r.Register("Print", ffi.Print); err != nil {
+	if err := r.Register("Print", _ffi_Print); err != nil {
 		return fmt.Errorf("failed to register Print: %w", err)
 	}
-	if err := r.Register("ReadLine", ffi.ReadLine); err != nil {
+	if err := r.Register("ReadLine", _ffi_ReadLine); err != nil {
 		return fmt.Errorf("failed to register ReadLine: %w", err)
 	}
-	if err := r.Register("PanicWithMessage", ffi.PanicWithMessage); err != nil {
+	if err := r.Register("PanicWithMessage", _ffi_PanicWithMessage); err != nil {
 		return fmt.Errorf("failed to register PanicWithMessage: %w", err)
 	}
-	if err := r.Register("EnvGet", ffi.EnvGet); err != nil {
+	if err := r.Register("EnvGet", _ffi_EnvGet); err != nil {
 		return fmt.Errorf("failed to register EnvGet: %w", err)
 	}
-	if err := r.Register("GetTodayString", ffi.GetTodayString); err != nil {
+	if err := r.Register("GetTodayString", _ffi_GetTodayString); err != nil {
 		return fmt.Errorf("failed to register GetTodayString: %w", err)
 	}
-	if err := r.Register("Now", ffi.Now); err != nil {
+	if err := r.Register("Now", _ffi_Now); err != nil {
 		return fmt.Errorf("failed to register Now: %w", err)
 	}
-	if err := r.Register("Sleep", ffi.Sleep); err != nil {
+	if err := r.Register("Sleep", _ffi_Sleep); err != nil {
 		return fmt.Errorf("failed to register Sleep: %w", err)
 	}
 	if err := r.Register("WaitFor", ffi.WaitFor); err != nil {
@@ -193,7 +520,7 @@ func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
 	if err := r.Register("SqlClose", ffi.SqlClose); err != nil {
 		return fmt.Errorf("failed to register SqlClose: %w", err)
 	}
-	if err := r.Register("SqlExtractParams", ffi.SqlExtractParams); err != nil {
+	if err := r.Register("SqlExtractParams", _ffi_SqlExtractParams); err != nil {
 		return fmt.Errorf("failed to register SqlExtractParams: %w", err)
 	}
 	if err := r.Register("SqlQuery", ffi.SqlQuery); err != nil {

--- a/compiler/bytecode/vm/vm.go
+++ b/compiler/bytecode/vm/vm.go
@@ -1001,6 +1001,12 @@ func (vm *VM) run() (*runtime.Object, error) {
 				return nil, err
 			}
 			vm.push(curr, res)
+		case bytecode.OpToDynamic:
+			val, err := vm.pop(curr)
+			if err != nil {
+				return nil, err
+			}
+			vm.push(curr, runtime.MakeDynamic(val.Raw()))
 		case bytecode.OpMatchBool, bytecode.OpMatchInt, bytecode.OpMatchEnum, bytecode.OpMatchUnion,
 			bytecode.OpMatchMaybe, bytecode.OpMatchResult:
 			return nil, fmt.Errorf("opcode not implemented: %s", inst.Op)

--- a/compiler/docs/ffi.md
+++ b/compiler/docs/ffi.md
@@ -2,289 +2,290 @@
 
 ## Overview
 
-The Ard FFI system enables the standard library to be written in Ard rather than Go by providing a clean, type-safe interface to call compiled Go functions from interpreted Ard code. This design keeps Ard as an interpreted language while allowing performance-critical operations to be implemented in Go.
+Ard's FFI lets standard library functions declared in Ard call Go implementations inside `compiler/ffi/`.
+
+The system is intentionally narrow:
+- it is for Ard's built-in standard library, not user-installed native extensions
+- it uses **zero reflection** at runtime
+- registration is fully code-generated with `go generate`
+- unsupported exported signatures in `ffi/*.go` are treated as **generator errors**
 
 ## Architecture
 
-### Core Design Principles
+### Directory structure
 
-- **Standard library focus**: FFI is designed specifically for standard library development, not general user extensions
-- **Type safety**: Full type checking and validation between Ard and Go boundaries
-- **Zero reflection**: Direct function calls using uniform signatures for maximum performance
-- **Automatic discovery**: Code generation eliminates manual registration overhead
-- **Clean separation**: Go implementations in `./ffi/`, Ard interfaces in `./std_lib/`
-
-### Directory Structure
-
-```
-ard/
-├── ffi/                    # FFI implementations (compiled into VM)
-│   ├── runtime.go         # Print, ReadLine, PanicWithMessage, EnvGet
-│   └── json.go            # JsonEncode
-├── std_lib/               # Standard library (interpreted Ard)
-│   ├── io.ard             # Uses "Print", "ReadLine"
-│   ├── env.ard            # Uses "EnvGet"
-│   └── json.ard           # Uses "JsonEncode"
-└── vm/
-    ├── ffi_generate.go    # Auto-discovery and registry generation
-    ├── ffi_registry.go    # Runtime FFI registry
-    └── registry.gen.go    # Generated function bindings
+```text
+compiler/
+├── ffi/                    # Go implementations of extern bindings
+├── std_lib/                # Ard declarations using extern fn ... = "BindingName"
+├── runtime/                # Ard runtime object model and VM-facing helpers
+└── bytecode/vm/
+    ├── ffi_registry.go     # Runtime registry + panic recovery
+    ├── ffi_generate.go     # AST-based FFI discovery + wrapper generation
+    └── registry.gen.go     # Generated registrations and idiomatic wrappers
 ```
 
-## FFI Function Implementation
+### Two-tier FFI model
 
-### Function Signature
+FFI functions can be written in one of two styles.
 
-All FFI functions follow a uniform signature for consistency and performance:
+#### 1. Raw FFI
+
+Raw functions work directly with Ard runtime objects.
 
 ```go
-func FunctionName(vm runtime.VM, args []*runtime.Object) *runtime.Object
+func HTTP_Send(args []*runtime.Object) *runtime.Object
 ```
 
-**Parameters:**
-- `vm runtime.VM`: Interface providing access to VM methods for object evaluation
-- `args []*runtime.Object`: Array of Ard values converted to VM's internal object representation
+Use raw FFI when the function needs:
+- `Dynamic` values
+- Ard structs/enums/results built manually
+- closures or VM/runtime internals
+- embedded Ard type lookups from `checker`
+- custom marshalling logic
 
-**Return:**
-- `*runtime.Object`: Single return value (use Result types for error handling)
+#### 2. Idiomatic Go FFI
 
-### Example Implementation
+Idiomatic functions use ordinary Go types, and the generator creates a raw wrapper automatically.
 
 ```go
-// ffi/runtime.go
-func Print(vm runtime.VM, args []*runtime.Object) *runtime.Object {
-    if len(args) != 1 {
-        panic(fmt.Errorf("print expects 1 argument, got %d", len(args)))
-    }
+func CryptoMd5(input string) string
+func EnvGet(key string) *string
+func FS_ReadFile(path string) (string, error)
+func OsArgs() []string
+```
 
-    arg := args[0]
-    switch raw := arg.Raw().(type) {
-    case string, bool, int, float64:
-        fmt.Printf("%v\n", raw)
-        return runtime.Void()
-    default:
-        // Handle complex types by calling Ard's to_str method
-        if _, ok := arg.Type().(*checker.StructDef); ok {
-            call := &checker.FunctionCall{Name: "to_str", Args: []checker.Expression{}}
-            str := vm.EvalStructMethod(arg, call).Raw().(string)
-            fmt.Println(str)
-            return runtime.Void()
-        }
-        panic(fmt.Errorf("unprintable type: %T", raw))
-    }
+The generated wrapper in `registry.gen.go`:
+- unwraps Ard arguments from `[]*runtime.Object`
+- calls the Go function directly
+- wraps the Go result back into Ard runtime objects
+
+## Supported idiomatic types
+
+### Parameters
+
+The generator currently supports these Go parameter types:
+- `string`
+- `int`
+- `float64`
+- `bool`
+- `*string`
+- `*int`
+- `*float64`
+- `*bool`
+- `[]string`
+- `[]int`
+- `[]float64`
+- `[]bool`
+- `map[string]string`
+
+Meaning:
+- scalar types map to Ard scalar values
+- pointer-to-scalar types map to Ard `Maybe<T>`
+- slice-of-scalar types map to Ard `[T]`
+- `map[string]string` maps to Ard `[Str:Str]`
+
+### Returns
+
+The generator supports these return shapes:
+- no return value
+- `T`
+- `*T`
+- `[]T`
+- `error`
+- `(T, error)`
+
+Where `T` is one of:
+- `string`
+- `int`
+- `float64`
+- `bool`
+- `*string`
+- `*int`
+- `*float64`
+- `*bool`
+- `[]string`
+- `[]int`
+- `[]float64`
+- `[]bool`
+- `map[string]string`
+
+### Ard mapping rules
+
+| Go type | Ard type |
+|---|---|
+| `string` | `Str` |
+| `int` | `Int` |
+| `float64` | `Float` |
+| `bool` | `Bool` |
+| `*string` | `Str?` |
+| `*int` | `Int?` |
+| `*float64` | `Float?` |
+| `*bool` | `Bool?` |
+| `[]string` | `[Str]` |
+| `[]int` | `[Int]` |
+| `[]float64` | `[Float]` |
+| `[]bool` | `[Bool]` |
+| `error` | `Void!Str` |
+| `(T, error)` | `T!Str` |
+
+Notes:
+- `nil` pointer return becomes `None`
+- non-`nil` pointer return becomes `Some(value)`
+- an `error` return is wrapped as `Err(Str)`
+- successful `(T, error)` returns are wrapped as `Ok(T)`
+
+## Generator behavior
+
+`go generate ./bytecode/vm` scans every exported, non-underscore-prefixed function in `compiler/ffi/*.go`.
+
+Each function must be exactly one of:
+1. a raw FFI function: `func([]*runtime.Object) *runtime.Object`
+2. a supported idiomatic Go FFI function
+
+Anything else is a generation error.
+
+That means functions in `ffi/` cannot silently disappear from the registry.
+
+### Example raw registration
+
+```go
+if err := r.Register("HTTP_Send", ffi.HTTP_Send); err != nil {
+    return fmt.Errorf("failed to register HTTP_Send: %w", err)
 }
 ```
 
-## Standard Library Integration
+### Example generated idiomatic wrapper
 
-### Extern Function Declaration
+Source function:
 
-Standard library modules use `extern fn` declarations to bind Ard functions to Go implementations:
+```go
+func FS_ReadFile(path string) (string, error)
+```
+
+Generated wrapper:
+
+```go
+func _ffi_FS_ReadFile(args []*runtime.Object) *runtime.Object {
+    arg0 := args[0].AsString()
+    result, err := ffi.FS_ReadFile(arg0)
+    if err != nil {
+        return runtime.MakeErr(runtime.MakeStr(err.Error()))
+    }
+    return runtime.MakeOk(runtime.MakeStr(result))
+}
+```
+
+## Standard library integration
+
+Ard code binds extern functions by string name:
 
 ```ard
-// std_lib/io.ard
-extern fn print(value: $T) Void = "Print"
-extern fn read_line() Str!Str = "ReadLine"
+extern fn read(path: Str) Str!Str = "FS_ReadFile"
+extern fn get(key: Str) Str? = "EnvGet"
+extern fn os_args() [Str] = "OsArgs"
 ```
 
-**Syntax:**
-- `extern fn` keyword introduces external function
-- Full Ard type signature for type safety
-- String binding directly references Go function name (no module prefix needed)
+The checker validates the Ard side. The generator validates the Go side.
 
-### Usage in User Code
+## Error handling
 
-```ard
-use ard/io
+### Explicit errors
 
-fn main() {
-    io::print("Hello from FFI!")
-
-    match io::read_line() {
-        Ok(input) -> io::print("You entered: " + input)
-        Err(error) -> io::print("Error: " + error)
-    }
-}
-```
-
-## Automatic Code Generation
-
-### Discovery Process
-
-The FFI system uses Go's `go generate` to automatically discover and register FFI functions:
-
-1. **Parse**: Scan all `./ffi/*.go` files using Go's AST parser
-2. **Validate**: Verify functions match required signature `func(vm runtime.VM, args []*runtime.Object) *runtime.Object`
-3. **Generate**: Create `vm/registry.gen.go` with registration code
-4. **Register**: VM automatically loads generated bindings at startup
-
-### Generated Registry
+Idiomatic functions should use normal Go `error` returns when possible:
 
 ```go
-// bytecode/vm/registry.gen.go (generated)
-func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
-    if err := r.Register("Print", ffi.Print); err != nil {
-        return fmt.Errorf("failed to register Print: %w", err)
+func ReadLine() (string, error)
+func FS_WriteFile(path, content string) error
+```
+
+### Panic recovery
+
+`RuntimeFFIRegistry.Call()` still wraps panics.
+
+Behavior:
+- if the Ard return type is a `Result`, a panic becomes `Err("panic in FFI function ...")`
+- otherwise the panic is re-thrown with FFI context
+
+This applies to both raw functions and generated idiomatic wrappers.
+
+## Raw FFI examples
+
+Use raw FFI when you need full control over Ard values:
+
+```go
+func FS_ListDir(args []*runtime.Object) *runtime.Object {
+    path := args[0].Raw().(string)
+    entries, err := os.ReadDir(path)
+    if err != nil {
+        return runtime.MakeErr(runtime.MakeStr(err.Error()))
     }
-    if err := r.Register("JsonEncode", ffi.JsonEncode); err != nil {
-        return fmt.Errorf("failed to register JsonEncode: %w", err)
+
+    dirEntryType := getFSDirEntryType()
+
+    var dirEntries []*runtime.Object
+    for _, entry := range entries {
+        dirEntries = append(dirEntries, runtime.MakeStruct(dirEntryType, map[string]*runtime.Object{
+            "name":    runtime.MakeStr(entry.Name()),
+            "is_file": runtime.MakeBool(!entry.IsDir()),
+        }))
     }
-    // ... more registrations
-    return nil
+
+    return runtime.MakeOk(runtime.MakeList(dirEntryType, dirEntries...))
 }
 ```
 
-### Build Integration
+This stays raw because it needs embedded Ard type lookup and manual struct construction.
+
+## Development workflow
+
+### Adding a new FFI binding
+
+1. Add a Go function in `compiler/ffi/`
+2. Choose either raw or idiomatic style
+3. Run:
 
 ```bash
-# Regenerate FFI registry after adding new functions
+cd compiler
 go generate ./bytecode/vm
+```
 
-# Build normally - generated code is included automatically
+4. Add or update the Ard declaration in `compiler/std_lib/*.ard`
+5. Validate with:
+
+```bash
 go build
+go test ./...
 ```
 
-## Type Marshalling
+### When to choose idiomatic vs raw
 
-### VM Interface
+Prefer **idiomatic** when the binding is mostly scalar/list/maybe/result marshalling.
 
-The `runtime.VM` interface provides access to VM operations needed by FFI functions:
+Prefer **raw** when the binding needs:
+- `Dynamic`
+- runtime closures
+- Ard structs/enums/maps beyond simple scalar collections
+- manual construction of Ard-specific types
+- special VM/runtime behavior
 
-```go
-// vm/runtime/vm.go
-type VM interface {
-    EvalStructMethod(obj *Object, call *checker.FunctionCall) *Object
-    EvalEnumMethod(obj *Object, call *checker.FunctionCall, enum *checker.Enum) *Object
-}
-```
+## Current status
 
-This interface enables FFI functions to:
-- Call Ard methods on objects (like `to_str()` for custom string conversion)
-- Evaluate enum methods for proper formatting
-- Maintain type safety across the FFI boundary
+The FFI system is incremental by design.
 
-### Runtime Objects
+Today the codebase uses both tiers:
+- many simple crypto, fs, runtime, prelude, and SQL helper bindings are idiomatic Go
+- HTTP, SQL execution, decode/dynamic conversion, and other complex bindings remain raw
 
-All values are marshalled through the VM's `*runtime.Object` type:
+This keeps the common cases ergonomic without weakening the low-level escape hatch.
 
-```go
-// Creating Ard values from Go
-runtime.MakeStr("hello")           // String
-runtime.MakeInt(42)                // Integer
-runtime.MakeBool(true)             // Boolean
-runtime.Void()                     // Void return
+## Summary
 
-// Result types for error handling
-runtime.MakeOk(value)              // Success case
-runtime.MakeErr(error)             // Error case
-runtime.MakeMaybe(value, type)     // Maybe types
-```
+Ard's FFI now provides:
+- zero-reflection dispatch
+- generated registration
+- generated marshalling for common Go types
+- hard errors for unsupported exported signatures
+- an escape hatch for complex runtime-aware bindings
 
-## Error Handling
-
-### Panic Recovery
-
-The FFI registry automatically recovers from panics and converts them appropriately:
-
-- **Result return types**: Panics become `Err(message)`
-- **Other return types**: Panics propagate with enhanced context
-
-### Example Error Patterns
-
-```go
-func SafeOperation(vm runtime.VM, args []*runtime.Object) *runtime.Object {
-    // Input validation - panic will be caught by registry
-    if len(args) != 1 {
-        panic(fmt.Errorf("expected 1 argument, got %d", len(args)))
-    }
-
-    // Operation that might fail
-    if result, err := riskyOperation(args[0]); err != nil {
-        return runtime.MakeErr(runtime.MakeStr(err.Error()))
-    } else {
-        return runtime.MakeOk(result)
-    }
-}
-```
-
-## Development Workflow
-
-### Adding New FFI Functions
-
-1. **Implement Go function** in appropriate `./ffi/*.go` file:
-   ```go
-   func NewFunction(vm runtime.VM, args []*runtime.Object) *runtime.Object {
-       // Implementation
-   }
-   ```
-
-2. **Regenerate registry**:
-   ```bash
-   go generate ./bytecode/vm
-   ```
-
-3. **Add Ard binding** in `./std_lib/*.ard`:
-   ```ard
-   extern fn new_function(param: Type) ReturnType = "NewFunction"
-   ```
-
-4. **Build and test**:
-   ```bash
-   go build && go run main.go run test_program.ard
-   ```
-
-### Function Organization
-
-- **`ffi/runtime.go`**: Core runtime functions (print, input, panic, environment)
-- **`ffi/json.go`**: JSON encoding/decoding operations
-- **Future modules**: File system, networking, cryptography, etc.
-
-## Current Implementation Status
-
-### ✅ Completed Features
-
-- **Complete FFI syntax**: `extern fn` declarations with direct Go function bindings
-- **Type-safe integration**: Full type checking between Ard and Go
-- **Automatic discovery**: Code generation eliminates manual registration
-- **Runtime execution**: Direct function calls with uniform signatures
-- **VM interface**: Clean access to VM operations for complex type handling
-- **Error handling**: Panic recovery and Result type integration
-- **Standard library migration**: Proof-of-concept with `io`, `env`, and `json` modules
-
-### 🎯 Architecture Achievements
-
-- **Zero reflection**: All function calls are direct for maximum performance
-- **Clean separation**: Go implementations completely separate from Ard interfaces
-- **Scalable design**: Adding new functions requires no manual registration
-- **Type safety**: Full marshalling between Ard and Go type systems
-- **Backward compatibility**: All existing sample programs work unchanged
-
-### 📊 Testing Coverage
-
-- **Unit tests**: Comprehensive FFI registry and marshalling tests
-- **Integration tests**: All VM tests pass with FFI-based standard library
-- **Sample programs**: All existing samples work with new FFI system
-- **Performance**: Equivalent or better than previous hardcoded implementations
-
-## Future Expansions
-
-### Standard Library Migration Candidates
-
-- **File system**: `ard/fs` for file operations
-- **HTTP client**: `ard/http` for web requests
-- **Cryptography**: `ard/crypto` for hashing and encryption
-- **Date/time**: `ard/time` for temporal operations
-- **Regular expressions**: `ard/regex` for pattern matching
-
-### Enhancement Opportunities
-
-- **Cross-compilation**: JavaScript target support with same syntax
-- **Documentation generation**: Auto-generate docs from Go function comments
-- **IDE integration**: Navigate from Ard declarations to Go implementations
-- **Validation**: Check Ard bindings match Go function signatures
-
-## Conclusion
-
-The FFI system successfully achieves its primary goal: enabling the standard library to be written in Ard rather than Go while maintaining the performance and type safety of a compiled implementation. The automatic discovery and registration system provides an excellent developer experience that scales naturally as new functionality is added.
-
-This architecture positions Ard well for future growth, with a clean separation between the interpreted language layer and high-performance system operations implemented in Go.
+That gives standard library authors a much more idiomatic Go authoring model while preserving Ard's existing runtime representation and safety checks.

--- a/compiler/ffi/crypto.go
+++ b/compiler/ffi/crypto.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/akonwi/ard/checker"
 	"github.com/akonwi/ard/runtime"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/scrypt"
@@ -26,7 +25,7 @@ const (
 	defaultScryptSaltLen = 16
 )
 
-func CryptoMd5(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func CryptoMd5(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("CryptoMd5 expects 1 argument, got %d", len(args)))
 	}
@@ -35,7 +34,7 @@ func CryptoMd5(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeStr(hex.EncodeToString(sum[:]))
 }
 
-func CryptoSha256(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func CryptoSha256(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("CryptoSha256 expects 1 argument, got %d", len(args)))
 	}
@@ -44,7 +43,7 @@ func CryptoSha256(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeStr(hex.EncodeToString(sum[:]))
 }
 
-func CryptoSha512(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func CryptoSha512(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("CryptoSha512 expects 1 argument, got %d", len(args)))
 	}
@@ -53,7 +52,7 @@ func CryptoSha512(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeStr(hex.EncodeToString(sum[:]))
 }
 
-func CryptoHashPassword(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func CryptoHashPassword(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 && len(args) != 2 {
 		panic(fmt.Errorf("CryptoHashPassword expects 1 or 2 arguments, got %d", len(args)))
 	}
@@ -73,7 +72,7 @@ func CryptoHashPassword(args []*runtime.Object, _ checker.Type) *runtime.Object 
 	return runtime.MakeOk(runtime.MakeStr(string(hashed)))
 }
 
-func CryptoVerifyPassword(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func CryptoVerifyPassword(args []*runtime.Object) *runtime.Object {
 	if len(args) != 2 {
 		panic(fmt.Errorf("CryptoVerifyPassword expects 2 arguments, got %d", len(args)))
 	}
@@ -92,7 +91,7 @@ func CryptoVerifyPassword(args []*runtime.Object, _ checker.Type) *runtime.Objec
 	return runtime.MakeErr(runtime.MakeStr(err.Error()))
 }
 
-func CryptoScryptHash(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func CryptoScryptHash(args []*runtime.Object) *runtime.Object {
 	if len(args) < 1 || len(args) > 6 {
 		panic(fmt.Errorf("CryptoScryptHash expects 1 to 6 arguments, got %d", len(args)))
 	}
@@ -148,7 +147,7 @@ func CryptoScryptHash(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeOk(runtime.MakeStr(hash))
 }
 
-func CryptoScryptVerify(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func CryptoScryptVerify(args []*runtime.Object) *runtime.Object {
 	if len(args) < 2 || len(args) > 6 {
 		panic(fmt.Errorf("CryptoScryptVerify expects 2 to 6 arguments, got %d", len(args)))
 	}
@@ -228,7 +227,7 @@ func validateScryptParams(n, r, p, dkLen int) error {
 	return nil
 }
 
-func CryptoUUID(_ []*runtime.Object, _ checker.Type) *runtime.Object {
+func CryptoUUID(_ []*runtime.Object) *runtime.Object {
 	u := make([]byte, 16)
 	if _, err := rand.Read(u); err != nil {
 		panic(fmt.Errorf("CryptoUUID failed: %w", err))

--- a/compiler/ffi/crypto.go
+++ b/compiler/ffi/crypto.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/akonwi/ard/runtime"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/scrypt"
 	"golang.org/x/text/unicode/norm"
@@ -25,190 +24,151 @@ const (
 	defaultScryptSaltLen = 16
 )
 
-func CryptoMd5(args []*runtime.Object) *runtime.Object {
-	if len(args) != 1 {
-		panic(fmt.Errorf("CryptoMd5 expects 1 argument, got %d", len(args)))
-	}
-
-	sum := md5.Sum([]byte(args[0].AsString()))
-	return runtime.MakeStr(hex.EncodeToString(sum[:]))
+func CryptoMd5(input string) string {
+	sum := md5.Sum([]byte(input))
+	return hex.EncodeToString(sum[:])
 }
 
-func CryptoSha256(args []*runtime.Object) *runtime.Object {
-	if len(args) != 1 {
-		panic(fmt.Errorf("CryptoSha256 expects 1 argument, got %d", len(args)))
-	}
-
-	sum := sha256.Sum256([]byte(args[0].AsString()))
-	return runtime.MakeStr(hex.EncodeToString(sum[:]))
+func CryptoSha256(input string) string {
+	sum := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(sum[:])
 }
 
-func CryptoSha512(args []*runtime.Object) *runtime.Object {
-	if len(args) != 1 {
-		panic(fmt.Errorf("CryptoSha512 expects 1 argument, got %d", len(args)))
-	}
-
-	sum := sha512.Sum512([]byte(args[0].AsString()))
-	return runtime.MakeStr(hex.EncodeToString(sum[:]))
+func CryptoSha512(input string) string {
+	sum := sha512.Sum512([]byte(input))
+	return hex.EncodeToString(sum[:])
 }
 
-func CryptoHashPassword(args []*runtime.Object) *runtime.Object {
-	if len(args) != 1 && len(args) != 2 {
-		panic(fmt.Errorf("CryptoHashPassword expects 1 or 2 arguments, got %d", len(args)))
+func CryptoHashPassword(password string, cost *int) (string, error) {
+	hashCost := bcrypt.DefaultCost
+	if cost != nil {
+		hashCost = *cost
 	}
 
-	password := args[0].AsString()
-	cost := bcrypt.DefaultCost
-
-	if len(args) == 2 && !args[1].IsNone() {
-		cost = args[1].AsInt()
-	}
-
-	hashed, err := bcrypt.GenerateFromPassword([]byte(password), cost)
+	hashed, err := bcrypt.GenerateFromPassword([]byte(password), hashCost)
 	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+		return "", err
 	}
 
-	return runtime.MakeOk(runtime.MakeStr(string(hashed)))
+	return string(hashed), nil
 }
 
-func CryptoVerifyPassword(args []*runtime.Object) *runtime.Object {
-	if len(args) != 2 {
-		panic(fmt.Errorf("CryptoVerifyPassword expects 2 arguments, got %d", len(args)))
-	}
-
-	password := args[0].AsString()
-	hashed := args[1].AsString()
+func CryptoVerifyPassword(password, hashed string) (bool, error) {
 	err := bcrypt.CompareHashAndPassword([]byte(hashed), []byte(password))
 	if err == nil {
-		return runtime.MakeOk(runtime.MakeBool(true))
+		return true, nil
 	}
-
 	if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
-		return runtime.MakeOk(runtime.MakeBool(false))
+		return false, nil
 	}
-
-	return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	return false, err
 }
 
-func CryptoScryptHash(args []*runtime.Object) *runtime.Object {
-	if len(args) < 1 || len(args) > 6 {
-		panic(fmt.Errorf("CryptoScryptHash expects 1 to 6 arguments, got %d", len(args)))
+func CryptoScryptHash(password string, saltHex *string, n, r, p, dkLen *int) (string, error) {
+	password = norm.NFKC.String(password)
+
+	nVal := defaultScryptN
+	rVal := defaultScryptR
+	pVal := defaultScryptP
+	dkLenVal := defaultScryptDKLen
+
+	if n != nil {
+		nVal = *n
+	}
+	if r != nil {
+		rVal = *r
+	}
+	if p != nil {
+		pVal = *p
+	}
+	if dkLen != nil {
+		dkLenVal = *dkLen
 	}
 
-	password := norm.NFKC.String(args[0].AsString())
-
-	n := defaultScryptN
-	r := defaultScryptR
-	p := defaultScryptP
-	dkLen := defaultScryptDKLen
-
-	if len(args) >= 3 && !args[2].IsNone() {
-		n = args[2].AsInt()
-	}
-	if len(args) >= 4 && !args[3].IsNone() {
-		r = args[3].AsInt()
-	}
-	if len(args) >= 5 && !args[4].IsNone() {
-		p = args[4].AsInt()
-	}
-	if len(args) >= 6 && !args[5].IsNone() {
-		dkLen = args[5].AsInt()
+	if err := validateScryptParams(nVal, rVal, pVal, dkLenVal); err != nil {
+		return "", fmt.Errorf("scrypt_runtime: %s", err.Error())
 	}
 
-	if err := validateScryptParams(n, r, p, dkLen); err != nil {
-		return runtime.MakeErr(runtime.MakeStr(fmt.Sprintf("scrypt_runtime: %s", err.Error())))
-	}
-
-	var saltHex string
-	if len(args) >= 2 && !args[1].IsNone() {
-		saltHex = strings.TrimSpace(args[1].AsString())
-		decoded, err := hex.DecodeString(saltHex)
+	var saltHexValue string
+	if saltHex != nil {
+		saltHexValue = strings.TrimSpace(*saltHex)
+		decoded, err := hex.DecodeString(saltHexValue)
 		if err != nil {
-			return runtime.MakeErr(runtime.MakeStr(fmt.Sprintf("scrypt_runtime: invalid salt hex: %s", err.Error())))
+			return "", fmt.Errorf("scrypt_runtime: invalid salt hex: %s", err.Error())
 		}
 		if len(decoded) == 0 {
-			return runtime.MakeErr(runtime.MakeStr("scrypt_runtime: invalid salt hex: empty salt"))
+			return "", errors.New("scrypt_runtime: invalid salt hex: empty salt")
 		}
 	} else {
 		saltBytes := make([]byte, defaultScryptSaltLen)
 		if _, err := rand.Read(saltBytes); err != nil {
-			return runtime.MakeErr(runtime.MakeStr(fmt.Sprintf("scrypt_runtime: failed to generate salt: %s", err.Error())))
+			return "", fmt.Errorf("scrypt_runtime: failed to generate salt: %s", err.Error())
 		}
-		saltHex = hex.EncodeToString(saltBytes)
+		saltHexValue = hex.EncodeToString(saltBytes)
 	}
 
-	derived, err := scrypt.Key([]byte(password), []byte(saltHex), n, r, p, dkLen)
+	derived, err := scrypt.Key([]byte(password), []byte(saltHexValue), nVal, rVal, pVal, dkLenVal)
 	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(fmt.Sprintf("scrypt_runtime: %s", err.Error())))
+		return "", fmt.Errorf("scrypt_runtime: %s", err.Error())
 	}
 
-	hash := fmt.Sprintf("%s:%s", saltHex, hex.EncodeToString(derived))
-	return runtime.MakeOk(runtime.MakeStr(hash))
+	return fmt.Sprintf("%s:%s", saltHexValue, hex.EncodeToString(derived)), nil
 }
 
-func CryptoScryptVerify(args []*runtime.Object) *runtime.Object {
-	if len(args) < 2 || len(args) > 6 {
-		panic(fmt.Errorf("CryptoScryptVerify expects 2 to 6 arguments, got %d", len(args)))
+func CryptoScryptVerify(password, hash string, n, r, p, dkLen *int) (bool, error) {
+	password = norm.NFKC.String(password)
+	hash = strings.TrimSpace(hash)
+
+	nVal := defaultScryptN
+	rVal := defaultScryptR
+	pVal := defaultScryptP
+	dkLenVal := defaultScryptDKLen
+
+	if n != nil {
+		nVal = *n
+	}
+	if r != nil {
+		rVal = *r
+	}
+	if p != nil {
+		pVal = *p
+	}
+	if dkLen != nil {
+		dkLenVal = *dkLen
 	}
 
-	password := norm.NFKC.String(args[0].AsString())
-	hash := strings.TrimSpace(args[1].AsString())
-
-	n := defaultScryptN
-	r := defaultScryptR
-	p := defaultScryptP
-	dkLen := defaultScryptDKLen
-
-	if len(args) >= 3 && !args[2].IsNone() {
-		n = args[2].AsInt()
-	}
-	if len(args) >= 4 && !args[3].IsNone() {
-		r = args[3].AsInt()
-	}
-	if len(args) >= 5 && !args[4].IsNone() {
-		p = args[4].AsInt()
-	}
-	if len(args) >= 6 && !args[5].IsNone() {
-		dkLen = args[5].AsInt()
-	}
-
-	if err := validateScryptParams(n, r, p, dkLen); err != nil {
-		return runtime.MakeErr(runtime.MakeStr(fmt.Sprintf("scrypt_runtime: %s", err.Error())))
+	if err := validateScryptParams(nVal, rVal, pVal, dkLenVal); err != nil {
+		return false, fmt.Errorf("scrypt_runtime: %s", err.Error())
 	}
 
 	parts := strings.Split(hash, ":")
-	if len(parts) != 2 {
-		return runtime.MakeErr(runtime.MakeStr("scrypt_malformed_hash: expected format <salt_hex>:<derived_key_hex>"))
-	}
-	if parts[0] == "" || parts[1] == "" {
-		return runtime.MakeErr(runtime.MakeStr("scrypt_malformed_hash: expected format <salt_hex>:<derived_key_hex>"))
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return false, errors.New("scrypt_malformed_hash: expected format <salt_hex>:<derived_key_hex>")
 	}
 
 	saltHex := parts[0]
 	salt, err := hex.DecodeString(saltHex)
 	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(fmt.Sprintf("scrypt_malformed_hash: invalid salt hex: %s", err.Error())))
+		return false, fmt.Errorf("scrypt_malformed_hash: invalid salt hex: %s", err.Error())
 	}
 	if len(salt) == 0 {
-		return runtime.MakeErr(runtime.MakeStr("scrypt_malformed_hash: invalid salt hex: empty salt"))
+		return false, errors.New("scrypt_malformed_hash: invalid salt hex: empty salt")
 	}
 
 	storedKey, err := hex.DecodeString(parts[1])
 	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(fmt.Sprintf("scrypt_malformed_hash: invalid derived key hex: %s", err.Error())))
+		return false, fmt.Errorf("scrypt_malformed_hash: invalid derived key hex: %s", err.Error())
 	}
-	if len(storedKey) != dkLen {
-		return runtime.MakeErr(runtime.MakeStr(fmt.Sprintf("scrypt_malformed_hash: derived key length mismatch: expected %d bytes, got %d", dkLen, len(storedKey))))
+	if len(storedKey) != dkLenVal {
+		return false, fmt.Errorf("scrypt_malformed_hash: derived key length mismatch: expected %d bytes, got %d", dkLenVal, len(storedKey))
 	}
 
-	derived, err := scrypt.Key([]byte(password), []byte(saltHex), n, r, p, dkLen)
+	derived, err := scrypt.Key([]byte(password), []byte(saltHex), nVal, rVal, pVal, dkLenVal)
 	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(fmt.Sprintf("scrypt_runtime: %s", err.Error())))
+		return false, fmt.Errorf("scrypt_runtime: %s", err.Error())
 	}
 
-	matched := subtle.ConstantTimeCompare(derived, storedKey) == 1
-	return runtime.MakeOk(runtime.MakeBool(matched))
+	return subtle.ConstantTimeCompare(derived, storedKey) == 1, nil
 }
 
 func validateScryptParams(n, r, p, dkLen int) error {
@@ -227,7 +187,7 @@ func validateScryptParams(n, r, p, dkLen int) error {
 	return nil
 }
 
-func CryptoUUID(_ []*runtime.Object) *runtime.Object {
+func CryptoUUID() string {
 	u := make([]byte, 16)
 	if _, err := rand.Read(u); err != nil {
 		panic(fmt.Errorf("CryptoUUID failed: %w", err))
@@ -237,5 +197,5 @@ func CryptoUUID(_ []*runtime.Object) *runtime.Object {
 	u[6] = (u[6] & 0x0f) | 0x40
 	u[8] = (u[8] & 0x3f) | 0x80
 
-	return runtime.MakeStr(fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:16]))
+	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:16])
 }

--- a/compiler/ffi/decoders.go
+++ b/compiler/ffi/decoders.go
@@ -5,35 +5,56 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/akonwi/ard/checker"
 	"github.com/akonwi/ard/runtime"
 )
 
-func StrToDynamic(args []*runtime.Object, _ checker.Type) *runtime.Object {
+var (
+	decodeErrorType     checker.Type
+	decodeErrorTypeOnce sync.Once
+)
+
+func getDecodeErrorType() checker.Type {
+	decodeErrorTypeOnce.Do(func() {
+		mod, ok := checker.FindEmbeddedModule("ard/decode")
+		if !ok {
+			panic("failed to load ard/decode embedded module")
+		}
+		sym := mod.Get("Error")
+		if sym.Type == nil {
+			panic("Error type not found in ard/decode module")
+		}
+		decodeErrorType = sym.Type
+	})
+	return decodeErrorType
+}
+
+func StrToDynamic(args []*runtime.Object) *runtime.Object {
 	strValue := args[0].AsString()
 	return runtime.MakeDynamic(strValue)
 }
 
-func IntToDynamic(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func IntToDynamic(args []*runtime.Object) *runtime.Object {
 	intValue := args[0].AsInt()
 	return runtime.MakeDynamic(intValue)
 }
 
-func FloatToDynamic(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FloatToDynamic(args []*runtime.Object) *runtime.Object {
 	floatValue := args[0].AsFloat()
 	return runtime.MakeDynamic(floatValue)
 }
 
-func BoolToDynamic(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func BoolToDynamic(args []*runtime.Object) *runtime.Object {
 	return runtime.MakeDynamic(args[0].Raw())
 }
 
-func VoidToDynamic(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func VoidToDynamic(args []*runtime.Object) *runtime.Object {
 	return runtime.MakeDynamic(nil)
 }
 
-func ListToDynamic(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func ListToDynamic(args []*runtime.Object) *runtime.Object {
 	arg := args[0].AsList()
 	raw := make([]any, len(arg))
 	for i, item := range arg {
@@ -42,7 +63,7 @@ func ListToDynamic(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeDynamic(raw)
 }
 
-func MapToDynamic(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func MapToDynamic(args []*runtime.Object) *runtime.Object {
 	arg := args[0].AsMap()
 	raw := map[string]any{}
 	for key, val := range arg {
@@ -52,7 +73,7 @@ func MapToDynamic(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // Parse external data (JSON text) into Dynamic object
-func JsonToDynamic(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func JsonToDynamic(args []*runtime.Object) *runtime.Object {
 	jsonString := args[0].AsString()
 	jsonBytes := []byte(jsonString)
 
@@ -67,27 +88,27 @@ func JsonToDynamic(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // fn (Dynamic) Str!Error
-func DecodeString(args []*runtime.Object, outType checker.Type) *runtime.Object {
-	resultType := outType.(*checker.Result)
+func DecodeString(args []*runtime.Object) *runtime.Object {
+	errType := getDecodeErrorType()
 	arg := args[0]
 	data := arg.Raw()
 	if data == nil {
-		return runtime.MakeErr(makeError("Str", "null", resultType.Err()))
+		return runtime.MakeErr(makeError("Str", "null", errType))
 	}
 	if str, ok := data.(string); ok {
 		return runtime.MakeOk(runtime.MakeStr(str))
 	}
 
-	return runtime.MakeErr(makeError("Str", formatRawValueForError(arg.GoValue()), resultType.Err()))
+	return runtime.MakeErr(makeError("Str", formatRawValueForError(arg.GoValue()), errType))
 }
 
 // fn (Dynamic) Int!Error
-func DecodeInt(args []*runtime.Object, outType checker.Type) *runtime.Object {
-	resultType := outType.(*checker.Result)
+func DecodeInt(args []*runtime.Object) *runtime.Object {
+	errType := getDecodeErrorType()
 	arg := args[0]
 	data := arg.Raw()
 	if data == nil {
-		return runtime.MakeErr(makeError("Int", "null", resultType.Err()))
+		return runtime.MakeErr(makeError("Int", "null", errType))
 	}
 	if int, ok := data.(int); ok {
 		return runtime.MakeOk(runtime.MakeInt(int))
@@ -104,16 +125,16 @@ func DecodeInt(args []*runtime.Object, outType checker.Type) *runtime.Object {
 		}
 	}
 
-	return runtime.MakeErr(makeError("Int", formatRawValueForError(arg.GoValue()), resultType.Err()))
+	return runtime.MakeErr(makeError("Int", formatRawValueForError(arg.GoValue()), errType))
 }
 
 // fn (Dynamic) Float!Error
-func DecodeFloat(args []*runtime.Object, outType checker.Type) *runtime.Object {
-	resultType := outType.(*checker.Result)
+func DecodeFloat(args []*runtime.Object) *runtime.Object {
+	errType := getDecodeErrorType()
 	arg := args[0]
 	data := arg.Raw()
 	if data == nil {
-		return runtime.MakeErr(makeError("Float", "null", resultType.Err()))
+		return runtime.MakeErr(makeError("Float", "null", errType))
 	}
 	if float, ok := data.(float64); ok {
 		return runtime.MakeOk(runtime.MakeFloat(float))
@@ -126,32 +147,32 @@ func DecodeFloat(args []*runtime.Object, outType checker.Type) *runtime.Object {
 		return runtime.MakeOk(runtime.MakeFloat(float64(intVal)))
 	}
 
-	return runtime.MakeErr(makeError("Float", formatRawValueForError(arg.GoValue()), resultType.Err()))
+	return runtime.MakeErr(makeError("Float", formatRawValueForError(arg.GoValue()), errType))
 }
 
 // fn (Dynamic) Bool!Error
-func DecodeBool(args []*runtime.Object, outType checker.Type) *runtime.Object {
-	resultType := outType.(*checker.Result)
+func DecodeBool(args []*runtime.Object) *runtime.Object {
+	errType := getDecodeErrorType()
 	arg := args[0]
 	data := arg.Raw()
 	if data == nil {
-		return runtime.MakeErr(makeError("Bool", "null", resultType.Err()))
+		return runtime.MakeErr(makeError("Bool", "null", errType))
 	}
 	if val, ok := data.(bool); ok {
 		return runtime.MakeOk(runtime.MakeBool(val))
 	}
 
-	return runtime.MakeErr(makeError("Bool", formatRawValueForError(arg.GoValue()), resultType.Err()))
+	return runtime.MakeErr(makeError("Bool", formatRawValueForError(arg.GoValue()), errType))
 }
 
 // fn (Dynamic) Bool
-func IsNil(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func IsNil(args []*runtime.Object) *runtime.Object {
 	isNil := args[0].Raw() == nil
 	return runtime.MakeBool(isNil)
 }
 
 // fn (Dyanmic) [Dynamic]!Str
-func DynamicToList(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func DynamicToList(args []*runtime.Object) *runtime.Object {
 	arg := args[0]
 	data := arg.Raw()
 
@@ -171,7 +192,7 @@ func DynamicToList(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // fn (Dyanmic) [Dynamic:Dynamic]!Str
-func DynamicToMap(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func DynamicToMap(args []*runtime.Object) *runtime.Object {
 	arg := args[0]
 	data := arg.Raw()
 
@@ -191,7 +212,7 @@ func DynamicToMap(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // fn (Dynamic, Str) Dynamic!Str
-func ExtractField(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func ExtractField(args []*runtime.Object) *runtime.Object {
 	arg := args[0]
 	data := arg.Raw()
 

--- a/compiler/ffi/decoders.go
+++ b/compiler/ffi/decoders.go
@@ -31,29 +31,6 @@ func getDecodeErrorType() checker.Type {
 	return decodeErrorType
 }
 
-func StrToDynamic(args []*runtime.Object) *runtime.Object {
-	strValue := args[0].AsString()
-	return runtime.MakeDynamic(strValue)
-}
-
-func IntToDynamic(args []*runtime.Object) *runtime.Object {
-	intValue := args[0].AsInt()
-	return runtime.MakeDynamic(intValue)
-}
-
-func FloatToDynamic(args []*runtime.Object) *runtime.Object {
-	floatValue := args[0].AsFloat()
-	return runtime.MakeDynamic(floatValue)
-}
-
-func BoolToDynamic(args []*runtime.Object) *runtime.Object {
-	return runtime.MakeDynamic(args[0].Raw())
-}
-
-func VoidToDynamic(args []*runtime.Object) *runtime.Object {
-	return runtime.MakeDynamic(nil)
-}
-
 func ListToDynamic(args []*runtime.Object) *runtime.Object {
 	arg := args[0].AsList()
 	raw := make([]any, len(arg))

--- a/compiler/ffi/fs.go
+++ b/compiler/ffi/fs.go
@@ -1,16 +1,36 @@
 package ffi
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/akonwi/ard/checker"
 	"github.com/akonwi/ard/runtime"
 )
 
-func FS_Exists(args []*runtime.Object, _ checker.Type) *runtime.Object {
+var (
+	fsDirEntryType     checker.Type
+	fsDirEntryTypeOnce sync.Once
+)
+
+func getFSDirEntryType() checker.Type {
+	fsDirEntryTypeOnce.Do(func() {
+		mod, ok := checker.FindEmbeddedModule("ard/fs")
+		if !ok {
+			panic("failed to load ard/fs embedded module")
+		}
+		sym := mod.Get("DirEntry")
+		if sym.Type == nil {
+			panic("DirEntry type not found in ard/fs module")
+		}
+		fsDirEntryType = sym.Type
+	})
+	return fsDirEntryType
+}
+
+func FS_Exists(args []*runtime.Object) *runtime.Object {
 	path := args[0].Raw().(string)
 	if _, err := os.Stat(path); err == nil {
 		return runtime.MakeBool(true)
@@ -18,7 +38,7 @@ func FS_Exists(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeBool(false)
 }
 
-func FS_CreateFile(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FS_CreateFile(args []*runtime.Object) *runtime.Object {
 	path := args[0].Raw().(string)
 	if file, err := os.Create(path); err != nil {
 		return runtime.MakeErr(runtime.MakeStr(err.Error()))
@@ -28,7 +48,7 @@ func FS_CreateFile(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeOk(runtime.MakeBool(true))
 }
 
-func FS_WriteFile(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FS_WriteFile(args []*runtime.Object) *runtime.Object {
 	path := args[0].AsString()
 	content := args[1].AsString()
 	/* file permissions:
@@ -42,7 +62,7 @@ func FS_WriteFile(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeOk(runtime.Void())
 }
 
-func FS_AppendFile(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FS_AppendFile(args []*runtime.Object) *runtime.Object {
 	path := args[0].Raw().(string)
 	content := args[1].Raw().(string)
 	if file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644); err != nil {
@@ -57,7 +77,7 @@ func FS_AppendFile(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeOk(runtime.Void())
 }
 
-func FS_ReadFile(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FS_ReadFile(args []*runtime.Object) *runtime.Object {
 	path := args[0].Raw().(string)
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -66,7 +86,7 @@ func FS_ReadFile(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeOk(runtime.MakeStr(string(content)))
 }
 
-func FS_DeleteFile(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FS_DeleteFile(args []*runtime.Object) *runtime.Object {
 	path := args[0].Raw().(string)
 	if err := os.Remove(path); err != nil {
 		return runtime.MakeErr(runtime.MakeStr(err.Error()))
@@ -74,7 +94,7 @@ func FS_DeleteFile(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeOk(runtime.Void())
 }
 
-func FS_IsFile(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FS_IsFile(args []*runtime.Object) *runtime.Object {
 	path := args[0].Raw().(string)
 	info, err := os.Stat(path)
 	if err != nil {
@@ -83,7 +103,7 @@ func FS_IsFile(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeBool(!info.IsDir())
 }
 
-func FS_IsDir(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FS_IsDir(args []*runtime.Object) *runtime.Object {
 	path := args[0].Raw().(string)
 	info, err := os.Stat(path)
 	if err != nil {
@@ -92,7 +112,7 @@ func FS_IsDir(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeBool(info.IsDir())
 }
 
-func FS_Copy(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FS_Copy(args []*runtime.Object) *runtime.Object {
 	from := args[0].Raw().(string)
 	to := args[1].Raw().(string)
 
@@ -114,7 +134,7 @@ func FS_Copy(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeOk(runtime.Void())
 }
 
-func FS_Rename(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FS_Rename(args []*runtime.Object) *runtime.Object {
 	from := args[0].Raw().(string)
 	to := args[1].Raw().(string)
 	if err := os.Rename(from, to); err != nil {
@@ -123,7 +143,7 @@ func FS_Rename(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeOk(runtime.Void())
 }
 
-func FS_Cwd(_ []*runtime.Object, _ checker.Type) *runtime.Object {
+func FS_Cwd(_ []*runtime.Object) *runtime.Object {
 	dir, err := os.Getwd()
 	if err != nil {
 		return runtime.MakeErr(runtime.MakeStr(err.Error()))
@@ -131,7 +151,7 @@ func FS_Cwd(_ []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeOk(runtime.MakeStr(dir))
 }
 
-func FS_Abs(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FS_Abs(args []*runtime.Object) *runtime.Object {
 	path := args[0].Raw().(string)
 	absPath, err := filepath.Abs(path)
 	if err != nil {
@@ -140,7 +160,7 @@ func FS_Abs(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeOk(runtime.MakeStr(absPath))
 }
 
-func FS_CreateDir(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FS_CreateDir(args []*runtime.Object) *runtime.Object {
 	path := args[0].Raw().(string)
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return runtime.MakeErr(runtime.MakeStr(err.Error()))
@@ -148,7 +168,7 @@ func FS_CreateDir(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeOk(runtime.Void())
 }
 
-func FS_DeleteDir(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FS_DeleteDir(args []*runtime.Object) *runtime.Object {
 	path := args[0].Raw().(string)
 	if err := os.RemoveAll(path); err != nil {
 		return runtime.MakeErr(runtime.MakeStr(err.Error()))
@@ -156,23 +176,14 @@ func FS_DeleteDir(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeOk(runtime.Void())
 }
 
-func FS_ListDir(args []*runtime.Object, outType checker.Type) *runtime.Object {
+func FS_ListDir(args []*runtime.Object) *runtime.Object {
 	path := args[0].Raw().(string)
 	entries, err := os.ReadDir(path)
 	if err != nil {
 		return runtime.MakeErr(runtime.MakeStr(err.Error()))
 	}
 
-	// Extract the DirEntry struct type from the result type
-	resultType, ok := outType.(*checker.Result)
-	if !ok {
-		panic(fmt.Sprintf("Unexpected return type of list_dir(): %s", outType))
-	}
-	listType, ok := resultType.Val().(*checker.List)
-	if !ok {
-		panic(fmt.Sprintf("Unexpected return Result::ok type of list_dir(): %s", resultType.Val()))
-	}
-	dirEntryType := listType.Of()
+	dirEntryType := getFSDirEntryType()
 
 	var dirEntries []*runtime.Object
 	for _, entry := range entries {

--- a/compiler/ffi/fs.go
+++ b/compiler/ffi/fs.go
@@ -30,150 +30,105 @@ func getFSDirEntryType() checker.Type {
 	return fsDirEntryType
 }
 
-func FS_Exists(args []*runtime.Object) *runtime.Object {
-	path := args[0].Raw().(string)
-	if _, err := os.Stat(path); err == nil {
-		return runtime.MakeBool(true)
-	}
-	return runtime.MakeBool(false)
+func FS_Exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
-func FS_CreateFile(args []*runtime.Object) *runtime.Object {
-	path := args[0].Raw().(string)
-	if file, err := os.Create(path); err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
-	} else {
-		file.Close()
+func FS_CreateFile(path string) (bool, error) {
+	file, err := os.Create(path)
+	if err != nil {
+		return false, err
 	}
-	return runtime.MakeOk(runtime.MakeBool(true))
+	file.Close()
+	return true, nil
 }
 
-func FS_WriteFile(args []*runtime.Object) *runtime.Object {
-	path := args[0].AsString()
-	content := args[1].AsString()
+func FS_WriteFile(path, content string) error {
 	/* file permissions:
 	- `6` (owner): read (4) + write (2) = 6
 	- `4` (group): read only
 	- `4` (others): read only
 	*/
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
-	}
-	return runtime.MakeOk(runtime.Void())
+	return os.WriteFile(path, []byte(content), 0644)
 }
 
-func FS_AppendFile(args []*runtime.Object) *runtime.Object {
-	path := args[0].Raw().(string)
-	content := args[1].Raw().(string)
-	if file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644); err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
-	} else {
-		if _, err := file.WriteString(content); err != nil {
-			file.Close()
-			return runtime.MakeErr(runtime.MakeStr(err.Error()))
-		}
+func FS_AppendFile(path, content string) error {
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	if _, err := file.WriteString(content); err != nil {
 		file.Close()
+		return err
 	}
-	return runtime.MakeOk(runtime.Void())
+	file.Close()
+	return nil
 }
 
-func FS_ReadFile(args []*runtime.Object) *runtime.Object {
-	path := args[0].Raw().(string)
+func FS_ReadFile(path string) (string, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+		return "", err
 	}
-	return runtime.MakeOk(runtime.MakeStr(string(content)))
+	return string(content), nil
 }
 
-func FS_DeleteFile(args []*runtime.Object) *runtime.Object {
-	path := args[0].Raw().(string)
-	if err := os.Remove(path); err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
-	}
-	return runtime.MakeOk(runtime.Void())
+func FS_DeleteFile(path string) error {
+	return os.Remove(path)
 }
 
-func FS_IsFile(args []*runtime.Object) *runtime.Object {
-	path := args[0].Raw().(string)
+func FS_IsFile(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {
-		return runtime.MakeBool(false)
+		return false
 	}
-	return runtime.MakeBool(!info.IsDir())
+	return !info.IsDir()
 }
 
-func FS_IsDir(args []*runtime.Object) *runtime.Object {
-	path := args[0].Raw().(string)
+func FS_IsDir(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {
-		return runtime.MakeBool(false)
+		return false
 	}
-	return runtime.MakeBool(info.IsDir())
+	return info.IsDir()
 }
 
-func FS_Copy(args []*runtime.Object) *runtime.Object {
-	from := args[0].Raw().(string)
-	to := args[1].Raw().(string)
-
+func FS_Copy(from, to string) error {
 	src, err := os.Open(from)
 	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+		return err
 	}
 	defer src.Close()
 
 	dst, err := os.Create(to)
 	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+		return err
 	}
 	defer dst.Close()
 
-	if _, err := io.Copy(dst, src); err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
-	}
-	return runtime.MakeOk(runtime.Void())
+	_, err = io.Copy(dst, src)
+	return err
 }
 
-func FS_Rename(args []*runtime.Object) *runtime.Object {
-	from := args[0].Raw().(string)
-	to := args[1].Raw().(string)
-	if err := os.Rename(from, to); err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
-	}
-	return runtime.MakeOk(runtime.Void())
+func FS_Rename(from, to string) error {
+	return os.Rename(from, to)
 }
 
-func FS_Cwd(_ []*runtime.Object) *runtime.Object {
-	dir, err := os.Getwd()
-	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
-	}
-	return runtime.MakeOk(runtime.MakeStr(dir))
+func FS_Cwd() (string, error) {
+	return os.Getwd()
 }
 
-func FS_Abs(args []*runtime.Object) *runtime.Object {
-	path := args[0].Raw().(string)
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
-	}
-	return runtime.MakeOk(runtime.MakeStr(absPath))
+func FS_Abs(path string) (string, error) {
+	return filepath.Abs(path)
 }
 
-func FS_CreateDir(args []*runtime.Object) *runtime.Object {
-	path := args[0].Raw().(string)
-	if err := os.MkdirAll(path, 0755); err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
-	}
-	return runtime.MakeOk(runtime.Void())
+func FS_CreateDir(path string) error {
+	return os.MkdirAll(path, 0755)
 }
 
-func FS_DeleteDir(args []*runtime.Object) *runtime.Object {
-	path := args[0].Raw().(string)
-	if err := os.RemoveAll(path); err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
-	}
-	return runtime.MakeOk(runtime.Void())
+func FS_DeleteDir(path string) error {
+	return os.RemoveAll(path)
 }
 
 func FS_ListDir(args []*runtime.Object) *runtime.Object {

--- a/compiler/ffi/http.go
+++ b/compiler/ffi/http.go
@@ -52,27 +52,27 @@ func requestBodyMaybe(r *http.Request) *runtime.Object {
 }
 
 // fn (req: Dynamic) Str
-func GetReqPath(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func GetReqPath(args []*runtime.Object) *runtime.Object {
 	req := args[0].Raw().(*http.Request)
 	return runtime.MakeStr(req.URL.Path)
 }
 
 // fn (req: Dynamic, name: Str) Str
-func GetPathValue(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func GetPathValue(args []*runtime.Object) *runtime.Object {
 	req := args[0].Raw().(*http.Request)
 	name := args[1].Raw().(string)
 	return runtime.MakeStr(req.PathValue(name))
 }
 
 // fn (req: Dynamic, name: Str) Str
-func GetQueryParam(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func GetQueryParam(args []*runtime.Object) *runtime.Object {
 	req := args[0].Raw().(*http.Request)
 	name := args[1].Raw().(string)
 	return runtime.MakeStr(req.URL.Query().Get(name))
 }
 
 // fn (method: Str, url: Str, body: Dynamic?, headers: [Str:Str], timeout: Int?) Response!Str
-func HTTP_Send(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func HTTP_Send(args []*runtime.Object) *runtime.Object {
 	method := args[0].AsString()
 	url := args[1].AsString()
 	body := func() io.Reader {
@@ -158,7 +158,7 @@ func convertToGoPattern(path string) string {
 }
 
 // fn serve(port: Int, handlers: [Str:fn(Request, mut Response)])
-func HTTP_Serve(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func HTTP_Serve(args []*runtime.Object) *runtime.Object {
 	port := args[0].AsInt()
 	handlers := args[1].AsMap()
 

--- a/compiler/ffi/http.go
+++ b/compiler/ffi/http.go
@@ -5,11 +5,32 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/akonwi/ard/checker"
 	"github.com/akonwi/ard/runtime"
 )
+
+var (
+	httpResponseType     checker.Type
+	httpResponseTypeOnce sync.Once
+)
+
+func getHTTPResponseType() checker.Type {
+	httpResponseTypeOnce.Do(func() {
+		mod, ok := checker.FindEmbeddedModule("ard/http")
+		if !ok {
+			panic("failed to load ard/http embedded module")
+		}
+		sym := mod.Get("Response")
+		if sym.Type == nil {
+			panic("Response type not found in ard/http module")
+		}
+		httpResponseType = sym.Type
+	})
+	return httpResponseType
+}
 
 func requestBodyMaybe(r *http.Request) *runtime.Object {
 	body := runtime.MakeNone(checker.Dynamic)
@@ -51,7 +72,7 @@ func GetQueryParam(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // fn (method: Str, url: Str, body: Dynamic?, headers: [Str:Str], timeout: Int?) Response!Str
-func HTTP_Send(args []*runtime.Object, returnType checker.Type) *runtime.Object {
+func HTTP_Send(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	method := args[0].AsString()
 	url := args[1].AsString()
 	body := func() io.Reader {
@@ -115,9 +136,7 @@ func HTTP_Send(args []*runtime.Object, returnType checker.Type) *runtime.Object 
 		"body":    runtime.MakeStr(bodyStr),
 	}
 
-	resultType := returnType.(*checker.Result)
-
-	return runtime.MakeOk(runtime.MakeStruct(resultType.Val(), respMap))
+	return runtime.MakeOk(runtime.MakeStruct(getHTTPResponseType(), respMap))
 }
 
 /*

--- a/compiler/ffi/json.go
+++ b/compiler/ffi/json.go
@@ -3,12 +3,11 @@ package ffi
 import (
 	"encoding/json/v2"
 
-	"github.com/akonwi/ard/checker"
 	"github.com/akonwi/ard/runtime"
 )
 
 // Encode an Ard value into a JSON string
-func JsonEncode(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func JsonEncode(args []*runtime.Object) *runtime.Object {
 	bytes, err := json.Marshal(args[0])
 	if err != nil {
 		return runtime.MakeErr(runtime.MakeStr(err.Error()))

--- a/compiler/ffi/prelude.go
+++ b/compiler/ffi/prelude.go
@@ -9,7 +9,7 @@ import (
 )
 
 // FloatFromStr parses a string to a float, returning Float? (Maybe<Float>)
-func FloatFromStr(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FloatFromStr(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic("FloatFromStr expects 1 argument")
 	}
@@ -23,7 +23,7 @@ func FloatFromStr(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // FloatFromInt converts an integer to a float
-func FloatFromInt(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FloatFromInt(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic("FloatFromInt expects 1 argument")
 	}
@@ -33,7 +33,7 @@ func FloatFromInt(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // FloatFloor returns the floor of a float
-func FloatFloor(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func FloatFloor(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic("FloatFloor expects 1 argument")
 	}
@@ -42,7 +42,7 @@ func FloatFloor(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeFloat(math.Floor(floatVal))
 }
 
-func IntFromStr(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func IntFromStr(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic("IntFromStr expects 1 argument")
 	}

--- a/compiler/ffi/prelude.go
+++ b/compiler/ffi/prelude.go
@@ -1,7 +1,6 @@
 package ffi
 
 import (
-	"fmt"
 	"math"
 	"strconv"
 
@@ -56,10 +55,4 @@ func IntFromStr(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return out
 }
 
-func NewList(args []*runtime.Object, ret checker.Type) *runtime.Object {
-	retList, ok := ret.(*checker.List)
-	if !ok {
-		panic(fmt.Errorf("expected *checker.List, got %T", ret))
-	}
-	return runtime.MakeList(retList.Of())
-}
+

--- a/compiler/ffi/prelude.go
+++ b/compiler/ffi/prelude.go
@@ -3,56 +3,30 @@ package ffi
 import (
 	"math"
 	"strconv"
-
-	"github.com/akonwi/ard/checker"
-	"github.com/akonwi/ard/runtime"
 )
 
 // FloatFromStr parses a string to a float, returning Float? (Maybe<Float>)
-func FloatFromStr(args []*runtime.Object) *runtime.Object {
-	if len(args) != 1 {
-		panic("FloatFromStr expects 1 argument")
-	}
-
-	str := args[0].AsString()
-	out := runtime.MakeNone(checker.Float)
+func FloatFromStr(str string) *float64 {
 	if value, err := strconv.ParseFloat(str, 64); err == nil {
-		out = out.ToSome(value)
+		return &value
 	}
-	return out
+	return nil
 }
 
 // FloatFromInt converts an integer to a float
-func FloatFromInt(args []*runtime.Object) *runtime.Object {
-	if len(args) != 1 {
-		panic("FloatFromInt expects 1 argument")
-	}
-
-	intVal := args[0].AsInt()
-	return runtime.MakeFloat(float64(intVal))
+func FloatFromInt(intVal int) float64 {
+	return float64(intVal)
 }
 
 // FloatFloor returns the floor of a float
-func FloatFloor(args []*runtime.Object) *runtime.Object {
-	if len(args) != 1 {
-		panic("FloatFloor expects 1 argument")
-	}
-
-	floatVal := args[0].AsFloat()
-	return runtime.MakeFloat(math.Floor(floatVal))
+func FloatFloor(floatVal float64) float64 {
+	return math.Floor(floatVal)
 }
 
-func IntFromStr(args []*runtime.Object) *runtime.Object {
-	if len(args) != 1 {
-		panic("IntFromStr expects 1 argument")
-	}
-
-	str := args[0].AsString()
-	out := runtime.MakeNone(checker.Int)
+// IntFromStr parses a string to an int, returning Int? (Maybe<Int>)
+func IntFromStr(str string) *int {
 	if value, err := strconv.Atoi(str); err == nil {
-		return out.ToSome(value)
+		return &value
 	}
-	return out
+	return nil
 }
-
-

--- a/compiler/ffi/runtime.go
+++ b/compiler/ffi/runtime.go
@@ -7,134 +7,65 @@ import (
 	"sync"
 	"time"
 
-	"github.com/akonwi/ard/checker"
 	"github.com/akonwi/ard/runtime"
 )
 
-var (
-	osArgsMu       sync.RWMutex
-	osArgsOverride []string
-)
-
-func SetOSArgs(args []string) {
-	osArgsMu.Lock()
-	defer osArgsMu.Unlock()
-
-	if args == nil {
-		osArgsOverride = nil
-		return
-	}
-
-	osArgsOverride = append([]string(nil), args...)
-}
-
-func currentOSArgs() []string {
-	osArgsMu.RLock()
-	override := append([]string(nil), osArgsOverride...)
-	osArgsMu.RUnlock()
-	if override != nil {
-		return override
-	}
-	return append([]string(nil), os.Args...)
-}
-
 // Runtime module FFI functions
 
-func OsArgs(_ []*runtime.Object) *runtime.Object {
-	args := currentOSArgs()
-	var out []*runtime.Object = make([]*runtime.Object, len(args))
-	for i, a := range args {
-		out[i] = runtime.MakeStr(a)
-	}
-	return runtime.MakeList(checker.Str, out...)
+func OsArgs() []string {
+	return runtime.CurrentOSArgs()
 }
 
 // Print prints a value to stdout
-func Print(args []*runtime.Object) *runtime.Object {
-	if len(args) != 1 {
-		panic(fmt.Errorf("print expects 1 argument, got %d", len(args)))
-	}
-
-	str := args[0].AsString()
-
+func Print(str string) {
 	fmt.Println(str)
-	return runtime.Void()
 }
 
 // ReadLine reads a line from stdin
-func ReadLine(args []*runtime.Object) *runtime.Object {
-	if len(args) != 0 {
-		panic(fmt.Errorf("read_line expects 0 arguments, got %d", len(args)))
-	}
-
+func ReadLine() (string, error) {
 	scanner := bufio.NewScanner(os.Stdin)
-
 	if !scanner.Scan() {
-		// No more input available or EOF
 		if err := scanner.Err(); err != nil {
-			return runtime.MakeErr(runtime.MakeStr(err.Error()))
+			return "", err
 		}
 		// EOF - return empty string as success
-		return runtime.MakeOk(runtime.MakeStr(""))
+		return "", nil
 	}
-
-	return runtime.MakeOk(runtime.MakeStr(scanner.Text()))
+	return scanner.Text(), nil
 }
 
 // PanicWithMessage panics with a message
-func PanicWithMessage(args []*runtime.Object) *runtime.Object {
-	if len(args) != 1 {
-		panic(fmt.Errorf("panic expects 1 argument, got %d", len(args)))
-	}
-
-	message, ok := args[0].Raw().(string)
-	if !ok {
-		panic(fmt.Errorf("panic expects string argument, got %T", args[0].Raw()))
-	}
-
+func PanicWithMessage(message string) {
 	panic(message)
 }
 
 // Environment module FFI functions
 
 // EnvGet retrieves an environment variable
-func EnvGet(args []*runtime.Object) *runtime.Object {
-	if len(args) != 1 {
-		panic(fmt.Errorf("get expects 1 argument, got %d", len(args)))
-	}
-
-	key, ok := args[0].Raw().(string)
-	if !ok {
-		panic(fmt.Errorf("get expects string argument, got %T", args[0].Raw()))
-	}
-
+func EnvGet(key string) *string {
 	value, exists := os.LookupEnv(key)
 	if !exists {
-		// Return None
-		return runtime.MakeNone(checker.Str)
+		return nil
 	}
-
-	// Return Some(value)
-	return runtime.MakeNone(checker.Str).ToSome(value)
+	return &value
 }
 
-func GetTodayString(_ []*runtime.Object) *runtime.Object {
+func GetTodayString() string {
 	year, month, day := time.Now().Date()
-	return runtime.MakeStr(fmt.Sprintf("%d-%02d-%02d", year, month, day))
+	return fmt.Sprintf("%d-%02d-%02d", year, month, day)
 }
 
 // Chrono module FFI functions
 
 // fn now() Int
-func Now(_ []*runtime.Object) *runtime.Object {
-	seconds := time.Now().Unix()
-	return runtime.MakeInt(int(seconds))
+func Now() int {
+	return int(time.Now().Unix())
 }
 
-// fn (ns: Int) Void
-func Sleep(args []*runtime.Object) *runtime.Object {
-	time.Sleep(time.Duration(args[0].AsInt()))
-	return runtime.Void()
+// fn sleep(ms: Int) Void — the Ard param is named "ms" but the
+// duration module converts to nanoseconds, so the value is actually ns.
+func Sleep(ns int) {
+	time.Sleep(time.Duration(ns))
 }
 
 // fn (wg: Dynamic) Void

--- a/compiler/ffi/runtime.go
+++ b/compiler/ffi/runtime.go
@@ -40,7 +40,7 @@ func currentOSArgs() []string {
 
 // Runtime module FFI functions
 
-func OsArgs(_ []*runtime.Object, _ checker.Type) *runtime.Object {
+func OsArgs(_ []*runtime.Object) *runtime.Object {
 	args := currentOSArgs()
 	var out []*runtime.Object = make([]*runtime.Object, len(args))
 	for i, a := range args {
@@ -50,7 +50,7 @@ func OsArgs(_ []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // Print prints a value to stdout
-func Print(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func Print(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("print expects 1 argument, got %d", len(args)))
 	}
@@ -62,7 +62,7 @@ func Print(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // ReadLine reads a line from stdin
-func ReadLine(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func ReadLine(args []*runtime.Object) *runtime.Object {
 	if len(args) != 0 {
 		panic(fmt.Errorf("read_line expects 0 arguments, got %d", len(args)))
 	}
@@ -82,7 +82,7 @@ func ReadLine(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // PanicWithMessage panics with a message
-func PanicWithMessage(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func PanicWithMessage(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("panic expects 1 argument, got %d", len(args)))
 	}
@@ -98,7 +98,7 @@ func PanicWithMessage(args []*runtime.Object, _ checker.Type) *runtime.Object {
 // Environment module FFI functions
 
 // EnvGet retrieves an environment variable
-func EnvGet(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func EnvGet(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("get expects 1 argument, got %d", len(args)))
 	}
@@ -118,7 +118,7 @@ func EnvGet(args []*runtime.Object, _ checker.Type) *runtime.Object {
 	return runtime.MakeNone(checker.Str).ToSome(value)
 }
 
-func GetTodayString(_ []*runtime.Object, _ checker.Type) *runtime.Object {
+func GetTodayString(_ []*runtime.Object) *runtime.Object {
 	year, month, day := time.Now().Date()
 	return runtime.MakeStr(fmt.Sprintf("%d-%02d-%02d", year, month, day))
 }
@@ -126,26 +126,26 @@ func GetTodayString(_ []*runtime.Object, _ checker.Type) *runtime.Object {
 // Chrono module FFI functions
 
 // fn now() Int
-func Now(_ []*runtime.Object, _ checker.Type) *runtime.Object {
+func Now(_ []*runtime.Object) *runtime.Object {
 	seconds := time.Now().Unix()
 	return runtime.MakeInt(int(seconds))
 }
 
 // fn (ns: Int) Void
-func Sleep(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func Sleep(args []*runtime.Object) *runtime.Object {
 	time.Sleep(time.Duration(args[0].AsInt()))
 	return runtime.Void()
 }
 
 // fn (wg: Dynamic) Void
-func WaitFor(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func WaitFor(args []*runtime.Object) *runtime.Object {
 	wg := args[0].Raw().(*sync.WaitGroup)
 	wg.Wait()
 	return runtime.Void()
 }
 
 // fn (fibers: [Fiber]) Void
-func Join(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func Join(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("join expects 1 argument, got %d", len(args)))
 	}

--- a/compiler/ffi/sql.go
+++ b/compiler/ffi/sql.go
@@ -30,7 +30,7 @@ type sqlTransaction struct {
 // - SQLite: "file:test.db" or "test.db"
 // - PostgreSQL: "postgres://user:password@localhost:5432/dbname"
 // - MySQL: "user:password@tcp(localhost:3306)/dbname"
-func SqlCreateConnection(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func SqlCreateConnection(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("open expects 1 argument, got %d", len(args)))
 	}
@@ -75,7 +75,7 @@ func detectDriver(connStr string) string {
 }
 
 // SqlClose closes a database connection
-func SqlClose(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func SqlClose(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("close expects 1 argument, got %d", len(args)))
 	}
@@ -94,7 +94,7 @@ func SqlClose(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // Extract parameter names from a sql expression in the order they appear
-func SqlExtractParams(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func SqlExtractParams(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("extract_params expects 1 argument, got %d", len(args)))
 	}
@@ -271,7 +271,7 @@ func executeQuery(runner sqlRunner, sqlStr string, values []any) *runtime.Object
 }
 
 // executes a query and returns the rows
-func SqlQuery(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func SqlQuery(args []*runtime.Object) *runtime.Object {
 	if len(args) != 3 {
 		panic(fmt.Errorf("query_run expects 3 arguments, got %d", len(args)))
 	}
@@ -297,7 +297,7 @@ func SqlQuery(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // executes a query and doesn't return rows
-func SqlExecute(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func SqlExecute(args []*runtime.Object) *runtime.Object {
 	if len(args) != 3 {
 		panic(fmt.Errorf("query_run expects 3 arguments, got %d", len(args)))
 	}
@@ -326,7 +326,7 @@ func SqlExecute(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // SqlBeginTx begins a new transaction
-func SqlBeginTx(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func SqlBeginTx(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("begin expects 1 argument, got %d", len(args)))
 	}
@@ -356,7 +356,7 @@ func SqlBeginTx(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // SqlCommit commits a transaction
-func SqlCommit(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func SqlCommit(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("commit expects 1 argument, got %d", len(args)))
 	}
@@ -375,7 +375,7 @@ func SqlCommit(args []*runtime.Object, _ checker.Type) *runtime.Object {
 }
 
 // SqlRollback rolls back a transaction
-func SqlRollback(args []*runtime.Object, _ checker.Type) *runtime.Object {
+func SqlRollback(args []*runtime.Object) *runtime.Object {
 	if len(args) != 1 {
 		panic(fmt.Errorf("rollback expects 1 argument, got %d", len(args)))
 	}

--- a/compiler/ffi/sql.go
+++ b/compiler/ffi/sql.go
@@ -94,13 +94,7 @@ func SqlClose(args []*runtime.Object) *runtime.Object {
 }
 
 // Extract parameter names from a sql expression in the order they appear
-func SqlExtractParams(args []*runtime.Object) *runtime.Object {
-	if len(args) != 1 {
-		panic(fmt.Errorf("extract_params expects 1 argument, got %d", len(args)))
-	}
-
-	sqlStr := args[0].AsString()
-
+func SqlExtractParams(sqlStr string) []string {
 	// Split SQL into tokens by multiple delimiters
 	delimiters := []string{" ", "(", ")", ",", ";", "=", "<", ">", "!", "\t", "\n", "\r"}
 	tokens := splitSQLByMultipleDelimiters(sqlStr, delimiters)
@@ -119,13 +113,7 @@ func SqlExtractParams(args []*runtime.Object) *runtime.Object {
 		}
 	}
 
-	// Convert to runtime objects
-	var result []*runtime.Object
-	for _, paramName := range paramNames {
-		result = append(result, runtime.MakeStr(paramName))
-	}
-
-	return runtime.MakeList(checker.Str, result...)
+	return paramNames
 }
 
 // splitSQLByMultipleDelimiters is a helper function to split string by multiple delimiters

--- a/compiler/main.go
+++ b/compiler/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/akonwi/ard/bytecode"
 	bytecodevm "github.com/akonwi/ard/bytecode/vm"
 	"github.com/akonwi/ard/checker"
-	"github.com/akonwi/ard/ffi"
 	"github.com/akonwi/ard/formatter"
 	"github.com/akonwi/ard/parse"
 	"github.com/akonwi/ard/runtime"
@@ -71,9 +70,9 @@ func main() {
 				fmt.Println(err)
 				os.Exit(1)
 			}
-			ffi.SetOSArgs(os.Args)
+			runtime.SetOSArgs(os.Args)
 			_, runErr := bytecodevm.New(program).Run("main")
-			ffi.SetOSArgs(nil)
+			runtime.SetOSArgs(nil)
 			if runErr != nil {
 				fmt.Println(runErr)
 				os.Exit(1)
@@ -536,8 +535,8 @@ func (t discoveredTest) displayName() string {
 }
 
 func runCompiledTest(program bytecode.Program, test discoveredTest) testOutcome {
-	ffi.SetOSArgs(os.Args)
-	defer ffi.SetOSArgs(nil)
+	runtime.SetOSArgs(os.Args)
+	defer runtime.SetOSArgs(nil)
 
 	res, err := bytecodevm.New(program).Run(test.name)
 	if err != nil {
@@ -640,9 +639,9 @@ func maybeRunEmbedded() bool {
 		fmt.Fprintln(os.Stderr, "Invalid bytecode:", err)
 		os.Exit(1)
 	}
-	ffi.SetOSArgs(argsForEmbeddedProgram(os.Args))
+	runtime.SetOSArgs(argsForEmbeddedProgram(os.Args))
 	_, runErr := bytecodevm.New(program).Run("main")
-	ffi.SetOSArgs(nil)
+	runtime.SetOSArgs(nil)
 	if runErr != nil {
 		fmt.Fprintln(os.Stderr, runErr)
 		os.Exit(1)

--- a/compiler/runtime/os_args.go
+++ b/compiler/runtime/os_args.go
@@ -1,0 +1,33 @@
+package runtime
+
+import (
+	"os"
+	"sync"
+)
+
+var (
+	osArgsMu       sync.RWMutex
+	osArgsOverride []string
+)
+
+func SetOSArgs(args []string) {
+	osArgsMu.Lock()
+	defer osArgsMu.Unlock()
+
+	if args == nil {
+		osArgsOverride = nil
+		return
+	}
+
+	osArgsOverride = append([]string(nil), args...)
+}
+
+func CurrentOSArgs() []string {
+	osArgsMu.RLock()
+	override := append([]string(nil), osArgsOverride...)
+	osArgsMu.RUnlock()
+	if override != nil {
+		return override
+	}
+	return append([]string(nil), os.Args...)
+}


### PR DESCRIPTION
## Summary

Refactor the FFI system so Go functions can be written with plain Go types instead of `func([]*runtime.Object) *runtime.Object`, with the code generator handling marshalling automatically.

## Changes

### Two-tier FFI system
FFI functions now support two styles:
- **Idiomatic** — plain Go types (`string`, `int`, `bool`, `error`, `*string`, `[]string`, etc.). The generator creates a `_ffi_` wrapper in `registry.gen.go` that handles unwrapping args and wrapping returns.
- **Raw** — `func([]*runtime.Object) *runtime.Object` for complex cases (HTTP, SQL execution, decoders, closures, embedded module types).

The generator **errors on any exported function** in `ffi/` that matches neither tier — no silent skipping.

### Scalar-to-Dynamic as VM instruction
Replaced 5 `*ToDynamic` FFI functions (`StrToDynamic`, `IntToDynamic`, `FloatToDynamic`, `BoolToDynamic`, `VoidToDynamic`) with a single `OpToDynamic` VM instruction. These were pure type-wrapping operations that did not need the FFI call overhead.

### Preparatory cleanup
- Dropped `returnType` from the `FFIFunc` signature (all FFI functions that needed Ard types now look them up via `checker.FindEmbeddedModule` with `sync.Once` caching)
- Moved `SetOSArgs`/`CurrentOSArgs` from `ffi/` to `runtime/` so `ffi/` contains only FFI-bound functions

## Results

| Metric | Before | After |
|---|---|---|
| FFI functions | 67 | 62 |
| Raw | 67 | 27 |
| Idiomatic | 0 | 35 |
| VM primitives | 0 | 5 (OpToDynamic) |

### Supported idiomatic types

**Params:** `string`, `int`, `float64`, `bool`, pointers (`*string` etc. → Maybe), slices (`[]string` etc. → List), `map[string]string`

**Returns:** same scalars/pointers/slices/maps, plus `error` → `Void!Str`, `(T, error)` → `T!Str`

### Files migrated to idiomatic Go
- `ffi/crypto.go` — all 8 functions
- `ffi/fs.go` — 15 of 16 (FS_ListDir stays raw)
- `ffi/prelude.go` — all 4 functions
- `ffi/runtime.go` — 8 of 10 (WaitFor, Join stay raw)
- `ffi/sql.go` — SqlExtractParams

## Testing
- All existing tests pass
- HTTP server sample manually verified (build + curl)
- `go generate ./bytecode/vm` produces correct registry
