### PR TITLE
feat(decode): allow from_json to accept Dynamic string input

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,5 @@
 # TODO
+- [ ] still need some sort of mapping for Result/Maybe 
 - [ ] allow FFI in user land
 - [ ] Dependency system
   * needs more thought

--- a/compiler/bytecode/vm/decode_test.go
+++ b/compiler/bytecode/vm/decode_test.go
@@ -142,7 +142,7 @@ func TestBytecodeFromJSONInputTypes(t *testing.T) {
 					ok(_) => "unexpected success",
 				}
 			`,
-			want: "from_json expected JSON text (Str), got 42",
+			want: "Expected a JSON string, got 42",
 		},
 	})
 }

--- a/compiler/bytecode/vm/decode_test.go
+++ b/compiler/bytecode/vm/decode_test.go
@@ -111,6 +111,42 @@ func TestBytecodeDecodeErrors(t *testing.T) {
 	})
 }
 
+func TestBytecodeFromJSONInputTypes(t *testing.T) {
+	runBytecodeTests(t, []vmTestCase{
+		{
+			name: "from_json accepts Str input",
+			input: `
+				use ard/decode
+				let data = decode::from_json("42").expect("parse")
+				decode::run(data, decode::int).expect("decode")
+			`,
+			want: 42,
+		},
+		{
+			name: "from_json accepts Dynamic string input",
+			input: `
+				use ard/decode
+				let raw = Dynamic::from("\{\"count\": 7\}")
+				let data = decode::from_json(raw).expect("parse")
+				decode::run(data, decode::field("count", decode::int)).expect("decode")
+			`,
+			want: 7,
+		},
+		{
+			name: "from_json rejects non-string Dynamic input",
+			input: `
+				use ard/decode
+				let raw = Dynamic::from(42)
+				match decode::from_json(raw) {
+					err(msg) => msg,
+					ok(_) => "unexpected success",
+				}
+			`,
+			want: "from_json expected JSON text (Str), got 42",
+		},
+	})
+}
+
 func TestBytecodeDecodeNullable(t *testing.T) {
 	runBytecodeTests(t, []vmTestCase{
 		{

--- a/compiler/std_lib/decode.ard
+++ b/compiler/std_lib/decode.ard
@@ -52,7 +52,7 @@ fn from_json(input: JsonInput) Dynamic!Str {
     Str(text) => text,
     Dynamic(raw) => {
       let text = try _decode_string(raw) -> err {
-        Result::err("from_json expected JSON text (Str), got {err.found}")
+        Result::err("Expected a JSON string, got {err.found}")
       }
       text
     },

--- a/compiler/std_lib/decode.ard
+++ b/compiler/std_lib/decode.ard
@@ -36,14 +36,30 @@ impl Str::ToString for Error {
   }
 }
 
-// parse json text
-extern fn from_json(json: Str) Dynamic!Str = "JsonToDynamic"
+type JsonInput = Str | Dynamic
 
 private extern fn _decode_string(data: Dynamic) Str!Error = "DecodeString"
 private extern fn _decode_int(data: Dynamic) Int!Error = "DecodeInt"
 private extern fn _decode_float(data: Dynamic) Float!Error = "DecodeFloat"
 private extern fn _decode_bool(data: Dynamic) Bool!Error = "DecodeBool"
 extern fn is_void(data: Dynamic) Bool = "IsNil"
+
+// parse json text
+private extern fn _from_json(json: Str) Dynamic!Str = "JsonToDynamic"
+
+fn from_json(input: JsonInput) Dynamic!Str {
+  let json = match input {
+    Str(text) => text,
+    Dynamic(raw) => {
+      let text = try _decode_string(raw) -> err {
+        Result::err("from_json expected JSON text (Str), got {err.found}")
+      }
+      text
+    },
+  }
+
+  _from_json(json)
+}
 
 type Decoder = fn(Dynamic) $Out![Error]
 


### PR DESCRIPTION
## Summary
- update `decode::from_json` to accept `Str | Dynamic` input (`JsonInput`)
- keep parsing behavior strict:
  - `Str` input is parsed as JSON
  - `Dynamic` input must contain a string, otherwise returns `Err(Str)`
- add VM coverage for:
  - `Str` input works
  - `Dynamic` string input works
  - non-string `Dynamic` input returns an error message
- remove completed TODO item about supporting `Dynamic|Str` for decode json input

## Validation
- `cd compiler && go run main.go format std_lib/decode.ard`
- `cd compiler && go run main.go format std_lib`
- `cd compiler && go test ./bytecode/vm -run TestBytecodeFromJSONInputTypes -v`
- `cd compiler && go test ./...`
- ran `samples/server.ard` and exercised endpoint requests:
  - `GET /` -> 200
  - `POST /api/auth/sign-up` missing body -> 400
  - invalid JSON body -> 400
  - valid JSON body -> 201

## Why
This simplifies common call paths (especially HTTP request bodies stored as `Dynamic?`) while still failing fast when the body is not actually JSON text.
