### PR TITLE
feat(result-maybe): add map/map_err/and_then combinators

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 # TODO
-- [ ] still need some sort of mapping for Result/Maybe 
 - [ ] allow FFI in user land
 - [ ] Dependency system
   * needs more thought

--- a/compiler/bytecode/vm/maybe_test.go
+++ b/compiler/bytecode/vm/maybe_test.go
@@ -78,6 +78,24 @@ func TestBytecodeMaybes(t *testing.T) {
 			`,
 			want: 42,
 		},
+		{
+			name: ".map() transforms some values with inferred callback types",
+			input: `
+				use ard/maybe
+				let result = maybe::some(41).map(fn(value) { value + 1 })
+				result.or(0)
+			`,
+			want: 42,
+		},
+		{
+			name: ".map() keeps none values with inferred callback types",
+			input: `
+				use ard/maybe
+				let result: Int? = maybe::none()
+				result.map(fn(value) { value + 1 }).is_none()
+			`,
+			want: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/compiler/bytecode/vm/maybe_test.go
+++ b/compiler/bytecode/vm/maybe_test.go
@@ -96,6 +96,24 @@ func TestBytecodeMaybes(t *testing.T) {
 			`,
 			want: true,
 		},
+		{
+			name: ".and_then() transforms and flattens some values",
+			input: `
+				use ard/maybe
+				let result = maybe::some(21).and_then(fn(value) { maybe::some(value * 2) })
+				result.or(0)
+			`,
+			want: 42,
+		},
+		{
+			name: ".and_then() keeps none values",
+			input: `
+				use ard/maybe
+				let result: Int? = maybe::none()
+				result.and_then(fn(value) { maybe::some(value + 1) }).is_none()
+			`,
+			want: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/compiler/bytecode/vm/maybe_test.go
+++ b/compiler/bytecode/vm/maybe_test.go
@@ -114,6 +114,15 @@ func TestBytecodeMaybes(t *testing.T) {
 			`,
 			want: true,
 		},
+		{
+			name: ".and_then() supports explicit type args",
+			input: `
+				use ard/maybe
+				let result = maybe::some(21).and_then<Str>(fn(value) { maybe::some("{value}") })
+				result.or("")
+			`,
+			want: "21",
+		},
 	}
 
 	for _, test := range tests {

--- a/compiler/bytecode/vm/methods.go
+++ b/compiler/bytecode/vm/methods.go
@@ -131,6 +131,31 @@ func (vm *VM) evalMaybeMethod(kind checker.MaybeMethodKind, subj *runtime.Object
 			return args[0], nil
 		}
 		return vm.makeValueWithType(subj.Raw(), returnType)
+	case checker.MaybeMap:
+		resolved, err := vm.typeFor(returnType)
+		if err != nil {
+			return nil, err
+		}
+		mappedMaybe, ok := resolved.(*checker.Maybe)
+		if !ok {
+			return nil, fmt.Errorf("expected Maybe return type for map, got %s", resolved)
+		}
+		if subj.Raw() == nil {
+			return runtime.MakeNone(mappedMaybe.Of()), nil
+		}
+		closure, ok := args[0].Raw().(*Closure)
+		if !ok {
+			return nil, fmt.Errorf("expected closure for Maybe.map, got %T", args[0].Raw())
+		}
+		subjType, ok := subj.Type().(*checker.Maybe)
+		if !ok {
+			return nil, fmt.Errorf("expected Maybe subject for map, got %s", subj.Type())
+		}
+		mapped, err := vm.runClosure(closure, []*runtime.Object{runtime.Make(subj.Raw(), subjType.Of())})
+		if err != nil {
+			return nil, err
+		}
+		return runtime.MakeNone(mappedMaybe.Of()).ToSome(mapped.Raw()), nil
 	default:
 		return nil, fmt.Errorf("Unknown MaybeMethodKind: %d", kind)
 	}
@@ -160,6 +185,32 @@ func (vm *VM) evalResultMethod(kind checker.ResultMethodKind, subj *runtime.Obje
 		return runtime.MakeBool(!subj.IsErr()), nil
 	case checker.ResultIsErr:
 		return runtime.MakeBool(subj.IsErr()), nil
+	case checker.ResultMap:
+		if subj.IsErr() {
+			return subj, nil
+		}
+		closure, ok := args[0].Raw().(*Closure)
+		if !ok {
+			return nil, fmt.Errorf("expected closure for Result.map, got %T", args[0].Raw())
+		}
+		mapped, err := vm.runClosure(closure, []*runtime.Object{subj.UnwrapResult()})
+		if err != nil {
+			return nil, err
+		}
+		return runtime.MakeOk(mapped), nil
+	case checker.ResultMapErr:
+		if !subj.IsErr() {
+			return subj, nil
+		}
+		closure, ok := args[0].Raw().(*Closure)
+		if !ok {
+			return nil, fmt.Errorf("expected closure for Result.map_err, got %T", args[0].Raw())
+		}
+		mapped, err := vm.runClosure(closure, []*runtime.Object{subj.UnwrapResult()})
+		if err != nil {
+			return nil, err
+		}
+		return runtime.MakeErr(mapped), nil
 	default:
 		return nil, fmt.Errorf("Unknown ResultMethodKind: %d", kind)
 	}

--- a/compiler/bytecode/vm/methods.go
+++ b/compiler/bytecode/vm/methods.go
@@ -156,6 +156,31 @@ func (vm *VM) evalMaybeMethod(kind checker.MaybeMethodKind, subj *runtime.Object
 			return nil, err
 		}
 		return runtime.MakeNone(mappedMaybe.Of()).ToSome(mapped.Raw()), nil
+	case checker.MaybeAndThen:
+		resolved, err := vm.typeFor(returnType)
+		if err != nil {
+			return nil, err
+		}
+		chainedMaybe, ok := resolved.(*checker.Maybe)
+		if !ok {
+			return nil, fmt.Errorf("expected Maybe return type for and_then, got %s", resolved)
+		}
+		if subj.Raw() == nil {
+			return runtime.MakeNone(chainedMaybe.Of()), nil
+		}
+		closure, ok := args[0].Raw().(*Closure)
+		if !ok {
+			return nil, fmt.Errorf("expected closure for Maybe.and_then, got %T", args[0].Raw())
+		}
+		subjType, ok := subj.Type().(*checker.Maybe)
+		if !ok {
+			return nil, fmt.Errorf("expected Maybe subject for and_then, got %s", subj.Type())
+		}
+		mapped, err := vm.runClosure(closure, []*runtime.Object{runtime.Make(subj.Raw(), subjType.Of())})
+		if err != nil {
+			return nil, err
+		}
+		return mapped, nil
 	default:
 		return nil, fmt.Errorf("Unknown MaybeMethodKind: %d", kind)
 	}
@@ -211,6 +236,19 @@ func (vm *VM) evalResultMethod(kind checker.ResultMethodKind, subj *runtime.Obje
 			return nil, err
 		}
 		return runtime.MakeErr(mapped), nil
+	case checker.ResultAndThen:
+		if subj.IsErr() {
+			return subj, nil
+		}
+		closure, ok := args[0].Raw().(*Closure)
+		if !ok {
+			return nil, fmt.Errorf("expected closure for Result.and_then, got %T", args[0].Raw())
+		}
+		mapped, err := vm.runClosure(closure, []*runtime.Object{subj.UnwrapResult()})
+		if err != nil {
+			return nil, err
+		}
+		return mapped, nil
 	default:
 		return nil, fmt.Errorf("Unknown ResultMethodKind: %d", kind)
 	}

--- a/compiler/bytecode/vm/result_test.go
+++ b/compiler/bytecode/vm/result_test.go
@@ -48,6 +48,48 @@ func TestBytecodeResults(t *testing.T) {
 			`,
 			want: -1,
 		},
+		{
+			name: "Result.map() transforms ok values with inferred callback types",
+			input: `
+				let res: Int!Str = Result::ok(21)
+				let mapped = res.map(fn(value) { value * 2 })
+				mapped.or(0)
+			`,
+			want: 42,
+		},
+		{
+			name: "Result.map() leaves err values unchanged with inferred callback types",
+			input: `
+				let res: Int!Str = Result::err("bad")
+				let mapped = res.map(fn(value) { value * 2 })
+				match mapped {
+					err(msg) => msg,
+					ok(value) => value.to_str(),
+				}
+			`,
+			want: "bad",
+		},
+		{
+			name: "Result.map_err() transforms err values with inferred callback types",
+			input: `
+				let res: Int!Str = Result::err("bad")
+				let mapped = res.map_err(fn(err) { err.size() })
+				match mapped {
+					err(size) => size,
+					ok(value) => value,
+				}
+			`,
+			want: 3,
+		},
+		{
+			name: "Result.map_err() leaves ok values unchanged with inferred callback types",
+			input: `
+				let res: Int!Str = Result::ok(42)
+				let mapped = res.map_err(fn(err) { err.size() })
+				mapped.or(0)
+			`,
+			want: 42,
+		},
 	}
 
 	for _, test := range tests {

--- a/compiler/bytecode/vm/result_test.go
+++ b/compiler/bytecode/vm/result_test.go
@@ -90,6 +90,33 @@ func TestBytecodeResults(t *testing.T) {
 			`,
 			want: 42,
 		},
+		{
+			name: "Result.and_then() chains ok values",
+			input: `
+				let res: Int!Str = Result::ok(21)
+				let chained = res.and_then(fn(value) { Result::ok(value * 2) })
+				chained.or(0)
+			`,
+			want: 42,
+		},
+		{
+			name: "Result.and_then() propagates callback errors",
+			input: `
+				let res: Int!Str = Result::ok(21)
+				let chained = res.and_then(fn(value) { Result::err("bad") })
+				chained.is_err()
+			`,
+			want: true,
+		},
+		{
+			name: "Result.and_then() leaves err values unchanged",
+			input: `
+				let res: Int!Str = Result::err("bad")
+				let chained = res.and_then(fn(value) { Result::ok(value * 2) })
+				chained.is_err()
+			`,
+			want: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/compiler/bytecode/vm/result_test.go
+++ b/compiler/bytecode/vm/result_test.go
@@ -117,6 +117,27 @@ func TestBytecodeResults(t *testing.T) {
 			`,
 			want: true,
 		},
+		{
+			name: "Result.and_then() supports explicit type args",
+			input: `
+				let res: Int!Str = Result::ok(21)
+				let chained = res.and_then<Str>(fn(value) { Result::ok("{value}") })
+				chained.or("")
+			`,
+			want: "21",
+		},
+		{
+			name: "Result.and_then() explicit type args resolve err-only callbacks",
+			input: `
+				let res: Int!Str = Result::err("bad")
+				let chained = res.and_then<Str>(fn(value) { Result::err("boom") })
+				match chained {
+					err(msg) => msg,
+					ok(value) => value,
+				}
+			`,
+			want: "bad",
+		},
 	}
 
 	for _, test := range tests {

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -4026,6 +4026,54 @@ func (c *Checker) areTypesComparable(left, right Type) bool {
 }
 
 // use this when we know what the expr's Type should be
+func bindInferredTypeVars(expected Type, actual Type) {
+	if expected == nil || actual == nil {
+		return
+	}
+
+	expected = derefType(expected)
+	actual = derefType(actual)
+
+	switch exp := expected.(type) {
+	case *TypeVar:
+		if exp.actual == nil {
+			exp.actual = actual
+			exp.bound = true
+			return
+		}
+		bindInferredTypeVars(exp.actual, actual)
+	case *Maybe:
+		if act, ok := actual.(*Maybe); ok {
+			bindInferredTypeVars(exp.Of(), act.Of())
+		}
+	case *Result:
+		if act, ok := actual.(*Result); ok {
+			bindInferredTypeVars(exp.Val(), act.Val())
+			bindInferredTypeVars(exp.Err(), act.Err())
+		}
+	case *List:
+		if act, ok := actual.(*List); ok {
+			bindInferredTypeVars(exp.Of(), act.Of())
+		}
+	case *Map:
+		if act, ok := actual.(*Map); ok {
+			bindInferredTypeVars(exp.Key(), act.Key())
+			bindInferredTypeVars(exp.Value(), act.Value())
+		}
+	case *FunctionDef:
+		if act, ok := actual.(*FunctionDef); ok {
+			limit := len(exp.Parameters)
+			if len(act.Parameters) < limit {
+				limit = len(act.Parameters)
+			}
+			for i := 0; i < limit; i++ {
+				bindInferredTypeVars(exp.Parameters[i].Type, act.Parameters[i].Type)
+			}
+			bindInferredTypeVars(exp.ReturnType, act.ReturnType)
+		}
+	}
+}
+
 func (c *Checker) checkExprAs(expr parse.Expression, expectedType Type) Expression {
 	switch s := (expr).(type) {
 	case *parse.ListLiteral:
@@ -4084,17 +4132,14 @@ func (c *Checker) checkExprAs(expr parse.Expression, expectedType Type) Expressi
 			// Add function to scope after checking body
 			c.scope.add(uniqueName, fn, false)
 
-			// Nuance: for context-inferred anonymous callbacks (e.g. Result.map/map_err, Maybe.map),
-			// the expected function return type can be an unbound TypeVar. If we leave it unbound,
-			// later method/property lookups on the callback result can panic with
-			// "Cannot look up symbols in unrefined $T". Bind that TypeVar to the body type here.
+			// Nuance: in context-inferred callbacks (map/map_err/and_then, etc), the expected return
+			// type can contain unbound generics (for example Result<$Mapped, E>). If these remain
+			// unresolved, later method/property lookup can panic with
+			// "Cannot look up symbols in unrefined $T". Bind generics from the checked body type here.
 			//
-			// This is in a shared anonymous-function inference path (not map/map_err-specific),
-			// so keep an eye on other closure call sites if this logic changes.
-			if typeVar, ok := returnType.(*TypeVar); ok && typeVar.actual == nil {
-				typeVar.actual = body.Type()
-				typeVar.bound = true
-			}
+			// This is a shared anonymous-function inference path, so changes here affect closure typing
+			// beyond Result/Maybe combinators.
+			bindInferredTypeVars(returnType, body.Type())
 
 			// Validate return type
 			if returnType != Void && !returnType.equal(body.Type()) {
@@ -4165,6 +4210,7 @@ func (c *Checker) checkExprAs(expr parse.Expression, expectedType Type) Expressi
 					c.addError(typeMismatch(resultType.Val(), arg.Type()), s.Function.Args[0].Value.GetLocation())
 					return nil
 				}
+				bindInferredTypeVars(resultType.Val(), arg.Type())
 			}
 			if fnDef.name() == "err" {
 				arg = c.checkExpr(s.Function.Args[0].Value)
@@ -4172,6 +4218,7 @@ func (c *Checker) checkExprAs(expr parse.Expression, expectedType Type) Expressi
 					c.addError(typeMismatch(resultType.Err(), arg.Type()), s.Function.Args[0].Value.GetLocation())
 					return nil
 				}
+				bindInferredTypeVars(resultType.Err(), arg.Type())
 			}
 
 			fnDef.ReturnType = resultType

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -1954,6 +1954,8 @@ func (c *Checker) createMaybeMethod(subject Expression, methodName string, args 
 		kind = MaybeOr
 	case "map":
 		kind = MaybeMap
+	case "and_then":
+		kind = MaybeAndThen
 	default:
 		panic(fmt.Sprintf("Unknown Maybe method: %s", methodName))
 	}
@@ -1983,6 +1985,8 @@ func (c *Checker) createResultMethod(subject Expression, methodName string, args
 		kind = ResultMap
 	case "map_err":
 		kind = ResultMapErr
+	case "and_then":
+		kind = ResultAndThen
 	default:
 		panic(fmt.Sprintf("Unknown Result method: %s", methodName))
 	}

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -1952,6 +1952,8 @@ func (c *Checker) createMaybeMethod(subject Expression, methodName string, args 
 		kind = MaybeIsSome
 	case "or":
 		kind = MaybeOr
+	case "map":
+		kind = MaybeMap
 	default:
 		panic(fmt.Sprintf("Unknown Maybe method: %s", methodName))
 	}
@@ -1977,6 +1979,10 @@ func (c *Checker) createResultMethod(subject Expression, methodName string, args
 		kind = ResultIsOk
 	case "is_err":
 		kind = ResultIsErr
+	case "map":
+		kind = ResultMap
+	case "map_err":
+		kind = ResultMapErr
 	default:
 		panic(fmt.Sprintf("Unknown Result method: %s", methodName))
 	}
@@ -4073,6 +4079,18 @@ func (c *Checker) checkExprAs(expr parse.Expression, expectedType Type) Expressi
 
 			// Add function to scope after checking body
 			c.scope.add(uniqueName, fn, false)
+
+			// Nuance: for context-inferred anonymous callbacks (e.g. Result.map/map_err, Maybe.map),
+			// the expected function return type can be an unbound TypeVar. If we leave it unbound,
+			// later method/property lookups on the callback result can panic with
+			// "Cannot look up symbols in unrefined $T". Bind that TypeVar to the body type here.
+			//
+			// This is in a shared anonymous-function inference path (not map/map_err-specific),
+			// so keep an eye on other closure call sites if this logic changes.
+			if typeVar, ok := returnType.(*TypeVar); ok && typeVar.actual == nil {
+				typeVar.actual = body.Type()
+				typeVar.bound = true
+			}
 
 			// Validate return type
 			if returnType != Void && !returnType.equal(body.Type()) {

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -424,6 +424,7 @@ const (
 	MaybeIsNone
 	MaybeIsSome
 	MaybeOr
+	MaybeMap
 )
 
 type MaybeMethod struct {
@@ -459,6 +460,8 @@ const (
 	ResultOr
 	ResultIsOk
 	ResultIsErr
+	ResultMap
+	ResultMapErr
 )
 
 type ResultMethod struct {

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -425,6 +425,7 @@ const (
 	MaybeIsSome
 	MaybeOr
 	MaybeMap
+	MaybeAndThen
 )
 
 type MaybeMethod struct {
@@ -462,6 +463,7 @@ const (
 	ResultIsErr
 	ResultMap
 	ResultMapErr
+	ResultAndThen
 )
 
 type ResultMethod struct {

--- a/compiler/checker/results_test.go
+++ b/compiler/checker/results_test.go
@@ -142,6 +142,35 @@ func TestResults(t *testing.T) {
 			diagnostics: []checker.Diagnostic{},
 		},
 		{
+			name: "Result.and_then() can change ok type",
+			input: `
+			fn foo() Str!Str {
+				let res: Int!Str = Result::ok(10)
+				res.and_then(fn(value: Int) Str!Str { Result::ok("{value}") })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Result.and_then() infers anonymous callback types",
+			input: `
+			fn foo() Int!Str {
+				let res: Int!Str = Result::ok(10)
+				res.and_then(fn(value) { Result::ok(value + 1) })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Result.and_then() enforces closure parameter type",
+			input: `
+			fn foo() {
+				let res: Int!Str = Result::ok(10)
+				res.and_then(fn(value: Str) Int!Str { Result::ok(1) })
+			}`,
+			diagnostics: []checker.Diagnostic{
+				{Kind: checker.Error, Message: "type mismatch: expected Int, got Str"},
+			},
+		},
+		{
 			name: "Result.map() enforces closure parameter type",
 			input: `
 			fn foo() {
@@ -171,6 +200,38 @@ func TestResults(t *testing.T) {
 				value.map(fn(v) { v + 1 })
 			}`,
 			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Maybe.and_then() can change inner type",
+			input: `
+			use ard/maybe
+			fn foo() Str? {
+				let value: Int? = maybe::some(10)
+				value.and_then(fn(v: Int) Str? { maybe::some("{v}") })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Maybe.and_then() infers anonymous callback types",
+			input: `
+			use ard/maybe
+			fn foo() Int? {
+				let value: Int? = maybe::some(10)
+				value.and_then(fn(v) { maybe::some(v + 1) })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Maybe.and_then() enforces closure parameter type",
+			input: `
+			use ard/maybe
+			fn foo() {
+				let value: Int? = maybe::some(10)
+				value.and_then(fn(v: Str) Int? { maybe::some(1) })
+			}`,
+			diagnostics: []checker.Diagnostic{
+				{Kind: checker.Error, Message: "type mismatch: expected Int, got Str"},
+			},
 		},
 		{
 			name: "Maybe.map() enforces closure parameter type",

--- a/compiler/checker/results_test.go
+++ b/compiler/checker/results_test.go
@@ -142,11 +142,38 @@ func TestResults(t *testing.T) {
 			diagnostics: []checker.Diagnostic{},
 		},
 		{
+			name: "Result.map_err() accepts explicit type args",
+			input: `
+			fn foo() Int!Int {
+				let res: Int!Str = Result::err("bad")
+				res.map_err<Int>(fn(err) { err.size() })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
 			name: "Result.and_then() can change ok type",
 			input: `
 			fn foo() Str!Str {
 				let res: Int!Str = Result::ok(10)
 				res.and_then(fn(value: Int) Str!Str { Result::ok("{value}") })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Result.and_then() accepts explicit type args",
+			input: `
+			fn foo() Str!Str {
+				let res: Int!Str = Result::ok(10)
+				res.and_then<Str>(fn(value) { Result::ok("{value}") })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Result.and_then() explicit type args support err-only callbacks",
+			input: `
+			fn foo() Str!Str {
+				let res: Int!Str = Result::err("bad")
+				res.and_then<Str>(fn(value) { Result::err("boom") })
 			}`,
 			diagnostics: []checker.Diagnostic{},
 		},
@@ -192,6 +219,16 @@ func TestResults(t *testing.T) {
 			diagnostics: []checker.Diagnostic{},
 		},
 		{
+			name: "Maybe.map() accepts explicit type args",
+			input: `
+			use ard/maybe
+			fn foo() Str? {
+				let value: Int? = maybe::some(10)
+				value.map<Str>(fn(v) { "{v}" })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
 			name: "Maybe.map() infers anonymous callback types",
 			input: `
 			use ard/maybe
@@ -208,6 +245,16 @@ func TestResults(t *testing.T) {
 			fn foo() Str? {
 				let value: Int? = maybe::some(10)
 				value.and_then(fn(v: Int) Str? { maybe::some("{v}") })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Maybe.and_then() accepts explicit type args",
+			input: `
+			use ard/maybe
+			fn foo() Str? {
+				let value: Int? = maybe::some(10)
+				value.and_then<Str>(fn(v) { maybe::some("{v}") })
 			}`,
 			diagnostics: []checker.Diagnostic{},
 		},

--- a/compiler/checker/results_test.go
+++ b/compiler/checker/results_test.go
@@ -106,6 +106,85 @@ func TestResults(t *testing.T) {
 			diagnostics: []checker.Diagnostic{},
 		},
 		{
+			name: "Result.map() can change ok type",
+			input: `
+			fn foo() Str!Str {
+				let res: Int!Str = Result::ok(10)
+				res.map(fn(value: Int) Str { "{value}" })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Result.map() infers anonymous callback types",
+			input: `
+			fn foo() Int!Str {
+				let res: Int!Str = Result::ok(10)
+				res.map(fn(value) { value + 1 })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Result.map_err() can change err type",
+			input: `
+			fn foo() Int!Int {
+				let res: Int!Str = Result::err("bad")
+				res.map_err(fn(err: Str) Int { 3 })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Result.map_err() infers anonymous callback types",
+			input: `
+			fn foo() Int!Int {
+				let res: Int!Str = Result::err("bad")
+				res.map_err(fn(err) { err.size() })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Result.map() enforces closure parameter type",
+			input: `
+			fn foo() {
+				let res: Int!Str = Result::ok(10)
+				res.map(fn(value: Str) Int { 1 })
+			}`,
+			diagnostics: []checker.Diagnostic{
+				{Kind: checker.Error, Message: "type mismatch: expected Int, got Str"},
+			},
+		},
+		{
+			name: "Maybe.map() can change inner type",
+			input: `
+			use ard/maybe
+			fn foo() Str? {
+				let value: Int? = maybe::some(10)
+				value.map(fn(v: Int) Str { "{v}" })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Maybe.map() infers anonymous callback types",
+			input: `
+			use ard/maybe
+			fn foo() Int? {
+				let value: Int? = maybe::some(10)
+				value.map(fn(v) { v + 1 })
+			}`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Maybe.map() enforces closure parameter type",
+			input: `
+			use ard/maybe
+			fn foo() {
+				let value: Int? = maybe::some(10)
+				value.map(fn(v: Str) Int { 1 })
+			}`,
+			diagnostics: []checker.Diagnostic{
+				{Kind: checker.Error, Message: "type mismatch: expected Int, got Str"},
+			},
+		},
+		{
 			name: "Matching on results",
 			input: `
 			use ard/io

--- a/compiler/checker/types.go
+++ b/compiler/checker/types.go
@@ -555,6 +555,20 @@ func (m *Maybe) get(name string) Type {
 			Parameters: []Parameter{{Name: "default", Type: m.of}},
 			ReturnType: m.of,
 		}
+	case "map":
+		mapped := &TypeVar{name: "Mapped"}
+		return &FunctionDef{
+			Name: name,
+			Parameters: []Parameter{{
+				Name: "with",
+				Type: &FunctionDef{
+					Name:       "<function>",
+					Parameters: []Parameter{{Name: "value", Type: m.of}},
+					ReturnType: mapped,
+				},
+			}},
+			ReturnType: MakeMaybe(mapped),
+		}
 	default:
 		return nil
 	}
@@ -651,6 +665,34 @@ func (r Result) get(name string) Type {
 			Name:       name,
 			Parameters: []Parameter{},
 			ReturnType: Bool,
+		}
+	case "map":
+		mappedVal := &TypeVar{name: "MappedVal"}
+		return &FunctionDef{
+			Name: name,
+			Parameters: []Parameter{{
+				Name: "with",
+				Type: &FunctionDef{
+					Name:       "<function>",
+					Parameters: []Parameter{{Name: "value", Type: r.val}},
+					ReturnType: mappedVal,
+				},
+			}},
+			ReturnType: MakeResult(mappedVal, r.err),
+		}
+	case "map_err":
+		mappedErr := &TypeVar{name: "MappedErr"}
+		return &FunctionDef{
+			Name: name,
+			Parameters: []Parameter{{
+				Name: "with",
+				Type: &FunctionDef{
+					Name:       "<function>",
+					Parameters: []Parameter{{Name: "err", Type: r.err}},
+					ReturnType: mappedErr,
+				},
+			}},
+			ReturnType: MakeResult(r.val, mappedErr),
 		}
 	default:
 		return nil

--- a/compiler/checker/types.go
+++ b/compiler/checker/types.go
@@ -569,6 +569,20 @@ func (m *Maybe) get(name string) Type {
 			}},
 			ReturnType: MakeMaybe(mapped),
 		}
+	case "and_then":
+		mapped := &TypeVar{name: "Mapped"}
+		return &FunctionDef{
+			Name: name,
+			Parameters: []Parameter{{
+				Name: "with",
+				Type: &FunctionDef{
+					Name:       "<function>",
+					Parameters: []Parameter{{Name: "value", Type: m.of}},
+					ReturnType: MakeMaybe(mapped),
+				},
+			}},
+			ReturnType: MakeMaybe(mapped),
+		}
 	default:
 		return nil
 	}
@@ -693,6 +707,20 @@ func (r Result) get(name string) Type {
 				},
 			}},
 			ReturnType: MakeResult(r.val, mappedErr),
+		}
+	case "and_then":
+		mappedVal := &TypeVar{name: "MappedVal"}
+		return &FunctionDef{
+			Name: name,
+			Parameters: []Parameter{{
+				Name: "with",
+				Type: &FunctionDef{
+					Name:       "<function>",
+					Parameters: []Parameter{{Name: "value", Type: r.val}},
+					ReturnType: MakeResult(mappedVal, r.err),
+				},
+			}},
+			ReturnType: MakeResult(mappedVal, r.err),
 		}
 	default:
 		return nil

--- a/website/src/content/docs/guide/error-handling.mdx
+++ b/website/src/content/docs/guide/error-handling.mdx
@@ -42,6 +42,31 @@ Or use the `.or(default)` method to provide a fallback value:
 let safe_result = divide(10, 0).or(-1)  // Returns -1 on error
 ```
 
+### Result Combinators
+
+For transformation-heavy code, use combinators instead of nested `match` expressions:
+
+```ard
+let res: Int!Str = Result::ok(21)
+let doubled = res.map(fn(v) { v * 2 })
+let normalized = doubled.map_err(fn(err) { "calc failed: {err}" })
+```
+
+Chain operations that may fail with `and_then`:
+
+```ard
+fn parse_num(raw: Str) Int!Str { ... }
+fn ensure_even(num: Int) Int!Str { ... }
+
+let checked = parse_num("42").and_then(ensure_even)
+```
+
+If inference is ambiguous, explicit type args can guide the checker:
+
+```ard
+let text = parse_num("42").and_then<Str>(fn(v) { Result::ok("{v}") })
+```
+
 ## Maybe Types
 
 Maybe types represent values that may or may not exist. They are written as `Type?` and are equivalent to `Maybe<Type>`:
@@ -73,6 +98,39 @@ match user {
     user => io::print("Found user: {user.name}"),
     _ => io::print("User not found")
 }
+```
+
+### Maybe Combinators
+
+Use `map` to transform a present value and keep `none` unchanged:
+
+```ard
+use ard/maybe
+
+let maybe_name: Str? = maybe::some("Alice")
+let maybe_len = maybe_name.map(fn(name) { name.size() })
+```
+
+Use `and_then` to chain Maybe-producing operations:
+
+```ard
+use ard/maybe
+
+fn non_empty(name: Str) Str? {
+  match name.is_empty() {
+    true => maybe::none(),
+    false => maybe::some(name),
+  }
+}
+
+let maybe_name: Str? = maybe::some("Alice")
+let checked = maybe_name.and_then(non_empty)
+```
+
+As with Results, explicit type args can guide inference when needed:
+
+```ard
+let maybe_text = maybe::some(42).map<Str>(fn(v) { "{v}" })
 ```
 
 ## The try Keyword

--- a/website/src/content/docs/stdlib/maybe.md
+++ b/website/src/content/docs/stdlib/maybe.md
@@ -87,6 +87,53 @@ let val: Int? = maybe::none()
 let result = val.or(0)  // 0
 ```
 
+### `fn expect(message: Str) $T`
+
+Get the value from the Maybe, or panic with a message if it's empty.
+
+```ard
+use ard/maybe
+
+let val: Int? = maybe::some(42)
+let result = val.expect("expected a value")  // 42
+```
+
+### `fn map(with: fn($T) $U) $U?`
+
+Transform a `some` value and keep `none` unchanged.
+
+```ard
+use ard/maybe
+
+let num: Int? = maybe::some(21)
+let doubled = num.map(fn(v) { v * 2 })
+let value = doubled.or(0) // 42
+```
+
+You can also provide explicit type arguments when you want to guide inference:
+
+```ard
+let as_text = num.map<Str>(fn(v) { "{v}" })
+```
+
+### `fn and_then(with: fn($T) $U?) $U?`
+
+Chain Maybe-producing operations (also known as `flat_map` in other languages).
+
+```ard
+use ard/maybe
+
+fn even_only(num: Int) Int? {
+  match num % 2 == 0 {
+    true => maybe::some(num),
+    false => maybe::none(),
+  }
+}
+
+let result = maybe::some(20).and_then(even_only)
+result.is_some() // true
+```
+
 ## Pattern Matching with Maybe
 
 Use `match` expressions to safely handle optional values:

--- a/website/src/content/docs/stdlib/result.md
+++ b/website/src/content/docs/stdlib/result.md
@@ -109,6 +109,49 @@ let result: Int!Str = Result::ok(42)
 let value = result.expect("Expected success")  // 42
 ```
 
+### `fn map(with: fn($T) $U) $U!$E`
+
+Transform the `ok` value while preserving the same error type.
+
+```ard
+let result: Int!Str = Result::ok(21)
+let doubled = result.map(fn(v) { v * 2 })
+let value = doubled.or(0) // 42
+```
+
+### `fn map_err(with: fn($E) $F) $T!$F`
+
+Transform the `err` value while preserving the same success type.
+
+```ard
+let result: Int!Str = Result::err("bad")
+let sized = result.map_err(fn(err) { err.size() })
+sized.is_err() // true (type is Int!Int)
+```
+
+### `fn and_then(with: fn($T) $U!$E) $U!$E`
+
+Chain Result-producing operations (also known as `flat_map` in other languages).
+
+```ard
+fn ensure_even(num: Int) Int!Str {
+  match num % 2 == 0 {
+    true => Result::ok(num),
+    false => Result::err("not even"),
+  }
+}
+
+let res: Int!Str = Result::ok(20)
+let checked = res.and_then(ensure_even)
+checked.is_ok() // true
+```
+
+You can provide explicit type arguments to guide inference when needed:
+
+```ard
+let as_text = res.and_then<Str>(fn(v) { Result::ok("{v}") })
+```
+
 ## Pattern Matching with Result
 
 Use `match` expressions to handle both success and error cases:


### PR DESCRIPTION
## Summary
- add `Maybe.map(with)` and `Maybe.and_then(with)`
- add `Result.map(with)`, `Result.map_err(with)`, and `Result.and_then(with)`
- support anonymous callback inference for these combinators
- fix checker inference gap by binding inferred TypeVars recursively from expected wrapper types
  - resolves previously unrefined `$MappedVal` cases in `and_then` flows
- remove completed TODO item: `still need some sort of mapping for Result/Maybe`
- add comprehensive checker + VM tests, including explicit type argument coverage on combinator methods

## Validation
- `cd compiler && go test ./checker -run TestResults -v`
- `cd compiler && go test ./bytecode/vm -run "TestBytecodeMaybes|TestBytecodeResults" -v`
- `cd compiler && go test ./...`

## Notes
This includes explicit type-arg tests such as:
- `res.map_err<Int>(...)`
- `res.and_then<Str>(...)`
- `value.map<Str>(...)`
- `value.and_then<Str>(...)`
