### PR TITLE
docs: clarify map vs and_then distinction

### DIFF
--- a/website/src/content/docs/guide/error-handling.mdx
+++ b/website/src/content/docs/guide/error-handling.mdx
@@ -46,24 +46,33 @@ let safe_result = divide(10, 0).or(-1)  // Returns -1 on error
 
 For transformation-heavy code, use combinators instead of nested `match` expressions:
 
+- **`map`** — transforms the ok value; the callback returns a **plain value** that is automatically wrapped in `ok(...)`. Use when the transformation cannot fail.
+- **`map_err`** — same idea but for the error side.
+- **`and_then`** — the callback returns a **Result** itself, so it can succeed or fail. Use when the next step can produce its own error.
+
 ```ard
 let res: Int!Str = Result::ok(21)
-let doubled = res.map(fn(v) { v * 2 })
-let normalized = doubled.map_err(fn(err) { "calc failed: {err}" })
-```
 
-Chain operations that may fail with `and_then`:
+// map: always succeeds — callback returns a plain value
+let doubled = res.map(fn(v) { v * 2 })          // ok(42)
 
-```ard
-fn parse_num(raw: Str) Int!Str { ... }
-fn ensure_even(num: Int) Int!Str { ... }
+// and_then: can fail — callback returns a Result
+fn ensure_positive(n: Int) Int!Str {
+  match n > 0 {
+    true => Result::ok(n),
+    false => Result::err("not positive"),
+  }
+}
+let checked = doubled.and_then(ensure_positive)  // ok(42)
 
-let checked = parse_num("42").and_then(ensure_even)
+// map_err: transform the error side
+let normalized = res.map_err(fn(err) { "calc failed: {err}" })
 ```
 
 If inference is ambiguous, explicit type args can guide the checker:
 
 ```ard
+fn parse_num(raw: Str) Int!Str { ... }
 let text = parse_num("42").and_then<Str>(fn(v) { Result::ok("{v}") })
 ```
 
