### PR TITLE
fix(formatter): preserve grouped 'not' parentheses semantics

### DIFF
--- a/compiler/bytecode/vm/vm_expressions_test.go
+++ b/compiler/bytecode/vm/vm_expressions_test.go
@@ -1,6 +1,10 @@
 package vm
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/akonwi/ard/formatter"
+)
 
 func TestBytecodeVMParityCoreExpressions(t *testing.T) {
 	tests := []struct {
@@ -54,5 +58,33 @@ func TestBytecodeVMParityCoreExpressions(t *testing.T) {
 				t.Fatalf("Expected %v, got %v", test.want, got)
 			}
 		})
+	}
+}
+
+func TestBytecodeVMNotGroupingChangesSemantics(t *testing.T) {
+	if got := runBytecode(t, `(not false) and false`); got != false {
+		t.Fatalf("Expected (not false) and false to be false, got %v", got)
+	}
+
+	if got := runBytecode(t, `not false and false`); got != true {
+		t.Fatalf("Expected not false and false to be true, got %v", got)
+	}
+}
+
+func TestBytecodeVMFormatterPreservesGroupedNotSemantics(t *testing.T) {
+	input := `(not false) and false`
+	formatted, err := formatter.Format([]byte(input), "test.ard")
+	if err != nil {
+		t.Fatalf("format failed: %v", err)
+	}
+
+	before := runBytecode(t, input)
+	after := runBytecode(t, string(formatted))
+
+	if before != false {
+		t.Fatalf("Expected source to evaluate to false, got %v", before)
+	}
+	if after != false {
+		t.Fatalf("Expected formatted source to evaluate to false, got %v", after)
 	}
 }

--- a/compiler/formatter/formatter_test.go
+++ b/compiler/formatter/formatter_test.go
@@ -180,6 +180,26 @@ func TestFormat(t *testing.T) {
 			output: "fn should_assign(assigned: Bool, due: Bool) Bool {\n  not assigned and due\n}\n",
 		},
 		{
+			name:   "preserves parentheses around left not in and expression",
+			input:  "fn should_assign(assigned: Bool, due: Bool) Bool {\n  (not assigned) and due\n}\n",
+			output: "fn should_assign(assigned: Bool, due: Bool) Bool {\n  (not assigned) and due\n}\n",
+		},
+		{
+			name:   "preserves parentheses around left not in or expression",
+			input:  "fn should_assign(assigned: Bool, due: Bool) Bool {\n  (not assigned) or due\n}\n",
+			output: "fn should_assign(assigned: Bool, due: Bool) Bool {\n  (not assigned) or due\n}\n",
+		},
+		{
+			name:   "preserves parentheses around right not in nested binary expression",
+			input:  "fn should_assign(a: Bool, b: Bool, c: Bool) Bool {\n  a and (not b) or c\n}\n",
+			output: "fn should_assign(a: Bool, b: Bool, c: Bool) Bool {\n  a and (not b) or c\n}\n",
+		},
+		{
+			name:   "keeps terminal right not operand unparenthesized",
+			input:  "fn should_assign(a: Bool, b: Bool) Bool {\n  a and not b\n}\n",
+			output: "fn should_assign(a: Bool, b: Bool) Bool {\n  a and not b\n}\n",
+		},
+		{
 			name:   "preserves escaped braces in plain string literals",
 			input:  "fn main() {\n  let body = \"\\{\\\"status\\\": \\\"ok\\\"\\}\"\n}\n",
 			output: "fn main() {\n  let body = \"\\{\\\"status\\\": \\\"ok\\\"\\}\"\n}\n",

--- a/compiler/formatter/printer.go
+++ b/compiler/formatter/printer.go
@@ -1311,6 +1311,12 @@ func (p printer) renderBinary(node *parse.BinaryExpression, parentPrecedence int
 	if isTryExpression(node.Right) {
 		right = "(" + right + ")"
 	}
+	if isUnaryNotExpression(node.Left) {
+		left = "(" + left + ")"
+	}
+	if isUnaryNotExpression(node.Right) && parentPrecedence > precedenceLowest {
+		right = "(" + right + ")"
+	}
 	operator := p.operatorString(node.Operator)
 	separator := " "
 	if node.Operator == parse.Range {
@@ -1330,6 +1336,17 @@ func isTryExpression(expression parse.Expression) bool {
 	switch expression.(type) {
 	case *parse.Try, parse.Try:
 		return true
+	default:
+		return false
+	}
+}
+
+func isUnaryNotExpression(expression parse.Expression) bool {
+	switch node := expression.(type) {
+	case *parse.UnaryExpression:
+		return node.Operator == parse.Not
+	case parse.UnaryExpression:
+		return node.Operator == parse.Not
 	default:
 		return false
 	}


### PR DESCRIPTION
## Summary
- preserve parentheses for unary `not` when used as a binary operand so formatter does not change semantics
- keep non-grouped forms stable (e.g. `a and not b`)
- add formatter regression tests for grouped `not` around `and`/`or`
- add VM regression tests proving `(not a) and b` and `not a and b` evaluate differently and that formatting preserves grouped behavior

## Validation
- `cd compiler && go test ./formatter`
- `cd compiler && go test ./bytecode/vm ./formatter`
- `cd compiler && go test ./...`

## Context
Fixes formatter behavior where `(not a) and b` could be rewritten to `not a and b`, changing program logic.
