### PR TITLE
Fix formatter handling for private extern types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ All commands should be run from the `/compiler` directory:
 - Build: `cd compiler && go build`
   > Important: do not stage and commit the built binary
 - Run Ard program: `cd compiler && go run main.go run samples/[file].ard`
+- Format Ard files: `cd compiler && go run main.go format [path]`
 - Run all tests: `cd compiler && go test ./...`
 - Run package tests: `cd compiler && go test ./ast` or `go test ./checker` or `go test ./bytecode/vm`
 - Run single test: `cd compiler && go test -run TestName ./[package]`
@@ -46,7 +47,11 @@ All commands should be run from the `/compiler` directory:
   - use TDD
   - when adding new features or fixing bugs, recreate them with a test where possible instead of creating sample programs
   - prefer vm tests over checker tests. use vm tests to validate that written code functions as expected. use checker tests to document expected compiler errors
-- **Formatting**: Standard Go formatting (`gofmt`)
+- **Formatting**:
+  - Go: standard Go formatting (`gofmt`)
+  - Ard: use `cd compiler && go run main.go format [path]`
+  - When changing `.ard` files, include a formatter verification pass as part of validation. At minimum, run `ard format` on the touched file(s) or containing directory and make sure formatting does not introduce unintended semantic changes.
+  - When changing formatter behavior or stdlib `.ard` files, also run the relevant formatter tests (at least `cd compiler && go test ./formatter`) and, for stdlib changes, prefer `cd compiler && go run main.go format std_lib` as a regression check.
 - **Project Structure**: Compiler follows ast → checker → vm pipeline
 - **Development Tracking**: Use TODO.md for feature development progress
 - **Sample Programs**: Reference samples directory for example Ard programs

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,3 @@
   * The desired Ard test shape is an untyped closure like `List::keep(users, fn(u) { u.age >= 30 })`, which exercises checker inference on closure params and field access.
   * When that style appears in `std_lib/*.ard`, formatter/idempotence tests currently fail; the formatter crashes while rendering anonymous function params whose types are omitted/inferred.
   * Revisit after fixing the formatter path so stdlib Ard tests can cover this compiler behavior without needing an explicit type annotation workaround.
-- [ ] Fix formatter handling for `private extern type` declarations.
-  * `ard format std_lib` currently rewrites declarations like `private extern type WaitGroup`, `private extern type RawRequest`, and `private extern type Db/Tx` to non-private `extern type ...`.
-  * This affects at least `compiler/std_lib/async.ard`, `compiler/std_lib/http.ard`, and `compiler/std_lib/sql.ard`.
-  * The formatter should preserve visibility modifiers on extern type declarations and have regression coverage for both `extern type Foo` and `private extern type Foo`.

--- a/compiler/formatter/formatter_test.go
+++ b/compiler/formatter/formatter_test.go
@@ -60,6 +60,16 @@ func TestFormat(t *testing.T) {
 			output: "extern fn hash(password: Str, cost: Int?) Result<Str, Str> = \"CryptoHashPassword\"\n",
 		},
 		{
+			name:   "formats extern type declaration",
+			input:  "extern type ConnectionPtr\n",
+			output: "extern type ConnectionPtr\n",
+		},
+		{
+			name:   "formats private extern type declaration",
+			input:  "private extern type ConnectionPtr\n",
+			output: "private extern type ConnectionPtr\n",
+		},
+		{
 			name:   "preserves mut in function type parameters",
 			input:  "type Handler = fn(Request, mut Response)\n",
 			output: "type Handler = fn(Request, mut Response)\n",
@@ -216,6 +226,10 @@ func TestFormatIsIdempotent(t *testing.T) {
 		{
 			name:  "test and regular functions together",
 			input: "fn helper() Int {\n  1\n}\ntest fn test_helper() Void!Str {\n  Result::ok(())\n}\n",
+		},
+		{
+			name:  "private extern type declaration",
+			input: "private extern type ConnectionPtr\n",
 		},
 	}
 

--- a/compiler/formatter/printer.go
+++ b/compiler/formatter/printer.go
@@ -129,6 +129,8 @@ func (p printer) renderStatementDoc(statement parse.Statement) doc {
 		return p.renderFunctionDeclarationDoc(node, false)
 	case *parse.StaticFunctionDeclaration:
 		return p.renderStaticFunctionDeclarationDoc(node)
+	case *parse.ExternTypeDeclaration:
+		return p.renderExternTypeDeclarationDoc(node)
 	case *parse.ExternalFunction:
 		return p.renderExternalFunctionDoc(node)
 	case *parse.StructDefinition:
@@ -272,6 +274,18 @@ func (p printer) renderStaticFunctionDeclarationDoc(node *parse.StaticFunctionDe
 		header += " " + p.renderType(node.ReturnType)
 	}
 	return p.renderBlockDoc(header, node.Body)
+}
+
+func (p printer) renderExternTypeDeclaration(node *parse.ExternTypeDeclaration) string {
+	prefix := ""
+	if node.Private {
+		prefix = "private "
+	}
+	return prefix + "extern type " + node.Name
+}
+
+func (p printer) renderExternTypeDeclarationDoc(node *parse.ExternTypeDeclaration) doc {
+	return dText(p.renderExternTypeDeclaration(node))
 }
 
 func (p printer) renderExternalFunction(node *parse.ExternalFunction) string {


### PR DESCRIPTION
## Summary
- preserve `private extern type` declarations in the Ard formatter
- add formatter regression coverage for extern type declarations
- document Ard formatter verification in `AGENTS.md`

## Validation
- cd compiler && go test -tags=goexperiment.jsonv2 ./formatter
- cd compiler && go run -tags=goexperiment.jsonv2 main.go format std_lib
- cd compiler && go run -tags=goexperiment.jsonv2 main.go test std_lib
- cd compiler && go test -tags=goexperiment.jsonv2 ./...
