### PR TITLE
fix(parser): support multi-line dot-chaining

### DIFF
--- a/compiler/bytecode/vm/vm_expressions_test.go
+++ b/compiler/bytecode/vm/vm_expressions_test.go
@@ -61,6 +61,62 @@ func TestBytecodeVMParityCoreExpressions(t *testing.T) {
 	}
 }
 
+func TestBytecodeVMMultilineDotChaining(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  any
+	}{
+		{
+			name: "property access on next line",
+			input: `
+				let x = [1, 2, 3]
+					.size()
+				x
+			`,
+			want: 3,
+		},
+		{
+			name: "chained methods across multiple lines",
+			input: `
+				let x = "hello"
+					.size()
+				x
+			`,
+			want: 5,
+		},
+		{
+			name: "three-level chain across lines",
+			input: `
+				let x: Int!Str = Result::ok(42)
+				let y = x
+					.map(fn(v: Int) Str { "{v}!" })
+					.or("fail")
+				y
+			`,
+			want: "42!",
+		},
+		{
+			name: "mixed single and multi-line chaining",
+			input: `
+				let a = [10, 20, 30].size()
+				let b = [1, 2]
+					.size()
+				a + b
+			`,
+			want: 5,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := runBytecode(t, test.input); got != test.want {
+				t.Fatalf("Expected %v, got %v", test.want, got)
+			}
+		})
+	}
+}
+
 func TestBytecodeVMNotGroupingChangesSemantics(t *testing.T) {
 	if got := runBytecode(t, `(not false) and false`); got != false {
 		t.Fatalf("Expected (not false) and false to be false, got %v", got)

--- a/compiler/parse/parser.go
+++ b/compiler/parse/parser.go
@@ -2729,7 +2729,18 @@ func (p *parser) memberAccess() (Expression, error) {
 		return nil, err
 	}
 
-	for p.match(dot, colon_colon) {
+	for {
+		// Allow dot-chaining across newlines: skip newlines and check for a
+		// leading dot, but restore position if the next non-newline token
+		// isn't a dot (so we don't swallow newlines that act as statement
+		// terminators).
+		savedIndex := p.index
+		p.skipNewlines()
+		if !p.match(dot, colon_colon) {
+			p.index = savedIndex
+			break
+		}
+
 		if p.previous().kind == dot {
 			call, err := p.call()
 			if err != nil {
@@ -2747,8 +2758,6 @@ func (p *parser) memberAccess() (Expression, error) {
 					Target: expr,
 					Method: *prop,
 				}
-				// match line break for multi-line chaining
-				p.match(new_line)
 			}
 		} else {
 			// Check for type arguments in static function calls


### PR DESCRIPTION
## Problem

Multi-line dot-chaining caused a parse error:

```ard
let result = foo()
  .map(fn(x: Int) Int { x + 1 })
  .or(0)
// => Parse error: Unexpected token: dot
```

Workaround was intermediate `let` bindings.

## Fix

In `memberAccess()`, the loop now skips newlines before checking for a `dot` token. If no dot follows, the parser restores its position so newlines acting as statement terminators aren't consumed.

## Tests

Added `TestBytecodeVMMultilineDotChaining` with cases:
- Property access on next line
- Chained methods across multiple lines
- Three-level chain across lines (with Result combinators)
- Mixed single-line and multi-line chaining

All existing tests pass.