### PR TITLE
Fix runtime generic return kinds

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 # TODO
-- [ ] Generic type variables emit KindDynamic at runtime instead of the resolved concrete kind. When a generic function like `list::find` returns a value, the emitter/VM wraps it as KindDynamic even though the checker has resolved the type variable to a concrete type (e.g. Int). This required a workaround in `evalCompare` (vm.go) to compare underlying Go values when either operand is KindDynamic. The proper fix is to thread the resolved type through emission so the runtime object gets the correct kind (e.g. KindInt) rather than KindDynamic.
 - [ ] allow FFI in user land
 - [ ] Dependency system
   * needs more thought

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 # TODO
-- [ ] FFI functions should be able to use idiomatic Go and compiler handles mappings
 - [ ] Generic type variables emit KindDynamic at runtime instead of the resolved concrete kind. When a generic function like `list::find` returns a value, the emitter/VM wraps it as KindDynamic even though the checker has resolved the type variable to a concrete type (e.g. Int). This required a workaround in `evalCompare` (vm.go) to compare underlying Go values when either operand is KindDynamic. The proper fix is to thread the resolved type through emission so the runtime object gets the correct kind (e.g. KindInt) rather than KindDynamic.
 - [ ] allow FFI in user land
 - [ ] Dependency system

--- a/compiler/bytecode/emitter.go
+++ b/compiler/bytecode/emitter.go
@@ -1405,7 +1405,8 @@ func (f *funcEmitter) emitFunctionCall(call *checker.FunctionCall) error {
 				return err
 			}
 		}
-		f.emit(Instruction{Op: OpCallClosure, B: argc})
+		retID := f.emitter.addType(call.ReturnType)
+		f.emit(Instruction{Op: OpCallClosure, B: argc, C: int(retID)})
 		f.adjustStack(argc+1, 1)
 		return nil
 	}
@@ -1419,7 +1420,8 @@ func (f *funcEmitter) emitFunctionCall(call *checker.FunctionCall) error {
 			return err
 		}
 	}
-	f.emit(Instruction{Op: OpCall, A: idx, B: argc})
+	retID := f.emitter.addType(call.ReturnType)
+	f.emit(Instruction{Op: OpCall, A: idx, B: argc, C: int(retID)})
 	f.adjustStack(argc, 1)
 	return nil
 }
@@ -1472,7 +1474,8 @@ func (f *funcEmitter) emitModuleFunctionCall(call *checker.ModuleFunctionCall) e
 				return err
 			}
 		}
-		f.emit(Instruction{Op: OpCall, A: idx, B: argc})
+		retID := f.emitter.addType(call.Call.ReturnType)
+		f.emit(Instruction{Op: OpCall, A: idx, B: argc, C: int(retID)})
 		f.adjustStack(argc, 1)
 		return nil
 	}
@@ -1486,7 +1489,8 @@ func (f *funcEmitter) emitModuleFunctionCall(call *checker.ModuleFunctionCall) e
 					return err
 				}
 			}
-			f.emit(Instruction{Op: OpCall, A: idx, B: argc})
+			retID := f.emitter.addType(call.Call.ReturnType)
+			f.emit(Instruction{Op: OpCall, A: idx, B: argc, C: int(retID)})
 			f.adjustStack(argc, 1)
 			return nil
 		}
@@ -1500,7 +1504,8 @@ func (f *funcEmitter) emitModuleFunctionCall(call *checker.ModuleFunctionCall) e
 						return err
 					}
 				}
-				f.emit(Instruction{Op: OpCall, A: idx, B: argc})
+				retID := f.emitter.addType(call.Call.ReturnType)
+				f.emit(Instruction{Op: OpCall, A: idx, B: argc, C: int(retID)})
 				f.adjustStack(argc, 1)
 				return nil
 			}
@@ -1513,7 +1518,8 @@ func (f *funcEmitter) emitModuleFunctionCall(call *checker.ModuleFunctionCall) e
 					return err
 				}
 			}
