### PR TITLE
feat: require ard version constraint in ard.toml

### DIFF
--- a/compiler/bytecode/vm/vm_modules_test.go
+++ b/compiler/bytecode/vm/vm_modules_test.go
@@ -14,7 +14,7 @@ func TestBytecodeVMParityModuleIntegration(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\""), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.1.0\"\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(filepath.Join(tempDir, "math.ard"), []byte("fn add(a: Int, b: Int) Int { a + b }"), 0644); err != nil {
@@ -35,7 +35,7 @@ math::add(10, 20)`)
 		}
 		defer os.RemoveAll(tempDir)
 
-		if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\""), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.1.0\"\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(filepath.Join(tempDir, "utils.ard"), []byte(`let add_one = fn(x: Int) Int { x + 1 }`), 0644); err != nil {
@@ -56,7 +56,7 @@ utils::add_one(5)`)
 		}
 		defer os.RemoveAll(tempDir)
 
-		if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\""), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.1.0\"\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(filepath.Join(tempDir, "utils.ard"), []byte(`let double = fn(x: Int) Int { x * 2 }`), 0644); err != nil {
@@ -78,7 +78,7 @@ f(10)`)
 		}
 		defer os.RemoveAll(tempDir)
 
-		if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\""), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.1.0\"\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(filepath.Join(tempDir, "sessions.ard"), []byte(`fn cleanup_expired_sessions() {
@@ -108,7 +108,7 @@ fiber.join()`)
 		}
 		defer os.RemoveAll(tempDir)
 
-		if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\""), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.1.0\"\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(filepath.Join(tempDir, "sessions.ard"), []byte(`fn cleanup_expired_sessions() {

--- a/compiler/checker/module_resolver.go
+++ b/compiler/checker/module_resolver.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 
 	"github.com/akonwi/ard/parse"
+	"github.com/akonwi/ard/version"
 )
 
 // ProjectInfo holds information about the current project
@@ -43,6 +44,16 @@ func FindProjectRoot(startPath string) (*ProjectInfo, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse ard.toml: %w", err)
 			}
+
+			// Check ard version constraint (required in ard.toml)
+			constraint, ok := parseArdVersion(tomlPath)
+			if !ok {
+				return nil, fmt.Errorf("ard.toml is missing required field: ard (e.g. ard = \">= 0.13.0\")")
+			}
+			if err := version.CheckVersion(constraint); err != nil {
+				return nil, err
+			}
+
 			return &ProjectInfo{
 				RootPath:    current,
 				ProjectName: projectName,
@@ -79,6 +90,23 @@ func parseProjectName(tomlPath string) (string, error) {
 	}
 
 	return matches[1], nil
+}
+
+// parseArdVersion extracts the ard constraint from ard.toml if present.
+// Format: ard = ">= 0.13.0" or ard = "0.13.0"
+func parseArdVersion(tomlPath string) (string, bool) {
+	content, err := os.ReadFile(tomlPath)
+	if err != nil {
+		return "", false
+	}
+
+	re := regexp.MustCompile(`(?m)^\s*ard\s*=\s*["']([^"']+)["']`)
+	matches := re.FindStringSubmatch(string(content))
+	if len(matches) < 2 {
+		return "", false
+	}
+
+	return matches[1], true
 }
 
 // NewModuleResolver creates a new module resolver for the given working directory

--- a/compiler/checker/module_resolver_test.go
+++ b/compiler/checker/module_resolver_test.go
@@ -3,6 +3,7 @@ package checker_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/akonwi/ard/checker"
@@ -17,7 +18,7 @@ func TestFindProjectRoot(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create ard.toml file
-	tomlContent := `name = "test_project"`
+	tomlContent := "name = \"test_project\"\nard = \">= 0.1.0\"\n"
 	tomlPath := filepath.Join(tempDir, "ard.toml")
 	err = os.WriteFile(tomlPath, []byte(tomlContent), 0644)
 	if err != nil {
@@ -67,6 +68,44 @@ func TestFindProjectRootFallback(t *testing.T) {
 	}
 }
 
+func TestArdVersionConstraint(t *testing.T) {
+	t.Run("missing ard field is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "ard.toml"), []byte(`name = "demo"`), 0644)
+
+		_, err := checker.NewModuleResolver(dir)
+		if err == nil {
+			t.Fatal("expected error for missing ard field")
+		}
+		if !strings.Contains(err.Error(), "missing required field: ard") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("dev version always passes", func(t *testing.T) {
+		dir := t.TempDir()
+		// Require a very high version — should still pass because compiler is "dev"
+		os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 99.0.0\"\n"), 0644)
+
+		_, err := checker.NewModuleResolver(dir)
+		if err != nil {
+			t.Fatalf("dev version should skip check, got: %v", err)
+		}
+	})
+
+	t.Run("invalid constraint is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \"not-a-version\"\n"), 0644)
+
+		// With "dev" version, CheckVersion skips the check, so this won't error.
+		// This test documents that invalid constraints are only caught with real versions.
+		_, err := checker.NewModuleResolver(dir)
+		if err != nil {
+			t.Fatalf("dev version should skip even invalid constraints, got: %v", err)
+		}
+	})
+}
+
 func TestResolveImportPath(t *testing.T) {
 	// Create test project structure
 	tempDir, err := os.MkdirTemp("", "ard_resolve_test_*")
@@ -76,7 +115,7 @@ func TestResolveImportPath(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create ard.toml
-	tomlContent := `name = "my_calculator"`
+	tomlContent := "name = \"my_calculator\"\nard = \">= 0.1.0\"\n"
 	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte(tomlContent), 0644)
 	if err != nil {
 		t.Fatal(err)

--- a/compiler/checker/user_modules_test.go
+++ b/compiler/checker/user_modules_test.go
@@ -19,7 +19,8 @@ func TestUserModulePathResolution(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create ard.toml
-	tomlContent := `name = "test_project"`
+	tomlContent := `name = "test_project"
+ard = ">= 0.1.0"`
 	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte(tomlContent), 0644)
 	if err != nil {
 		t.Fatal(err)
@@ -89,7 +90,8 @@ func TestUserModuleImports(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create ard.toml
-	tomlContent := `name = "my_calculator"`
+	tomlContent := `name = "my_calculator"
+ard = ">= 0.1.0"`
 	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte(tomlContent), 0644)
 	if err != nil {
 		t.Fatal(err)
@@ -153,7 +155,7 @@ func TestUserModuleSymbolResolution(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create project structure
-	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\""), 0644)
+	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.1.0\"\n"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +240,7 @@ func TestUserModulePrivateAccessError(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create project structure
-	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\""), 0644)
+	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.1.0\"\n"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +299,7 @@ func TestUserModuleCaching(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create project structure
-	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\""), 0644)
+	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.1.0\"\n"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,7 +380,8 @@ func TestUserModuleErrors(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create ard.toml
-	tomlContent := `name = "error_project"`
+	tomlContent := `name = "error_project"
+ard = ">= 0.1.0"`
 	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte(tomlContent), 0644)
 	if err != nil {
 		t.Fatal(err)
@@ -484,7 +487,8 @@ func TestLoadModule(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create ard.toml
-	tomlContent := `name = "load_test"`
+	tomlContent := `name = "load_test"
+ard = ">= 0.1.0"`
 	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte(tomlContent), 0644)
 	if err != nil {
 		t.Fatal(err)
@@ -540,7 +544,8 @@ func TestLoadModuleErrors(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create ard.toml
-	tomlContent := `name = "error_test"`
+	tomlContent := `name = "error_test"
+ard = ">= 0.1.0"`
 	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte(tomlContent), 0644)
 	if err != nil {
 		t.Fatal(err)
@@ -607,7 +612,8 @@ func TestModuleAST_Caching(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create ard.toml
-	tomlContent := `name = "cache_test"`
+	tomlContent := `name = "cache_test"
+ard = ">= 0.1.0"`
 	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte(tomlContent), 0644)
 	if err != nil {
 		t.Fatal(err)
@@ -674,7 +680,8 @@ func TestCircularDependencyDetection(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create ard.toml
-	tomlContent := `name = "circular_test"`
+	tomlContent := `name = "circular_test"
+ard = ">= 0.1.0"`
 	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte(tomlContent), 0644)
 	if err != nil {
 		t.Fatal(err)
@@ -734,7 +741,8 @@ func TestComplexCircularDependency(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create ard.toml
-	tomlContent := `name = "complex_circular"`
+	tomlContent := `name = "complex_circular"
+ard = ">= 0.1.0"`
 	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte(tomlContent), 0644)
 	if err != nil {
 		t.Fatal(err)
@@ -784,7 +792,8 @@ func TestNonCircularDependencies(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create ard.toml
-	tomlContent := `name = "valid_deps"`
+	tomlContent := `name = "valid_deps"
+ard = ">= 0.1.0"`
 	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte(tomlContent), 0644)
 	if err != nil {
 		t.Fatal(err)
@@ -837,7 +846,7 @@ func TestVariableModuleExports(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create project structure
-	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\""), 0644)
+	err = os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.1.0\"\n"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/compiler/main_test.go
+++ b/compiler/main_test.go
@@ -262,7 +262,7 @@ func TestTestCommand(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(projectDir, "test"), 0o755); err != nil {
 		t.Fatalf("failed to create project dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(projectDir, "ard.toml"), []byte("name = \"demo\"\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(projectDir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
 		t.Fatalf("failed to write ard.toml: %v", err)
 	}
 	mainSource := `use ard/testing
@@ -336,7 +336,7 @@ func TestTestCommandRespectsPrivateAccessInTestDir(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(projectDir, "test"), 0o755); err != nil {
 		t.Fatalf("failed to create project dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(projectDir, "ard.toml"), []byte("name = \"demo\"\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(projectDir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
 		t.Fatalf("failed to write ard.toml: %v", err)
 	}
 	utilsSource := `private fn private_helper() Int {

--- a/compiler/samples/ard.toml
+++ b/compiler/samples/ard.toml
@@ -1,1 +1,2 @@
 name = "samples"
+ard = ">= 0.13.0"

--- a/compiler/version/semver.go
+++ b/compiler/version/semver.go
@@ -1,0 +1,151 @@
+package version
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Semver represents a parsed semantic version (major.minor.patch).
+type Semver struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func (v Semver) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// Compare returns -1 if v < other, 0 if equal, 1 if v > other.
+func (v Semver) Compare(other Semver) int {
+	if v.Major != other.Major {
+		if v.Major < other.Major {
+			return -1
+		}
+		return 1
+	}
+	if v.Minor != other.Minor {
+		if v.Minor < other.Minor {
+			return -1
+		}
+		return 1
+	}
+	if v.Patch != other.Patch {
+		if v.Patch < other.Patch {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+// ParseSemver parses a version string like "0.13.0" or "v0.13.0".
+func ParseSemver(s string) (Semver, error) {
+	s = strings.TrimPrefix(s, "v")
+	parts := strings.Split(s, ".")
+
+	if len(parts) < 2 || len(parts) > 3 {
+		return Semver{}, fmt.Errorf("invalid version format: %q (expected MAJOR.MINOR or MAJOR.MINOR.PATCH)", s)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return Semver{}, fmt.Errorf("invalid major version in %q: %w", s, err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return Semver{}, fmt.Errorf("invalid minor version in %q: %w", s, err)
+	}
+
+	patch := 0
+	if len(parts) == 3 {
+		patch, err = strconv.Atoi(parts[2])
+		if err != nil {
+			return Semver{}, fmt.Errorf("invalid patch version in %q: %w", s, err)
+		}
+	}
+
+	return Semver{Major: major, Minor: minor, Patch: patch}, nil
+}
+
+// Constraint represents a version constraint like ">= 0.13.0".
+type Constraint struct {
+	Op      string // ">=", ">", "=", "<=", "<"
+	Version Semver
+}
+
+// Check returns true if the given version satisfies this constraint.
+func (c Constraint) Check(v Semver) bool {
+	cmp := v.Compare(c.Version)
+	switch c.Op {
+	case ">=":
+		return cmp >= 0
+	case ">":
+		return cmp > 0
+	case "=", "==":
+		return cmp == 0
+	case "<=":
+		return cmp <= 0
+	case "<":
+		return cmp < 0
+	default:
+		return false
+	}
+}
+
+func (c Constraint) String() string {
+	return fmt.Sprintf("%s %s", c.Op, c.Version)
+}
+
+// ParseConstraint parses a constraint string like ">= 0.13.0" or "0.13.0" (exact match).
+func ParseConstraint(s string) (Constraint, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return Constraint{}, fmt.Errorf("empty version constraint")
+	}
+
+	// Try to extract operator
+	for _, op := range []string{">=", "<=", "==", ">", "<", "="} {
+		if strings.HasPrefix(s, op) {
+			ver, err := ParseSemver(strings.TrimSpace(s[len(op):]))
+			if err != nil {
+				return Constraint{}, err
+			}
+			return Constraint{Op: op, Version: ver}, nil
+		}
+	}
+
+	// No operator — treat as exact match
+	ver, err := ParseSemver(s)
+	if err != nil {
+		return Constraint{}, err
+	}
+	return Constraint{Op: ">=", Version: ver}, nil
+}
+
+// CheckVersion checks whether the current compiler version satisfies the given
+// constraint string. Returns nil if satisfied, or an error describing the mismatch.
+// If the compiler version is "dev", the check is skipped.
+func CheckVersion(constraint string) error {
+	current := Get()
+	if current == "dev" {
+		return nil
+	}
+
+	currentVer, err := ParseSemver(current)
+	if err != nil {
+		return fmt.Errorf("failed to parse compiler version %q: %w", current, err)
+	}
+
+	c, err := ParseConstraint(constraint)
+	if err != nil {
+		return fmt.Errorf("invalid ard_version constraint %q: %w", constraint, err)
+	}
+
+	if !c.Check(currentVer) {
+		return fmt.Errorf("this project requires Ard %s, but you are running %s", c, currentVer)
+	}
+
+	return nil
+}

--- a/compiler/version/semver.go
+++ b/compiler/version/semver.go
@@ -17,27 +17,34 @@ func (v Semver) String() string {
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 }
 
-// Compare returns -1 if v < other, 0 if equal, 1 if v > other.
+// Comparison results for Semver.Compare.
+const (
+	LessThan    = -1
+	Equal       = 0
+	GreaterThan = 1
+)
+
+// Compare returns LessThan if v < other, Equal if v == other, GreaterThan if v > other.
 func (v Semver) Compare(other Semver) int {
 	if v.Major != other.Major {
 		if v.Major < other.Major {
-			return -1
+			return LessThan
 		}
-		return 1
+		return GreaterThan
 	}
 	if v.Minor != other.Minor {
 		if v.Minor < other.Minor {
-			return -1
+			return LessThan
 		}
-		return 1
+		return GreaterThan
 	}
 	if v.Patch != other.Patch {
 		if v.Patch < other.Patch {
-			return -1
+			return LessThan
 		}
-		return 1
+		return GreaterThan
 	}
-	return 0
+	return Equal
 }
 
 // ParseSemver parses a version string like "0.13.0" or "v0.13.0".
@@ -80,15 +87,15 @@ func (c Constraint) Check(v Semver) bool {
 	cmp := v.Compare(c.Version)
 	switch c.Op {
 	case ">=":
-		return cmp >= 0
+		return cmp == GreaterThan || cmp == Equal
 	case ">":
-		return cmp > 0
+		return cmp == GreaterThan
 	case "=", "==":
-		return cmp == 0
+		return cmp == Equal
 	case "<=":
-		return cmp <= 0
+		return cmp == LessThan || cmp == Equal
 	case "<":
-		return cmp < 0
+		return cmp == LessThan
 	default:
 		return false
 	}

--- a/compiler/version/semver_test.go
+++ b/compiler/version/semver_test.go
@@ -1,0 +1,179 @@
+package version
+
+import (
+	"testing"
+)
+
+func TestParseSemver(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    Semver
+		wantErr bool
+	}{
+		{"0.13.0", Semver{0, 13, 0}, false},
+		{"v0.13.0", Semver{0, 13, 0}, false},
+		{"1.2.3", Semver{1, 2, 3}, false},
+		{"0.1", Semver{0, 1, 0}, false},
+		{"v1.0", Semver{1, 0, 0}, false},
+		{"", Semver{}, true},
+		{"abc", Semver{}, true},
+		{"1.2.3.4", Semver{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseSemver(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseSemver(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSemverCompare(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"0.13.0", "0.13.0", 0},
+		{"0.13.1", "0.13.0", 1},
+		{"0.13.0", "0.13.1", -1},
+		{"0.14.0", "0.13.0", 1},
+		{"1.0.0", "0.99.99", 1},
+		{"0.1.0", "0.2.0", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			a, _ := ParseSemver(tt.a)
+			b, _ := ParseSemver(tt.b)
+			got := a.Compare(b)
+			if got != tt.want {
+				t.Fatalf("%s.Compare(%s) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseConstraint(t *testing.T) {
+	tests := []struct {
+		input  string
+		wantOp string
+		wantV  Semver
+	}{
+		{">= 0.13.0", ">=", Semver{0, 13, 0}},
+		{">=0.13.0", ">=", Semver{0, 13, 0}},
+		{"> 1.0.0", ">", Semver{1, 0, 0}},
+		{"= 0.13.0", "=", Semver{0, 13, 0}},
+		{"< 1.0.0", "<", Semver{1, 0, 0}},
+		{"<= 2.0.0", "<=", Semver{2, 0, 0}},
+		// bare version treated as >=
+		{"0.13.0", ">=", Semver{0, 13, 0}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			c, err := ParseConstraint(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if c.Op != tt.wantOp {
+				t.Fatalf("op = %q, want %q", c.Op, tt.wantOp)
+			}
+			if c.Version != tt.wantV {
+				t.Fatalf("version = %v, want %v", c.Version, tt.wantV)
+			}
+		})
+	}
+}
+
+func TestConstraintCheck(t *testing.T) {
+	tests := []struct {
+		constraint string
+		version    string
+		want       bool
+	}{
+		{">= 0.13.0", "0.13.0", true},
+		{">= 0.13.0", "0.14.0", true},
+		{">= 0.13.0", "1.0.0", true},
+		{">= 0.13.0", "0.12.0", false},
+		{">= 0.13.0", "0.12.99", false},
+		{"> 0.13.0", "0.13.0", false},
+		{"> 0.13.0", "0.13.1", true},
+		{"= 0.13.0", "0.13.0", true},
+		{"= 0.13.0", "0.13.1", false},
+		{"< 1.0.0", "0.99.0", true},
+		{"< 1.0.0", "1.0.0", false},
+		{"<= 1.0.0", "1.0.0", true},
+		{"<= 1.0.0", "1.0.1", false},
+		// bare version = >=
+		{"0.13.0", "0.13.0", true},
+		{"0.13.0", "0.12.0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.constraint+"_"+tt.version, func(t *testing.T) {
+			c, err := ParseConstraint(tt.constraint)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			v, err := ParseSemver(tt.version)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			if got := c.Check(v); got != tt.want {
+				t.Fatalf("Constraint(%s).Check(%s) = %v, want %v", tt.constraint, tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckVersionDevSkipsCheck(t *testing.T) {
+	// The default version is "dev", so CheckVersion should always pass
+	if err := CheckVersion(">= 99.0.0"); err != nil {
+		t.Fatalf("expected dev version to skip check, got: %v", err)
+	}
+}
+
+func TestCheckVersionWithRealVersion(t *testing.T) {
+	// Temporarily override the version
+	original := Version
+	defer func() { Version = original }()
+
+	Version = "0.13.0"
+
+	t.Run("satisfied constraint", func(t *testing.T) {
+		if err := CheckVersion(">= 0.13.0"); err != nil {
+			t.Fatalf("expected check to pass: %v", err)
+		}
+	})
+
+	t.Run("unsatisfied constraint", func(t *testing.T) {
+		err := CheckVersion(">= 0.14.0")
+		if err == nil {
+			t.Fatal("expected error for unsatisfied constraint")
+		}
+		expected := "this project requires Ard >= 0.14.0, but you are running 0.13.0"
+		if err.Error() != expected {
+			t.Fatalf("expected %q, got %q", expected, err.Error())
+		}
+	})
+
+	t.Run("bare version acts as >=", func(t *testing.T) {
+		if err := CheckVersion("0.12.0"); err != nil {
+			t.Fatalf("expected bare version check to pass: %v", err)
+		}
+		if err := CheckVersion("0.14.0"); err == nil {
+			t.Fatal("expected bare version check to fail")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Projects must now specify a required Ard compiler version in `ard.toml`:

```toml
name = "my-project"
ard = ">= 0.13.0"
```

If the running compiler doesn't satisfy the constraint, all commands (`run`, `build`, `check`, `test`) fail immediately:

```
this project requires Ard >= 0.13.0, but you are running 0.12.0
```

If the field is missing from `ard.toml`:

```
ard.toml is missing required field: ard (e.g. ard = ">= 0.13.0")
```

## Details

- **Required field** — any `ard.toml` must include `ard = "..."`
- **Operators**: `>=`, `>`, `=`, `<=`, `<`
- **Bare version** (e.g. `"0.13.0"`) is treated as `>=`
- **Dev builds** (version `"dev"`) always pass, so local development isn't blocked

## Implementation

- `compiler/version/semver.go`: semver parsing, comparison, constraint checking
- `compiler/checker/module_resolver.go`: reads `ard` from `ard.toml` during project root discovery; errors if missing
- Check runs in `FindProjectRoot`, so it gates all commands that resolve modules

## Tests

- `version/semver_test.go`: parsing, comparison, constraint operators, dev skip, real version mismatch
- `checker/module_resolver_test.go`: missing field rejected, dev version passes
- All existing test fixtures updated to include the `ard` field
- `compiler/samples/ard.toml` updated