### PR TITLE
refactor(http): split HTTP_Send into smaller idiomatic FFI functions

### DIFF
--- a/compiler/bytecode/vm/registry.gen.go
+++ b/compiler/bytecode/vm/registry.gen.go
@@ -341,6 +341,68 @@ func _ffi_GetQueryParam(args []*runtime.Object) *runtime.Object {
 	return runtime.MakeStr(result)
 }
 
+func _ffi_HTTP_Do(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	arg1 := args[1].AsString()
+	arg2 := args[2].Raw()
+	_rawMap3 := args[3].AsMap()
+	arg3 := make(map[string]string, len(_rawMap3))
+	for _k3, _v3 := range _rawMap3 {
+		arg3[_k3] = _v3.AsString()
+	}
+	var arg4 *int
+	if !args[4].IsNone() {
+		_v4 := args[4].AsInt()
+		arg4 = &_v4
+	}
+	result, err := ffi.HTTP_Do(arg0, arg1, arg2, arg3, arg4)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeDynamic(result))
+}
+
+func _ffi_HTTP_ResponseStatus(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].Raw()
+	result := ffi.HTTP_ResponseStatus(arg0)
+	return runtime.MakeInt(result)
+}
+
+func _ffi_HTTP_ResponseHeader(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].Raw()
+	arg1 := args[1].AsString()
+	result := ffi.HTTP_ResponseHeader(arg0, arg1)
+	if result == nil {
+		return runtime.MakeNone(checker.Str)
+	}
+	return runtime.MakeNone(checker.Str).ToSome(*result)
+}
+
+func _ffi_HTTP_ResponseHeaders(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].Raw()
+	result := ffi.HTTP_ResponseHeaders(arg0)
+	_map := runtime.MakeMap(checker.Str, checker.Str)
+	for _k, _v := range result {
+		_map.Map_Set(runtime.MakeStr(_k), runtime.MakeStr(_v))
+	}
+	return _map
+}
+
+func _ffi_HTTP_ResponseBody(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].Raw()
+	result, err := ffi.HTTP_ResponseBody(arg0)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeStr(result))
+}
+
+func _ffi_HTTP_ResponseClose(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].Raw()
+	ffi.HTTP_ResponseClose(arg0)
+	return runtime.Void()
+}
+
 func _ffi_FloatFromStr(args []*runtime.Object) *runtime.Object {
 	arg0 := args[0].AsString()
 	result := ffi.FloatFromStr(arg0)
@@ -617,8 +679,23 @@ func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
 	if err := r.Register("GetQueryParam", _ffi_GetQueryParam); err != nil {
 		return fmt.Errorf("failed to register GetQueryParam: %w", err)
 	}
-	if err := r.Register("HTTP_Send", ffi.HTTP_Send); err != nil {
-		return fmt.Errorf("failed to register HTTP_Send: %w", err)
+	if err := r.Register("HTTP_Do", _ffi_HTTP_Do); err != nil {
+		return fmt.Errorf("failed to register HTTP_Do: %w", err)
+	}
+	if err := r.Register("HTTP_ResponseStatus", _ffi_HTTP_ResponseStatus); err != nil {
+		return fmt.Errorf("failed to register HTTP_ResponseStatus: %w", err)
+	}
+	if err := r.Register("HTTP_ResponseHeader", _ffi_HTTP_ResponseHeader); err != nil {
+		return fmt.Errorf("failed to register HTTP_ResponseHeader: %w", err)
+	}
+	if err := r.Register("HTTP_ResponseHeaders", _ffi_HTTP_ResponseHeaders); err != nil {
+		return fmt.Errorf("failed to register HTTP_ResponseHeaders: %w", err)
+	}
+	if err := r.Register("HTTP_ResponseBody", _ffi_HTTP_ResponseBody); err != nil {
+		return fmt.Errorf("failed to register HTTP_ResponseBody: %w", err)
+	}
+	if err := r.Register("HTTP_ResponseClose", _ffi_HTTP_ResponseClose); err != nil {
+		return fmt.Errorf("failed to register HTTP_ResponseClose: %w", err)
 	}
 	if err := r.Register("HTTP_Serve", ffi.HTTP_Serve); err != nil {
 		return fmt.Errorf("failed to register HTTP_Serve: %w", err)

--- a/compiler/docs/ffi-refactoring.md
+++ b/compiler/docs/ffi-refactoring.md
@@ -1,0 +1,249 @@
+# FFI Refactoring Opportunities
+
+This document tracks identified improvements to reduce FFI complexity and maintenance burden.
+
+See also: [ffi-simplification.md](./ffi-simplification.md) for analysis of breaking down complex FFI functions using opaque types.
+
+## Current State
+
+The FFI system has **62 functions total**: 46 idiomatic, 16 raw.
+
+Raw functions remain raw because the generator doesn't support their required types.
+
+Some raw functions could be simplified by using opaque handles and moving logic to Ard code.
+
+## Opportunity 1: Add `[]any` Parameter and Return Support
+
+**Gap:** Generator doesn't support `[]any` (slice of any type).
+
+**Impact:** These functions could be idiomatic:
+- `ListToDynamic` - takes `[]any`, returns `any`
+- `DynamicToList` - takes `any`, returns `([]any, error)`
+- `SqlQuery`, `SqlExecute` - need `[]any` for values parameter
+
+**Implementation in `ffi_generate.go`:**
+
+Add to `parseGoType()`:
+
+```go
+case *ast.ArrayType:
+    if t.Len == nil {
+        if ident, ok := t.Elt.(*ast.Ident); ok {
+            switch ident.Name {
+            case "string", "int", "float64", "bool":
+                return GoType{Base: ident.Name, IsSlice: true}, true
+            case "any":// NEW
+                return GoType{Base: "any", IsSlice: true}, true
+            }
+        }
+    }
+```
+
+Generated wrapper for `[]any` param:
+
+```go
+// func Foo(items []any)
+_sl0 := args[0].AsList()
+arg0 := make([]any, len(_sl0))
+for _i, _e := range _sl0 {
+    arg0[_i] = _e.Raw()
+}
+```
+
+Generated wrapper for `[]any` return:
+
+```go
+// func Foo() []any
+result := ffi.Foo()
+_items := make([]*runtime.Object, len(result))
+for _i, _v := range result {
+    _items[_i] = runtime.MakeDynamic(_v)
+}
+return runtime.MakeList(checker.Dynamic, _items...)
+```
+
+---
+
+## Opportunity 2: Add `map[string]any` Parameter Support
+
+**Gap:** Generator supports `map[string]string` but not `map[string]any`.
+
+**Impact:** `MapToDynamic` could be idiomatic.
+
+**Implementation:**
+
+Add `IsStringMapAny bool` field to `GoType` struct.
+
+Generated wrapper:
+
+```go
+// func Foo(m map[string]any)
+_rawMap0 := args[0].AsMap()
+arg0 := make(map[string]any, len(_rawMap0))
+for _k, _v := range _rawMap0 {
+    arg0[_k] = _v.Raw()
+}
+```
+
+---
+
+## Opportunity 3: Extract Type Lookup Helper
+
+**Current pattern (repeated in 3 files):**
+
+```go
+var (
+    fsDirEntryType     checker.Type
+    fsDirEntryTypeOnce sync.Once
+)
+
+func getFSDirEntryType() checker.Type {
+    fsDirEntryTypeOnce.Do(func() {
+        mod, ok := checker.FindEmbeddedModule("ard/fs")
+        if !ok {
+            panic("failed to load ard/fs embedded module")
+        }
+        sym := mod.Get("DirEntry")
+        if sym.Type == nil {
+            panic("DirEntry type not found in ard/fs module")
+        }
+        fsDirEntryType = sym.Type
+    })
+    return fsDirEntryType
+}
+```
+
+**Proposal:** Create `ffi/types.go`:
+
+```go
+package ffi
+
+import (
+    "fmt"
+    "sync"
+
+    "github.com/akonwi/ard/checker"
+)
+
+var (
+    typeCache   = make(map[string]checker.Type)
+    typeCacheMu sync.RWMutex
+)
+
+// GetStdType returns an Ard type from a standard library module.
+// It caches the lookup for subsequent calls.
+//
+// Example: GetStdType("ard/fs", "DirEntry")
+func GetStdType(modulePath, typeName string) checker.Type {
+    key := modulePath + "." + typeName
+
+    typeCacheMu.RLock()
+    if t, ok := typeCache[key]; ok {
+        typeCacheMu.RUnlock()
+        return t
+    }
+    typeCacheMu.RUnlock()
+
+    typeCacheMu.Lock()
+    defer typeCacheMu.Unlock()
+
+    if t, ok := typeCache[key]; ok {
+        return t
+    }
+
+    mod, ok := checker.FindEmbeddedModule(modulePath)
+    if !ok {
+        panic(fmt.Errorf("FFI: module %q not found", modulePath))
+    }
+    sym := mod.Get(typeName)
+    if sym.Type == nil {
+        panic(fmt.Errorf("FFI: type %q not found in module %q", typeName, modulePath))
+    }
+    typeCache[key] = sym.Type
+    return sym.Type
+}
+```
+
+**Migration:** Replace all `getXxxType()` functions:
+
+| File | Function | Replacement |
+|------|----------|-------------|
+| `ffi/decoders.go` | `getDecodeErrorType()` | `GetStdType("ard/decode", "Error")` |
+| `ffi/fs.go` | `getFSDirEntryType()` | `GetStdType("ard/fs", "DirEntry")` |
+| `ffi/http.go` | `getHTTPResponseType()` | `GetStdType("ard/http", "Response")` |
+
+---
+
+## Opportunity 4: Naming Convention Documentation
+
+**Current:** Mix of prefixed and unprefixed FFI function names.
+
+**Convention:** FFI function names follow `{Module}_{Action}` pattern where the module prefix is preserved for disambiguation. Functions in dedicated single-concept modules use unprefixed names.
+
+| Module | Prefix | Examples |
+|--------|--------|----------|
+| `fs.ard` | `FS_` | `FS_Exists`, `FS_ReadFile` |
+| `crypto.ard` | `Crypto` | `CryptoMd5`, `CryptoHashPassword` |
+| `sql.ard` | `Sql` | `SqlCreateConnection`, `SqlQuery` |
+| `http.ard` | `HTTP_` | `HTTP_Send`, `HTTP_Serve` |
+| `io.ard` | (none) | `Print`, `ReadLine` |
+| `argv.ard` | (none) | `OsArgs` |
+| `base64.ard` | (none) | `Base64Encode`, `Base64Decode` |
+| `hex.ard` | (none) | `HexEncode`, `HexDecode` |
+
+---
+
+## Migration Plan
+
+### Phase 1: Helper Extraction (Low Risk)
+
+1. Create `ffi/types.go` with `GetStdType()`
+2. Update `decoders.go` to use `GetStdType("ard/decode", "Error")`
+3. Update `fs.go` to use `GetStdType("ard/fs", "DirEntry")`
+4. Update `http.go` to use `GetStdType("ard/http", "Response")`
+5. Remove the old `getXxxType()` functions
+
+### Phase 2: Generator Extensions (Medium Risk)
+
+1. Add `[]any` support to `ffi_generate.go`
+2. Add `map[string]any` support to `ffi_generate.go`
+3. Update `checkerTypeStr()` to handle `Dynamic` type
+4. Add tests for new type unwrapping/wrapping
+5. Run `go generate ./bytecode/vm`
+
+### Phase 3: Function Conversions (Low Risk after Phase 2)
+
+1. Convert `ListToDynamic` to `func ListToDynamic(items []any) any`
+2. Convert `MapToDynamic` to `func MapToDynamic(m map[string]any) any`
+3. Evaluate `DynamicToList`, `DynamicToMap` for idiomatic conversion
+4. Keep complex functions (`HTTP_Send`, `HTTP_Serve`, `Join`) as raw
+
+---
+
+## Functions That Must Remain Raw
+
+Some functions require runtime access that idiomatic FFI cannot provide:
+
+| Function | Reason |
+|----------|--------|
+| `HTTP_Send` | Builds Ard struct from response |
+| `HTTP_Serve` | Registers closure as HTTP handler, needs VM isolation |
+| `Join` | Iterates Fiber structs, extracts WaitGroups, calls VM |
+| `JsonEncode` | Marshals generic `*runtime.Object` |
+| `DecodeString/Int/Float/Bool` | Return custom error struct with embedded type lookup |
+| `ExtractField` | Returns `Dynamic` with complex construction |
+
+---
+
+## Testing Checklist
+
+After any FFI changes:
+
+```bash
+cd compiler
+go generate ./bytecode/vm
+go build
+go test ./...
+go run main.go run samples/basic.ard# Run formatter on std_lib after changes
+go run main.go format std_lib
+```

--- a/compiler/docs/ffi-simplification.md
+++ b/compiler/docs/ffi-simplification.md
@@ -1,0 +1,271 @@
+# FFI Simplification Analysis
+
+Thisdocument analyzes opportunities to simplify FFI functions by using opaque types and moving logic to Ard code.
+
+## Core Pattern
+
+The most effective FFI pattern uses:
+1. **Opaque handles** (`extern type`) for Go objects
+2. **Small FFI functions** that operate on handles
+3. **Ard code** for orchestration and composition
+
+### Success Story: SQL Module
+
+The SQL module demonstrates this pattern well:
+
+```ard
+// std_lib/sql.ard
+private extern type Db// Opaque handle
+private extern type Tx// Opaque handle
+
+// Simple FFI functions
+private extern fn connect(connection_string: Str) Db!Str
+private extern fn close_db(db: Db) Void!Str
+private extern fn execute(conn: Conn, sql: Str, values: [Value]) Void!Str
+private extern fn run_query(conn: Conn, sql: Str, values: [Value]) [Dynamic]!Str
+
+// Ard code orchestrates
+impl Query {
+  fn prepare(mut query_str: Str, mut values: [Value], args: [Str: Value]) Void!Str {
+    // Logic in Ard, not FFI
+  }
+}
+```
+
+The FFI functions are small and focused. Complex operations (parameter binding, query building) happen in Ard.
+
+---
+
+## Refactoring Opportunities
+
+### 1. HTTP Module: Break Down `HTTP_Send`
+
+**Current State:** Single 70-line raw FFI function that:
+- Extracts 5 arguments from runtime objects
+- Converts body types (string, bytes, any)
+- Builds HTTP request
+- Executes request
+- Converts response headers to Ard map
+- Builds Ard Response struct
+
+**Proposed Refactoring:**
+
+```ard
+// std_lib/http.ard
+private extern type HttpResponse// Opaque Go *http.Response// Simple FFI - just make request
+private extern fn _http_do(method: Str, url: Str, body: Str?, headers: [Str: Str], timeout: Int?) HttpResponse!Str
+
+// Accessors for response handle
+private extern fn _response_status(resp: HttpResponse) Int
+private extern fn _response_header(resp: HttpResponse, name: Str) Str?
+private extern fn _response_headers(resp: HttpResponse) [Str: Str]
+private extern fn _response_body(resp: HttpResponse) Str!Str
+private extern fn _response_close(resp: HttpResponse) Void
+
+// Ard orchestrates
+fn send(req: Request, timeout: Int?) Response!Str {
+  let method = req.method.to_str()
+  let body = match req.body {
+    s => maybe::some(s),
+    _ => maybe::none(),// Wait for proper pattern matching on Dynamic
+  }
+  
+  let resp = try _http_do(method, req.url, body, req.headers, timeout)
+  defer _response_close(resp)// hypothetical defer
+  
+  let status = _response_status(resp)
+  let headers = _response_headers(resp)
+  let body = try _response_body(resp)
+  
+  Result::ok(Response{status: status, headers: headers, body: body})
+}
+```
+
+**Benefits:**
+- FFI functions become idiomatic (could be auto-generated)
+- Response building logic moves to Ard
+- Easier to test individual pieces
+- Smaller FFI surface
+
+**FFI Functions (all could be idiomatic):**
+
+| Function | Signature | Type |
+|----------|-----------|------|
+| `_http_do` | `(string, string, *string, map[string]string, *int) (any, error)` | Idiomatic |
+| `_response_status` | `(any) int` | Idiomatic |
+| `_response_header` | `(any, string) *string` | Idiomatic |
+| `_response_headers` | `(any) map[string]string` | Idiomatic |
+| `_response_body` | `(any) (string, error)` | Idiomatic |
+| `_response_close` | `(any)` | Idiomatic |
+
+---
+
+### 2. Decode Module: Simplify Error Construction
+
+**Current State:** `DecodeString`, `DecodeInt`, etc. are raw FFI because they construct custom `Error` struct.
+
+**Problem:** The `Error` struct has `expected`, `found`, `path` fields that require embedded module type lookup.
+
+**Option A: Simpler Error Type**
+
+Replace complex `Error` struct with simple string:
+
+```ard
+// Current
+struct Error {
+  expected: Str,
+  found: Str,
+  path: [Str],
+}
+
+// Simplified
+type DecodeError = Str// Just a string
+```
+
+**Option B: Ard-Based Error Construction**
+
+FFI returns raw value + type info, Ard constructs error:
+
+```ard
+// FFI returns what it found, Ard builds error
+private extern fn _try_decode_string(data: Dynamic) Str?// Returns None if not string
+private extern fn _try_decode_int(data: Dynamic) Int?
+// etc.
+
+// Ard handles errors
+fn string(data: Dynamic) Str![Error] {
+  match _try_decode_string(data) {
+    s => Result::ok(s),
+    _ => {
+      let found = _describe_dynamic(data)// Get type description
+      Result::err([Error{expected: "Str", found: found, path: []}])
+    }
+  }
+}
+```
+
+**Recommendation:** Option A (simpler error) for initial refactoring. The current error type provides nice messages but adds significant complexity.
+
+---
+
+### 3. FS Module: Keep As-Is
+
+The `FS_ListDir` function returns a list of structs:
+
+```ard
+struct DirEntry {
+  name: Str,
+  is_file: Bool,}
+```
+
+This is already well-structured:
+- Simple scalar fields in the struct
+- FFI builds the struct
+- Would require struct return support in generator to simplify
+
+**Future:** If generator supports struct returns with scalar fields, this could become idiomatic.
+
+---
+
+### 4. HTTP Serve: Keep As-Is
+
+`HTTP_Serve` is inherently complex because:
+- It registers Ard closures as HTTP handlers
+- Converts Go `*http.Request` to Ard `Request` on each request
+- Must handle concurrent requests safely
+
+This pattern (Go calling Ard closures) is the inverse of normal FFI and requires VM/runtime integration.
+
+**No simplification recommended.**
+
+---
+
+### 5. Dynamic Conversions: Use `[]any` Support
+
+Once generator supports `[]any`:
+
+| Current | Simplified |
+|---------|------------|
+| `ListToDynamic(args []*runtime.Object)` | `ListToDynamic(items []any) any` |
+| `MapToDynamic(args []*runtime.Object)` | `MapToDynamic(m map[string]any) any` |
+| `DynamicToList(args []*runtime.Object)` | `DynamicToList(data any) ([]any, error)` |
+
+---
+
+## New Opaque Types to Add
+
+### HTTP Response Handle
+
+```ard
+// std_lib/http.ard
+private extern type HttpResponse// *http.Response in Go
+
+// Accessors
+private extern fn _response_status(resp: HttpResponse) Int
+private extern fn _response_headers(resp: HttpResponse) [Str: Str]
+private extern fn _response_body(resp: HttpResponse) Str!Str
+```
+
+### Potential Future: SQL Rows Handle
+
+```ard
+// For streaming large result sets
+private extern type Rows// *sql.Rows in Go
+private extern fn _rows_next(rows: Rows) Bool
+private extern fn _rows_scan(rows: Rows) Dynamic!Str
+private extern fn _rows_close(rows: Rows) Void
+```
+
+---
+
+## Implementation Priority
+
+### Phase 1: Low-Hanging Fruit
+1. Add `[]any` and `map[string]any` generator support
+2. Convert `ListToDynamic`, `MapToDynamic` to idiomatic
+3. Add `GetStdType()` helper
+
+### Phase 2: HTTP Simplification
+1. Create `HttpResponse` opaque type
+2. Create accessor FFI functions (all idiomatic)
+3. Refactor `send()` in Ard to use new functions
+4. Keep `HTTP_Serve` as-is
+
+### Phase 3: Decode Simplification (Optional)
+1. Evaluate if simpler error type suffices
+2. If complex errors needed, move construction to Ard
+
+---
+
+## Testing Strategy
+
+For each refactoring:
+
+```bash
+# 1. Make FFI changes
+cd compiler
+go generate ./bytecode/vm
+
+# 2. Run all tests
+go test ./...# 3. Run stdlib tests via samples
+go run main.go run std_lib/fs.ard
+go run main.go run std_lib/http.ard
+
+# 4. Format check
+go run main.go format std_lib
+```
+
+---
+
+## Summary
+
+| Module | Current | Recommended |
+|--------|---------|-------------|
+| SQL | Well-structured | Keep as-is |
+| HTTP Send | Single large FFI | Break into handle + accessors |
+| HTTP Serve | Complex callback | Keep as-is (inherently complex) |
+| Decode | Complex error struct | Simplify error OR move to Ard |
+| FS ListDir | Returns struct list | Keep as-is (needs struct support) |
+| Dynamic | Raw FFI | Convert to idiomatic with `[]any` |
+
+The key insight: **FFI should be thin wrappers around Go operations. Logic belongs in Ard.**

--- a/compiler/docs/ffi.md
+++ b/compiler/docs/ffi.md
@@ -352,3 +352,5 @@ Ard's FFI provides:
 - `any` support for Go-side handle functions
 - hard errors for unsupported exported signatures
 - an escape hatch for complex runtime-aware bindings
+
+See [ffi-refactoring.md](./ffi-refactoring.md) for identified improvement opportunities.

--- a/compiler/ffi/http.go
+++ b/compiler/ffi/http.go
@@ -5,32 +5,11 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/akonwi/ard/checker"
 	"github.com/akonwi/ard/runtime"
 )
-
-var (
-	httpResponseType     checker.Type
-	httpResponseTypeOnce sync.Once
-)
-
-func getHTTPResponseType() checker.Type {
-	httpResponseTypeOnce.Do(func() {
-		mod, ok := checker.FindEmbeddedModule("ard/http")
-		if !ok {
-			panic("failed to load ard/http embedded module")
-		}
-		sym := mod.Get("Response")
-		if sym.Type == nil {
-			panic("Response type not found in ard/http module")
-		}
-		httpResponseType = sym.Type
-	})
-	return httpResponseType
-}
 
 func requestBodyMaybe(r *http.Request) *runtime.Object {
 	body := runtime.MakeNone(checker.Dynamic)
@@ -70,72 +49,89 @@ func GetQueryParam(handle any, name string) string {
 	return req.URL.Query().Get(name)
 }
 
-// fn (method: Str, url: Str, body: Dynamic?, headers: [Str:Str], timeout: Int?) Response!Str
-func HTTP_Send(args []*runtime.Object) *runtime.Object {
-	method := args[0].AsString()
-	url := args[1].AsString()
-	body := func() io.Reader {
-		if args[2].IsNone() {
-			return strings.NewReader("")
-		}
-
-		raw := args[2].Raw()
-		switch value := raw.(type) {
+// HTTP_Do executes an HTTP request and returns an opaque *http.Response handle.
+// The caller must close the response using HTTP_ResponseClose.
+func HTTP_Do(method, url string, body any, headers map[string]string, timeout *int) (any, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		switch v := body.(type) {
 		case string:
-			return strings.NewReader(value)
+			bodyReader = strings.NewReader(v)
 		case []byte:
-			return strings.NewReader(string(value))
+			bodyReader = strings.NewReader(string(v))
 		default:
-			return strings.NewReader(fmt.Sprintf("%v", value))
+			bodyReader = strings.NewReader(fmt.Sprintf("%v", v))
 		}
-	}()
-	headers := make(http.Header)
+	} else {
+		bodyReader = strings.NewReader("")
+	}
 
-	for k, v := range args[3].AsMap() {
-		headers.Set(k, v.AsString())
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 
 	client := &http.Client{}
-	if len(args) >= 5 && !args[4].IsNone() {
-		client.Timeout = time.Duration(args[4].AsInt()) * time.Second
+	if timeout != nil {
+		client.Timeout = time.Duration(*timeout) * time.Second
 	}
-
-	req, err := http.NewRequest(method, url, body)
-	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
-	}
-
-	req.Header = headers
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+		return nil, err
 	}
-	defer resp.Body.Close()
 
-	// Read the response body
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	return resp, nil
+}
+
+// HTTP_ResponseStatus returns the HTTP status code from a response handle.
+func HTTP_ResponseStatus(handle any) int {
+	resp := handle.(*http.Response)
+	return resp.StatusCode
+}
+
+// HTTP_ResponseHeader returns a single header value from a response handle.
+// Returns nil if the header is not present.
+func HTTP_ResponseHeader(handle any, name string) *string {
+	resp := handle.(*http.Response)
+	values := resp.Header.Values(name)
+	if len(values) == 0 {
+		return nil
 	}
-	bodyStr := string(bodyBytes)
+	return &values[0]
+}
 
-	// Create response headers map
-	respHeadersMap := runtime.MakeMap(checker.Str, checker.Str)
+// HTTP_ResponseHeaders returns all headers from a response handle.
+func HTTP_ResponseHeaders(handle any) map[string]string {
+	resp := handle.(*http.Response)
+	headers := make(map[string]string)
 	for k, v := range resp.Header {
 		if len(v) > 0 {
-			respHeadersMap.Map_Set(runtime.MakeStr(k), runtime.MakeStr(v[0]))
+			headers[k] = v[0]
 		}
 	}
+	return headers
+}
 
-	// Create the response object
-	respMap := map[string]*runtime.Object{
-		"status":  runtime.MakeInt(resp.StatusCode),
-		"headers": respHeadersMap,
-		"body":    runtime.MakeStr(bodyStr),
+// HTTP_ResponseBody reads and returns the response body.
+// This consumes the body; subsequent calls will return an error.
+func HTTP_ResponseBody(handle any) (string, error) {
+	resp := handle.(*http.Response)
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
 	}
+	return string(bodyBytes), nil
+}
 
-	return runtime.MakeOk(runtime.MakeStruct(getHTTPResponseType(), respMap))
+// HTTP_ResponseClose closes a response handle, freeing resources.
+func HTTP_ResponseClose(handle any) {
+	resp := handle.(*http.Response)
+	_ = resp.Body.Close()
 }
 
 /*

--- a/compiler/std_lib/http.ard
+++ b/compiler/std_lib/http.ard
@@ -1,3 +1,4 @@
+use ard/dynamic
 use ard/maybe
 use ard/string as Str
 
@@ -25,6 +26,9 @@ impl Str::ToString for Method {
 
 // Opaque pointer to Go's *http.Request for inbound requests
 private extern type RawRequest
+
+// Opaque pointer to Go's *http.Response for outbound responses
+private extern type RawResponse
 
 struct Request {
   method: Method,
@@ -78,7 +82,13 @@ impl Response {
   }
 }
 
-private extern fn _send(method: Str, url: Str, body: Dynamic?, headers: [Str: Str], timeout: Int?) Response!Str = "HTTP_Send"
+// HTTP client FFI functions - operate on opaque RawResponse handle
+// body is Dynamic (nil means no body)
+private extern fn http_do(method: Str, url: Str, body: Dynamic, headers: [Str: Str], timeout: Int?) RawResponse!Str = "HTTP_Do"
+private extern fn http_response_status(resp: RawResponse) Int = "HTTP_ResponseStatus"
+private extern fn http_response_headers(resp: RawResponse) [Str: Str] = "HTTP_ResponseHeaders"
+private extern fn http_response_body(resp: RawResponse) Str!Str = "HTTP_ResponseBody"
+private extern fn http_response_close(resp: RawResponse) Void = "HTTP_ResponseClose"
 
 fn send(req: Request, timeout: Int?) Response!Str {
   let method = req.method.to_str()
@@ -86,7 +96,33 @@ fn send(req: Request, timeout: Int?) Response!Str {
     t => maybe::some(t),
     _ => req.timeout,
   }
-  _send(method, req.url, req.body, req.headers, effective_timeout)
+
+  // Extract body: Dynamic? -> Dynamic (nil means no body)
+  let body: Dynamic = match req.body {
+    d => d,
+    _ => dynamic::from_void(),
+  }
+
+  // Make the HTTP request
+  let resp = try http_do(method, req.url, body, req.headers, effective_timeout)
+
+  // Extract response data
+  let status = http_response_status(resp)
+  let headers = http_response_headers(resp)
+  let body_result = http_response_body(resp)
+
+  // Clean up resources
+  http_response_close(resp)
+
+  // Build response
+  let body = try body_result
+  Result::ok(
+    Response{
+      status: status,
+      headers: headers,
+      body: body,
+    },
+  )
 }
 
 type HandlerFn = fn(Request, mut Response)


### PR DESCRIPTION
## Summary

Refactors the HTTP client FFI from one monolithic raw function into six smaller idiomatic functions, following the pattern outlined in `docs/ffi-simplification.md`.

## Changes

### Before
- `HTTP_Send` was a 70-line raw FFI function that:
  - Manually unwrapped `[]*runtime.Object` arguments
  - Built HTTP request
  - Executed request
  - Manually constructed Ard `Response` struct

### After
Six small idiomatic FFI functions:

| Function | Signature | Type |
|----------|-----------|------|
| `HTTP_Do` | `(string, string, any, map[string]string, *int) (any, error)` | Idiomatic |
| `HTTP_ResponseStatus` | `(any) int` | Idiomatic |
| `HTTP_ResponseHeader` | `(any, string) *string` | Idiomatic |
| `HTTP_ResponseHeaders` | `(any) map[string]string` | Idiomatic |
| `HTTP_ResponseBody` | `(any) (string, error)` | Idiomatic |
| `HTTP_ResponseClose` | `(any)` | Idiomatic |

### Key Changes
1. Added `RawResponse` opaque type (`extern type`) to safely pass `*http.Response` between Go and Ard
2. Updated `send()` in `std_lib/http.ard` to orchestrate response building in Ard:
   - Calls `http_do` → gets `RawResponse!Str`
   - Extracts status, headers, body via accessor functions
   - Closes response handle explicitly
3. All new FFI functions use idiomatic signatures (auto-generated wrappers in `registry.gen.go`)
4. `HTTP_Serve` remains as-is (complex callback pattern with VM isolation)

## Benefits
- **Simpler FFI** - All HTTP client functions are idiomatic (no manual unwrapping)
- **Testable** - Each function does one thing
- **Extensible** - Easy to add more accessor functions
- **Separation of concerns** - Go handles HTTP mechanics, Ard handles response construction

## Testing
- All unit tests pass
- HTTP-specific tests pass (`TestBytecodeHttpSendUsesRequestTimeout`, etc.)
- Server sample works correctly (`samples/server.ard`)
- All curl endpoints verified

## Documentation
Related: `docs/ffi-simplification.md` - FFI simplification analysis