-			f.emit(Instruction{Op: OpCall, A: idx, B: argc})
+			retID := f.emitter.addType(call.Call.ReturnType)
+			f.emit(Instruction{Op: OpCall, A: idx, B: argc, C: int(retID)})
 			f.adjustStack(argc, 1)
 			return nil
 		}
@@ -2274,7 +2280,8 @@ func (f *funcEmitter) emitInstanceMethod(method *checker.InstanceMethod) error {
 		}
 	}
 	nameIdx := f.emitter.addConst(Constant{Kind: ConstStr, Str: method.Method.Name})
-	f.emit(Instruction{Op: OpCallMethod, A: nameIdx, B: len(method.Method.Args)})
+	retID := f.emitter.addType(method.Method.ReturnType)
+	f.emit(Instruction{Op: OpCallMethod, A: nameIdx, B: len(method.Method.Args), C: int(retID)})
 	f.adjustStack(len(method.Method.Args)+1, 1)
 	return nil
 }

--- a/compiler/bytecode/vm/generic_eq_test.go
+++ b/compiler/bytecode/vm/generic_eq_test.go
@@ -3,6 +3,19 @@ package vm
 import "testing"
 
 func TestGenericValueEquality(t *testing.T) {
+	t.Run("direct generic return compared with ==", func(t *testing.T) {
+		res := runBytecode(t, `
+fn id<$T>(value: $T) $T {
+  value
+}
+
+id(3) == 3
+`)
+		if res != true {
+			t.Fatalf("Expected true, got %v (%T)", res, res)
+		}
+	})
+
 	t.Run("find result compared with ==", func(t *testing.T) {
 		res := runBytecode(t, `
 use ard/list

--- a/compiler/bytecode/vm/vm.go
+++ b/compiler/bytecode/vm/vm.go
@@ -10,18 +10,20 @@ import (
 )
 
 type Frame struct {
-	Fn       bytecode.Function
-	IP       int
-	Locals   []*runtime.Object
-	Stack    []*runtime.Object
-	MaxStack int
+	Fn         bytecode.Function
+	IP         int
+	Locals     []*runtime.Object
+	Stack      []*runtime.Object
+	MaxStack   int
+	ReturnType checker.Type
 }
 
 type Closure struct {
-	FnIndex  int
-	Captures []*runtime.Object
-	Program  *bytecode.Program
-	Params   []checker.Parameter
+	FnIndex    int
+	Captures   []*runtime.Object
+	Program    *bytecode.Program
+	Params     []checker.Parameter
+	ReturnType checker.Type
 }
 
 func (c *Closure) Eval(args ...*runtime.Object) *runtime.Object {
@@ -265,6 +267,9 @@ func (vm *VM) run() (*runtime.Object, error) {
 		case bytecode.OpReturn:
 			if len(curr.Stack) == 0 {
 				val := runtime.Void()
+				if curr.ReturnType != nil {
+					val.SetRefinedType(curr.ReturnType)
+				}
 				vm.Frames = vm.Frames[:len(vm.Frames)-1]
 				if len(vm.Frames) == 0 {
 					return val, nil
@@ -275,6 +280,9 @@ func (vm *VM) run() (*runtime.Object, error) {
 			val, err := vm.pop(curr)
 			if err != nil {
 				return nil, err
+			}
+			if curr.ReturnType != nil {
+				val.SetRefinedType(curr.ReturnType)
 			}
 			vm.Frames = vm.Frames[:len(vm.Frames)-1]
 			if len(vm.Frames) == 0 {
@@ -296,7 +304,11 @@ func (vm *VM) run() (*runtime.Object, error) {
 				}
 				args[i] = arg
 			}
-			frame, err := vm.newFrame(fnDef, args, nil)
+			retType, err := vm.typeFor(bytecode.TypeID(inst.C))
+			if err != nil {
+				return nil, err
+			}
+			frame, err := vm.newFrame(fnDef, args, nil, retType)
 			if err != nil {
 				return nil, err
 			}
@@ -326,7 +338,11 @@ func (vm *VM) run() (*runtime.Object, error) {
 			if def, ok := fnType.(*checker.FunctionDef); ok {
 				params = def.Parameters
 			}
-			closure := &Closure{FnIndex: fnIndex, Captures: captures, Program: &vm.Program, Params: params}
+			var returnType checker.Type = checker.Dynamic
+			if def, ok := fnType.(*checker.FunctionDef); ok {
+				returnType = def.ReturnType
+			}
+			closure := &Closure{FnIndex: fnIndex, Captures: captures, Program: &vm.Program, Params: params, ReturnType: returnType}
 			vm.push(curr, runtime.Make(closure, fnType))
 		case bytecode.OpCallClosure:
 			argc := inst.B
@@ -350,7 +366,11 @@ func (vm *VM) run() (*runtime.Object, error) {
 				return nil, fmt.Errorf("function index out of range")
 			}
 			fnDef := vm.Program.Functions[closure.FnIndex]
-			frame, err := vm.newFrame(fnDef, args, closure.Captures)
+			retType, err := vm.typeFor(bytecode.TypeID(inst.C))
+			if err != nil {
+				return nil, err
+			}
+			frame, err := vm.newFrame(fnDef, args, closure.Captures, retType)
 			if err != nil {
 				return nil, err
 			}
@@ -932,12 +952,17 @@ func (vm *VM) run() (*runtime.Object, error) {
 			if fnDef.Arity != argc+1 {
 				return nil, fmt.Errorf("arity mismatch: expected %d, got %d", fnDef.Arity, argc+1)
 			}
+			retType, err := vm.typeFor(bytecode.TypeID(inst.C))
+			if err != nil {
+				return nil, err
+			}
 			frame := &Frame{
-				Fn:       fnDef,
-				IP:       0,
-				Locals:   make([]*runtime.Object, fnDef.Locals),
-				Stack:    []*runtime.Object{},
-				MaxStack: fnDef.MaxStack,
+				Fn:         fnDef,
+				IP:         0,
+				Locals:     make([]*runtime.Object, fnDef.Locals),
+				Stack:      []*runtime.Object{},
+				MaxStack:   fnDef.MaxStack,
+				ReturnType: retType,
 			}
 			frame.Locals[0] = subj
 			for i := range args {
@@ -1034,7 +1059,7 @@ func (vm *VM) spawn() *VM {
 	return child
 }
 
-func (vm *VM) newFrame(fnDef bytecode.Function, args []*runtime.Object, captures []*runtime.Object) (*Frame, error) {
+func (vm *VM) newFrame(fnDef bytecode.Function, args []*runtime.Object, captures []*runtime.Object, returnType checker.Type) (*Frame, error) {
 	if len(args) != fnDef.Arity {
 		return nil, fmt.Errorf("arity mismatch: expected %d, got %d", fnDef.Arity, len(args))
 	}
@@ -1045,11 +1070,12 @@ func (vm *VM) newFrame(fnDef bytecode.Function, args []*runtime.Object, captures
 		return nil, fmt.Errorf("capture mismatch: expected %d, got %d", len(fnDef.Captures), len(captures))
 	}
 	frame := &Frame{
-		Fn:       fnDef,
-		IP:       0,
-		Locals:   make([]*runtime.Object, fnDef.Locals),
-		Stack:    []*runtime.Object{},
-		MaxStack: fnDef.MaxStack,
+		Fn:         fnDef,
+		IP:         0,
+		Locals:     make([]*runtime.Object, fnDef.Locals),
+		Stack:      []*runtime.Object{},
+		MaxStack:   fnDef.MaxStack,
+		ReturnType: returnType,
 	}
 	for i, localIdx := range fnDef.Captures {
 		if localIdx < 0 || localIdx >= len(frame.Locals) {
@@ -1069,7 +1095,7 @@ func (vm *VM) runClosure(closure *Closure, args []*runtime.Object) (*runtime.Obj
 	}
 	child := vm.spawn()
 	fnDef := child.Program.Functions[closure.FnIndex]
-	frame, err := child.newFrame(fnDef, args, closure.Captures)
+	frame, err := child.newFrame(fnDef, args, closure.Captures, closure.ReturnType)
 	if err != nil {
 		return nil, err
 	}
@@ -1197,14 +1223,6 @@ func (vm *VM) evalCompare(op bytecode.Opcode, left, right *runtime.Object) (*run
 		}
 		if left.Kind() == runtime.KindInt && right.Kind() == runtime.KindEnum {
 			eq := left.AsInt() == right.Raw().(int)
-			if op == bytecode.OpEq {
-				return runtime.MakeBool(eq), nil
-			}
-			return runtime.MakeBool(!eq), nil
-		}
-		// Handle KindDynamic: compare underlying Go values when kinds don't match
-		if left.Kind() == runtime.KindDynamic || right.Kind() == runtime.KindDynamic {
-			eq := left.Raw() == right.Raw()
 			if op == bytecode.OpEq {
 				return runtime.MakeBool(eq), nil
 			}

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -2195,6 +2195,14 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 			if args == nil {
 				return nil
 			}
+			if fnDef.hasGenerics() && len(s.TypeArgs) > 0 {
+				specialized, err := c.resolveGenericFunction(fnDef, args, s.TypeArgs, s.GetLocation())
+				if err != nil {
+					c.addError(err.Error(), s.GetLocation())
+					return nil
+				}
+				fnToUse = specialized
+			}
 
 			call := &FunctionCall{
 				Name:       s.Name,
@@ -2364,6 +2372,14 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 			args, fnToUse := c.checkAndProcessArguments(fnDef, resolvedArgs, resolvedExprs, fnDefCopy, genericScope, numOmittedArgs)
 			if args == nil {
 				return nil
+			}
+			if fnDef.hasGenerics() && len(s.Method.TypeArgs) > 0 {
+				specialized, err := c.resolveGenericFunction(fnDef, args, s.Method.TypeArgs, s.GetLocation())
+				if err != nil {
+					c.addError(err.Error(), s.GetLocation())
+					return nil
+				}
+				fnToUse = specialized
 			}
 
 			// Create function call
@@ -2850,6 +2866,14 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 			args, fnToUse := c.checkAndProcessArguments(fnDef, resolvedArgs, resolvedExprs, fnDefCopy, genericScope, numOmittedArgs)
 			if args == nil {
 				return nil
+			}
+			if fnDef.hasGenerics() && len(s.Function.TypeArgs) > 0 {
+				specialized, err := c.resolveGenericFunction(fnDef, args, s.Function.TypeArgs, s.GetLocation())
+				if err != nil {
+					c.addError(err.Error(), s.GetLocation())
+					return nil
+				}
+				fnToUse = specialized
 			}
 
 			// Create function call
@@ -4527,7 +4551,11 @@ func (c *Checker) checkAndProcessArguments(fnDef *FunctionDef, resolvedArgs []pa
 		var checkedArg Expression
 		switch resolvedExprs[i].(type) {
 		case *parse.ListLiteral, *parse.MapLiteral:
-			checkedArg = c.checkExprAs(resolvedExprs[i], expectedType)
+			if hasGenericsInType(expectedType) {
+				checkedArg = c.checkExpr(resolvedExprs[i])
+			} else {
+				checkedArg = c.checkExprAs(resolvedExprs[i], expectedType)
+			}
 		case *parse.AnonymousFunction:
 			checkedArg = c.checkExprAs(resolvedExprs[i], expectedType)
 		default:


### PR DESCRIPTION
## Summary
- thread resolved return types through bytecode call instructions
- refine VM return values at call sites so generic returns keep their concrete runtime kind
- remove the KindDynamic equality workaround and add regression coverage

## Validation
- cd compiler && go test ./bytecode/vm -run TestGenericValueEquality
- cd compiler && go test ./bytecode/vm ./checker
- cd compiler && go test ./...