@@ -102,29 +111,26 @@ match user {
 
 ### Maybe Combinators
 
-Use `map` to transform a present value and keep `none` unchanged:
+- **`map`** — transforms a present value; the callback returns a **plain value** that is automatically wrapped in `some(...)`. Use when the transformation always produces a value.
+- **`and_then`** — the callback returns a **Maybe** itself, so it can produce `some(...)` or `none()`. Use when the next step might not produce a value.
 
 ```ard
 use ard/maybe
 
+// map: always produces a value — callback returns a plain value
 let maybe_name: Str? = maybe::some("Alice")
-let maybe_len = maybe_name.map(fn(name) { name.size() })
-```
+let maybe_len = maybe_name.map(fn(name) { name.size() }) // some(5)
 
-Use `and_then` to chain Maybe-producing operations:
-
-```ard
-use ard/maybe
-
+// and_then: can produce none — callback returns a Maybe
 fn non_empty(name: Str) Str? {
   match name.is_empty() {
     true => maybe::none(),
     false => maybe::some(name),
   }
 }
-
-let maybe_name: Str? = maybe::some("Alice")
-let checked = maybe_name.and_then(non_empty)
+let checked = maybe_name.and_then(non_empty) // some("Alice")
+let empty: Str? = maybe::some("")
+empty.and_then(non_empty) // none
 ```
 
 As with Results, explicit type args can guide inference when needed:

--- a/website/src/content/docs/stdlib/maybe.md
+++ b/website/src/content/docs/stdlib/maybe.md
@@ -100,7 +100,9 @@ let result = val.expect("expected a value")  // 42
 
 ### `fn map(with: fn($T) $U) $U?`
 
-Transform a `some` value and keep `none` unchanged.
+Transform a `some` value with a function that **returns a plain value**. The result is automatically wrapped in `some(...)`. If the Maybe is `none`, the callback is not called and `none` passes through unchanged.
+
+Use `map` when the transformation always produces a value.
 
 ```ard
 use ard/maybe
@@ -108,6 +110,10 @@ use ard/maybe
 let num: Int? = maybe::some(21)
 let doubled = num.map(fn(v) { v * 2 })
 let value = doubled.or(0) // 42
+
+// none passes through untouched
+let empty: Int? = maybe::none()
+empty.map(fn(v) { v * 2 }).is_none() // true
 ```
 
 You can also provide explicit type arguments when you want to guide inference:
@@ -118,7 +124,9 @@ let as_text = num.map<Str>(fn(v) { "{v}" })
 
 ### `fn and_then(with: fn($T) $U?) $U?`
 
-Chain Maybe-producing operations (also known as `flat_map` in other languages).
+Chain operations that **return a Maybe themselves** (also known as `flat_map` in other languages). Unlike `map`, the callback is responsible for wrapping its return value in `some(...)` or returning `none()`. This lets the callback itself decide whether a value is present.
+
+Use `and_then` when the next step might not produce a value.
 
 ```ard
 use ard/maybe
@@ -132,6 +140,10 @@ fn even_only(num: Int) Int? {
 
 let result = maybe::some(20).and_then(even_only)
 result.is_some() // true
+
+// The callback can return none, unlike map:
+let odd = maybe::some(21).and_then(even_only)
+odd.is_none() // true
 ```
 
 ## Pattern Matching with Maybe

--- a/website/src/content/docs/stdlib/result.md
+++ b/website/src/content/docs/stdlib/result.md
@@ -111,17 +111,23 @@ let value = result.expect("Expected success")  // 42
 
 ### `fn map(with: fn($T) $U) $U!$E`
 
-Transform the `ok` value while preserving the same error type.
+Transform the `ok` value with a function that **returns a plain value**. The result is automatically wrapped in `ok(...)`. If the Result is an error, the callback is not called and the error passes through unchanged.
+
+Use `map` when the transformation itself cannot fail.
 
 ```ard
 let result: Int!Str = Result::ok(21)
 let doubled = result.map(fn(v) { v * 2 })
 let value = doubled.or(0) // 42
+
+// Errors pass through untouched
+let err: Int!Str = Result::err("bad")
+err.map(fn(v) { v * 2 }).is_err() // true
 ```
 
 ### `fn map_err(with: fn($E) $F) $T!$F`
 
-Transform the `err` value while preserving the same success type.
+Transform the `err` value while preserving the same success type. The counterpart to `map` for the error side.
 
 ```ard
 let result: Int!Str = Result::err("bad")
@@ -131,7 +137,9 @@ sized.is_err() // true (type is Int!Int)
 
 ### `fn and_then(with: fn($T) $U!$E) $U!$E`
 
-Chain Result-producing operations (also known as `flat_map` in other languages).
+Chain operations that **return a Result themselves** (also known as `flat_map` in other languages). Unlike `map`, the callback is responsible for wrapping its return value in `ok(...)` or `err(...)`. This lets the callback itself decide whether to succeed or fail.
+
+Use `and_then` when the next step can produce its own error.
 
 ```ard
 fn ensure_even(num: Int) Int!Str {
@@ -144,6 +152,10 @@ fn ensure_even(num: Int) Int!Str {
 let res: Int!Str = Result::ok(20)
 let checked = res.and_then(ensure_even)
 checked.is_ok() // true
+
+// The callback can fail, unlike map:
+let odd: Int!Str = Result::ok(21)
+odd.and_then(ensure_even).is_err() // true — "not even"
 ```
 
 You can provide explicit type arguments to guide inference when needed:


### PR DESCRIPTION
Clarifies the key difference between `map` and `and_then` across all combinator docs:

- **`map`**: callback returns a plain value (auto-wrapped in ok/some)
- **`and_then`**: callback returns a Result/Maybe itself (can fail or return none)

Updated in:
- `website/src/content/docs/stdlib/result.md`
- `website/src/content/docs/stdlib/maybe.md`
- `website/src/content/docs/guide/error-handling.mdx`

Also updated v0.13.0 release notes with the same clarification.