### PR TITLE
fix(vm): preserve inner type when refining Result return values

### DIFF
--- a/compiler/bytecode/vm/result_test.go
+++ b/compiler/bytecode/vm/result_test.go
@@ -149,6 +149,148 @@ func TestBytecodeResults(t *testing.T) {
 	}
 }
 
+func TestBytecodeResultOrThenMaybeCombinators(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  any
+	}{
+		{
+			name: "map after or(maybe::none()) on ok result",
+			input: `
+				use ard/maybe
+				let res: Str?!Str = Result::ok(maybe::some("hello"))
+				let val = res
+					.or(maybe::none())
+					.map(fn(s: Str) Int { s.size() })
+					.or(0)
+				val
+			`,
+			want: 5,
+		},
+		{
+			name: "map after or(maybe::none()) on err result",
+			input: `
+				use ard/maybe
+				let res: Str?!Str = Result::err("bad")
+				let val = res
+					.or(maybe::none())
+					.map(fn(s: Str) Int { s.size() })
+					.or(0)
+				val
+			`,
+			want: 0,
+		},
+		{
+			name: "and_then after or(maybe::none()) on ok result",
+			input: `
+				use ard/maybe
+				let res: Str?!Str = Result::ok(maybe::some("world"))
+				let val = res
+					.or(maybe::none())
+					.and_then(fn(s: Str) Int? { maybe::some(s.size()) })
+					.or(0)
+				val
+			`,
+			want: 5,
+		},
+		{
+			name: "and_then after or(maybe::none()) on err result",
+			input: `
+				use ard/maybe
+				let res: Str?!Str = Result::err("bad")
+				let val = res
+					.or(maybe::none())
+					.and_then(fn(s: Str) Int? { maybe::some(s.size()) })
+					.or(0)
+				val
+			`,
+			want: 0,
+		},
+		{
+			name: "or(fallback) after or(maybe::none())",
+			input: `
+				use ard/maybe
+				let res: Str?!Str = Result::err("bad")
+				let val = res
+					.or(maybe::none())
+					.or("default")
+				val
+			`,
+			want: "default",
+		},
+		{
+			name: "intermediate let binding preserves Maybe type",
+			input: `
+				use ard/maybe
+				let res: Str?!Str = Result::ok(maybe::some("test"))
+				let maybe_val: Str? = res.or(maybe::none())
+				let mapped = maybe_val.map(fn(s: Str) Int { s.size() })
+				mapped.or(0)
+			`,
+			want: 4,
+		},
+		{
+			name: "map after or(maybe::none()) on function return value",
+			input: `
+				use ard/maybe
+
+				fn returns_result() Dynamic?!Str {
+					Result::ok(maybe::some(Dynamic::from("hello")))
+				}
+
+				let val = returns_result()
+					.or(maybe::none())
+					.map(fn(d: Dynamic) Str { "got it" })
+					.or("nope")
+				val
+			`,
+			want: "got it",
+		},
+		{
+			name: "and_then after or(maybe::none()) on function return value",
+			input: `
+				use ard/maybe
+
+				fn returns_result() Dynamic?!Str {
+					Result::ok(maybe::some(Dynamic::from("hello")))
+				}
+
+				let val = returns_result()
+					.or(maybe::none())
+					.and_then(fn(d: Dynamic) Str? { maybe::some("chained") })
+					.or("nope")
+				val
+			`,
+			want: "chained",
+		},
+		{
+			name: "map with intermediate binding from function return",
+			input: `
+				use ard/maybe
+
+				fn returns_result() Dynamic?!Str {
+					Result::ok(maybe::some(Dynamic::from("test")))
+				}
+
+				let res = returns_result()
+				let maybe_val = res.or(maybe::none())
+				let mapped = maybe_val.map(fn(d: Dynamic) Str { "mapped" })
+				mapped.or("nope")
+			`,
+			want: "mapped",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := runBytecode(t, test.input); got != test.want {
+				t.Fatalf("Expected %v, got %v", test.want, got)
+			}
+		})
+	}
+}
+
 func TestBytecodeTryResultParity(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/compiler/runtime/object.go
+++ b/compiler/runtime/object.go
@@ -74,6 +74,19 @@ func (o *Object) Set(v any) {
 //     let result = returns_generic()
 //     result.expect("foobar").do_stuff() // .expect(...) returns an open generic
 func (o *Object) SetRefinedType(declared checker.Type) {
+	// When the declared type is a Result and this object is already a result
+	// value (isOk/isErr), refine to the appropriate inner type rather than
+	// the full Result wrapper. This prevents .or() unwraps from losing their
+	// inner type (e.g. Maybe<Dynamic>) when the function return type is
+	// Result<Dynamic?, Str>.
+	if declResult, ok := declared.(*checker.Result); ok && (o.isOk || o.isErr) {
+		if o.isOk {
+			declared = declResult.Val()
+		} else {
+			declared = declResult.Err()
+		}
+	}
+
 	if result, ok := o._type.(*checker.Result); ok {
 		if o.isErr {
 			o._type = result.Err()


### PR DESCRIPTION
## Problem

Chaining Maybe combinators after `Result.or(maybe::none())` panicked at runtime:

```ard
fn returns_result() Dynamic?!Str {
  Result::ok(maybe::some(Dynamic::from("hello")))
}

// panic: expected Maybe subject for map, got Dynamic?!Str
returns_result()
  .or(maybe::none())
  .map(fn(d: Dynamic) Str { "got it" })
```

The type checker accepted the code, but the VM saw the wrong type on the unwrapped value.

## Root Cause

`SetRefinedType` in `OpReturn` was called with the function's return type (`Result<Dynamic?, Str>`) on the value being returned. The ok value's inner type was `Maybe<Dynamic>` (from `MakeOk`/`UnwrapResult`), which matched the `IsMaybe` branch in `SetRefinedType` and was **overwritten** with the full `Result<Dynamic?, Str>` type.

After this, `.or()` unwrapped correctly but the object retained the Result type, causing `evalMaybeMethod` to fail its type assertion.

## Fix

When `SetRefinedType` receives a Result type and the object is already a result value (`isOk`/`isErr`), extract the appropriate inner type (`Val()` or `Err()`) before applying refinement. This prevents the full Result wrapper from replacing the inner Maybe type.

## Tests

Added 3 new test cases in `TestBytecodeResultOrThenMaybeCombinators`:
- `.map()` after `.or(maybe::none())` on function return value
- `.and_then()` after `.or(maybe::none())` on function return value
- `.map()` with intermediate let binding from function return

All existing tests pass.