### PR TITLE
feat(generator): add support for map[string]bool/int/float64

### DIFF
--- a/backlog/go-transpilation.md
+++ b/backlog/go-transpilation.md
@@ -1,0 +1,371 @@
+# Go Transpilation Backend
+
+This document captures the design decisions for transpiling Ard source code to Go as an alternative backend to the bytecode VM.
+
+## Background
+
+The current Ard compiler produces bytecode that runs on a stack-based VM. This proposal adds a Go transpilation backend that emits Go source code, which can then be compiled with `go build`.
+
+## Transpilation Mappings
+
+| Ard | Go | Notes |
+|-----|-----|-------|
+| `Int` | `int` | Direct |
+| `Float` | `float64` | Direct |
+| `Str` | `string` | Direct |
+| `Bool` | `bool` | Direct |
+| `Void` | `struct{}` or omit | |
+| `List<T>` | `[]T` | Go slice, emit copy on assignment |
+| `Map<K,V>` | `map[string]V` | Key coercion if K ≠ string |
+| `Struct` | Go `struct` | Direct |
+| `Enum` | `struct { tag int }` + const tags | Simple discriminant pattern |
+| `Union` | `interface{}` + type switch | |
+| `Result<T,E>` | Go `(T, error)` tuple | Idiomatic Go error handling |
+| `Maybe<T>` | `ard/go.Maybe[T]` struct | Custom struct preserves semantics |
+| `Dynamic` | `any` + JSON helpers | |
+| `extern fn` | Registry stub | Calls `ardgo.CallExtern()` |
+
+### Copy Semantics
+
+Ard has copy semantics for assignments. Go slices and maps share on assignment. The transpiler must emit explicit copy calls:
+
+```ard
+let a = [1, 2, 3]
+let b = a  // b is a copy
+```
+
+```go
+a := []int{1, 2, 3}
+b := ardgo.CopySlice(a)  // explicit copy
+```
+
+### Name Rules
+
+| Ard | Go | Rationale |
+|-----|-----| -----|
+| `fn my_func()` | `func MyFunc()` | Go convention: exported = PascalCase |
+| `fn internal_func()` (no `pub`) | `func internalFunc()` | Unexported = camelCase |
+| `utils::helper()` | `utils.Helper()` | Package-qualified call |
+| `struct MyStruct` | `type MyStruct struct` | Direct |
+| `enum Color` | `type Color struct { tag int }` + constants | |
+
+Private by default. Ard uses `pub` keyword for exports — transpiler emits exported Go names only for `pub` declarations.
+
+## CLI and Configuration
+
+### Command Line
+
+```bash
+ard build                      # use target from ard.toml (default: bytecode)
+ard build --target bytecode    # explicit bytecode
+ard build --target go          # Go transpilation
+ard run main.ard               # runs via bytecode VM
+ard run --target go main.ard   # transpile + go run
+```
+
+### `ard.toml` Configuration
+
+```toml
+name = "myproject"
+version = "0.1.0"
+target = "bytecode"  # "bytecode" (default) or "go"
+```
+
+The `target` field specifies the default backend. The `--target` flag overrides it.
+
+### Output
+
+- **Bytecode**: Single executable with embedded program
+- **Go backend**: `generated/` directory with `go.mod` and Go packages
+
+## Module Mapping
+
+Each `.ard` file becomes one Go package.
+
+### Directory Structure
+
+**Ard project:**
+```
+myproject/
+  ard.toml                  # name = "myproject"
+  main.ard
+  utils.ard
+  helpers/
+    math.ard
+```
+
+**Transpiled Go:**
+```
+myproject/
+  generated/
+    go.mod                  # module github.com/user/myproject (from ard.toml name)
+    main/
+      main.go               # package main
+    utils/
+      utils.go              # package utils
+    helpers/
+      math/
+        math.go             # package math
+```
+
+The Go module path is derived from `ard.toml`'s `name` field.
+
+### Import Translation
+
+```ard
+// main.ard
+use ./utils
+use ./helpers/math
+
+fn main() {
+  let a = utils::double(5)
+  let b = math::add(3, 4)
+}
+```
+
+```go
+// generated/main/main.go
+package main
+
+import (
+    "github.com/user/myproject/generated/utils"
+    math "github.com/user/myproject/generated/helpers/math"
+)
+
+func main() {
+    a := utils.Double(5)
+    b := math.Add(3, 4)
+}
+```
+
+## Standard Library
+
+The standard library (`std_lib/*.ard`) is pre-transpiled to Go packages shipped with the compiler.
+
+```
+compiler/go/
+  maybe.go
+  copy.go
+  dynamic.go
+  enum.go
+  extern.go
+  stdlib/
+    json/
+      json.go              # pre-transpiled from std_lib/json.ard
+    http/
+      http.go              # pre-transpiled from std_lib/http.ard
+    async/
+      async.go             # pre-transpiled from std_lib/async.ard
+    ...
+```
+
+User code imports these as normal Go packages.
+
+## Extern Functions
+
+Extern functions (`extern fn`) generate stub functions that call a registry at runtime.
+
+```ard
+// user code
+extern fn my_extension(x: Int) Str = "MyExtension"
+```
+
+```go
+// generated stub
+func myExtension(x int) string {
+    result, err := ardgo.CallExtern("MyExtension", x)
+    if err != nil {
+        panic(err)
+    }
+    return result.(string)
+}
+```
+
+The registry maps binding names to Go implementations, mirroring the current FFI model. Implementations live in `ard/go/stdlib/` or are registered by user code.
+
+### Async Semantics
+
+The current VM uses `sync.WaitGroup` with child goroutines. The Go backend preserves this pattern:
+
+```ard
+let fiber = async::start(fn() { do_work() })
+fiber.join()
+```
+
+```go
+fiber := async.Start(func() { doWork() })
+fiber.Join()
+```
+
+The `async` stdlib module provides this as pre-transpiled Go code.
+
+## Helper Package: `ard/go`
+
+Core helper types and functions for transpiled code:
+
+```
+compiler/go/
+  maybe.go          # Maybe[T] struct
+  copy.go           # Copy functions for slices/maps
+  dynamic.go        # Dynamic type + JSON helpers
+  enum.go           # Enum tag construction
+  extern.go         # Extern function registry
+```
+
+### `maybe.go`
+
+```go
+package ardgo
+
+type Maybe[T any] struct {
+    value T
+    none  bool
+}
+
+func Some[T any](v T) Maybe[T] { return Maybe[T]{value: v} }
+func None[T any]() Maybe[T] { return Maybe[T]{none: true} }
+func (m Maybe[T]) IsNone() bool { return m.none }
+func (m Maybe[T]) IsSome() bool { return !m.none }
+func (m Maybe[T]) Expect(msg string) T {
+    if m.none {
+        panic(msg)
+    }
+    return m.value
+}
+func (m Maybe[T]) Or(default_ T) T {
+    if m.none {
+        return default_
+    }
+    return m.value
+}
+```
+
+### `copy.go`
+
+```go
+package ardgo
+
+func CopySlice[T any](s []T) []T {
+    copied := make([]T, len(s))
+    copy(copied, s)
+    return copied
+}
+
+func CopyMap[K comparable, V any](m map[K]V) map[K]V {
+    copied := make(map[K]V, len(m))
+    for k, v := range m {
+        copied[k] = v
+    }
+    return copied
+}
+```
+
+### `enum.go`
+
+```go
+package ardgo
+
+type Enum struct {
+    Tag   int
+    Value any
+}
+
+func MakeEnum(tag int, value any) Enum {
+    return Enum{Tag: tag, Value: value}
+}
+```
+
+### `extern.go`
+
+```go
+package ardgo
+
+var externRegistry = make(map[string]func(...any) (any, error))
+
+func RegisterExtern(name string, fn func(...any) (any, error)) {
+    externRegistry[name] = fn
+}
+
+func CallExtern(name string, args ...any) (any, error) {
+    fn, ok := externRegistry[name]
+    if !ok {
+        return nil, fmt.Errorf("extern function not found: %s", name)
+    }
+    return fn(args...)
+}
+```
+
+## Implementation Plan
+
+### Phase 1: Core Helpers
+
+Create `compiler/go/` package with:
+- `maybe.go` — Maybe[T] implementation
+- `copy.go` — Copy functions
+- `enum.go` — Enum construction helpers
+- `extern.go` — Extern registry
+
+### Phase 2: Minimal Transpiler
+
+Create `compiler/transpile/` package that handles:
+- Function definitions with parameters and return types
+- Primitive types (Int, Float, Str, Bool)
+- Basic expressions (arithmetic, comparisons)
+- Variable declarations and assignments
+- Control flow (if/else, while, for)
+
+### Phase 3: Type Declarations
+
+Add support for:
+- Struct definitions
+- Enum definitions
+- Union types
+
+### Phase 4: Collections and Pattern Matching
+
+Add support for:
+- List and Map literals and operations
+- Pattern matching on enums, unions, integers
+- Result and Maybe types
+
+### Phase 5: CLI Integration
+
+Update `compiler/main.go` to:
+- Read `target` from `ard.toml`
+- Accept `--target` flag
+- Emit Go output to `generated/` directory
+- Invoke `go build` forGo target
+
+### Phase 6: Stdlib Transpilation
+
+Run transpiler on all `std_lib/*.ard` files and output to `compiler/go/stdlib/`.
+
+### Phase 7: Parity Testing
+
+Create test infrastructure to run the same tests through both backends and compare outputs.
+
+## Decisions Summary
+
+| Aspect | Decision |
+|--------|----------|
+| Result | Go `(T, error)` tuple |
+| Maybe | `ard/go.Maybe[T]` struct |
+| Enum | `struct { tag int }` + const |
+| Union | `interface{}` + type switch |
+| Dynamic | `any` + JSON helpers |
+| Module mapping | One .ard file → One Go package |
+| CLI flag | `--target <value>` (bytecode/go) |
+| Config | `target` field in `ard.toml` |
+| Stdlib | Pre-transpiled Go packages |
+| Externs | Registry + stub functions |
+| Copy semantics | Explicit `ardgo.Copy*()` calls |
+
+## Open Questions
+
+1. **Go module path derivation** — How to map `ard.toml` name to Go module path?
+   - Option A: Use name directly (e.g., `name = "myproject"` → `module myproject`)
+   - Option B: Require full path in config (e.g., `module = "github.com/user/myproject"`)
+
+2. **Circular dependencies** — Go requires all imports to exist. How to handle circular module dependencies in Ard?
+
+3. **Dependency ordering** — Transpiler needs to emit packages in dependency order. Might need a dependency graph analysis pass.

--- a/compiler/bytecode/vm/ffi_generate.go
+++ b/compiler/bytecode/vm/ffi_generate.go
@@ -22,10 +22,10 @@ const (
 
 // GoType represents a supported Go type for idiomatic FFI functions.
 type GoType struct {
-	Base        string // "string", "int", "float64", "bool", "error"
-	IsPtr       bool   // *string, *int, etc. → maps to Maybe
-	IsSlice     bool   // []string, []int, etc. → maps to List
-	IsStringMap bool   // map[string]string → maps to [Str:Str]
+	Base       string // "string", "int", "float64", "bool", "error"
+	IsPtr      bool   // *string, *int, etc. → maps to Maybe
+	IsSlice    bool   // []string, []int, etc. → maps to List
+	MapValue   string // "string", "int", "float64", "bool" for map[string]T
 }
 
 type FFIFunction struct {
@@ -283,8 +283,11 @@ func parseGoType(expr ast.Expr) (GoType, bool) {
 	case *ast.MapType:
 		keyIdent, keyOK := t.Key.(*ast.Ident)
 		valueIdent, valueOK := t.Value.(*ast.Ident)
-		if keyOK && valueOK && keyIdent.Name == "string" && valueIdent.Name == "string" {
-			return GoType{IsStringMap: true}, true
+		if keyOK && valueOK && keyIdent.Name == "string" {
+			switch valueIdent.Name {
+			case "string", "int", "float64", "bool":
+				return GoType{MapValue: valueIdent.Name}, true
+			}
 		}
 	}
 	return GoType{}, false
@@ -304,12 +307,12 @@ func generateRegistry(functions []FFIFunction) error {
 		}
 		hasIdiomatic = true
 		for _, t := range fn.Returns {
-			if t.IsPtr || t.IsSlice || t.IsStringMap {
+			if t.IsPtr || t.IsSlice || t.MapValue != "" {
 				needsChecker = true
 			}
 		}
 		for _, t := range fn.Params {
-			if t.IsPtr || t.IsSlice || t.IsStringMap {
+			if t.IsPtr || t.IsSlice || t.MapValue != "" {
 				needsChecker = true
 			}
 		}
@@ -420,11 +423,11 @@ func generateParamUnwrap(sb *strings.Builder, idx int, t GoType) {
 		sb.WriteString(fmt.Sprintf("\t\t%s[_i%d] = %s\n", varName, idx, unwrapScalar(fmt.Sprintf("_e%d", idx), t.Base)))
 		sb.WriteString("\t}\n")
 
-	case t.IsStringMap:
+	case t.MapValue != "":
 		sb.WriteString(fmt.Sprintf("\t_rawMap%d := %s.AsMap()\n", idx, argRef))
-		sb.WriteString(fmt.Sprintf("\t%s := make(map[string]string, len(_rawMap%d))\n", varName, idx))
+		sb.WriteString(fmt.Sprintf("\t%s := make(map[string]%s, len(_rawMap%d))\n", varName, t.MapValue, idx))
 		sb.WriteString(fmt.Sprintf("\tfor _k%d, _v%d := range _rawMap%d {\n", idx, idx, idx))
-		sb.WriteString(fmt.Sprintf("\t\t%s[_k%d] = _v%d.AsString()\n", varName, idx, idx))
+		sb.WriteString(fmt.Sprintf("\t\t%s[_k%d] = %s\n", varName, idx, unwrapScalar(fmt.Sprintf("_v%d", idx), t.MapValue)))
 		sb.WriteString("\t}\n")
 
 	default:
@@ -478,10 +481,11 @@ func generateReturnWrap(sb *strings.Builder, t GoType, varName string, isResult 
 		sb.WriteString("\t}\n")
 		wrap(fmt.Sprintf("runtime.MakeList(%s, _items...)", checkerType))
 
-	case t.IsStringMap:
-		sb.WriteString(fmt.Sprintf("\t_map := runtime.MakeMap(checker.Str, checker.Str)\n"))
+	case t.MapValue != "":
+		valueCheckerType := checkerTypeStr(t.MapValue)
+		sb.WriteString(fmt.Sprintf("\t_map := runtime.MakeMap(checker.Str, %s)\n", valueCheckerType))
 		sb.WriteString(fmt.Sprintf("\tfor _k, _v := range %s {\n", varName))
-		sb.WriteString("\t\t_map.Map_Set(runtime.MakeStr(_k), runtime.MakeStr(_v))\n")
+		sb.WriteString(fmt.Sprintf("\t\t_map.Map_Set(runtime.MakeStr(_k), %s)\n", wrapScalar("_v", t.MapValue)))
 		sb.WriteString("\t}\n")
 		wrap("_map")
 

--- a/compiler/bytecode/vm/registry.gen.go
+++ b/compiler/bytecode/vm/registry.gen.go
@@ -306,6 +306,19 @@ func _ffi_FS_DeleteDir(args []*runtime.Object) *runtime.Object {
 	return runtime.MakeOk(runtime.Void())
 }
 
+func _ffi_FS_ListDir(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].AsString()
+	result, err := ffi.FS_ListDir(arg0)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	_map := runtime.MakeMap(checker.Str, checker.Bool)
+	for _k, _v := range result {
+		_map.Map_Set(runtime.MakeStr(_k), runtime.MakeBool(_v))
+	}
+	return runtime.MakeOk(_map)
+}
+
 func _ffi_HexEncode(args []*runtime.Object) *runtime.Object {
 	arg0 := args[0].AsString()
 	result := ffi.HexEncode(arg0)
@@ -661,7 +674,7 @@ func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
 	if err := r.Register("FS_DeleteDir", _ffi_FS_DeleteDir); err != nil {
 		return fmt.Errorf("failed to register FS_DeleteDir: %w", err)
 	}
-	if err := r.Register("FS_ListDir", ffi.FS_ListDir); err != nil {
+	if err := r.Register("FS_ListDir", _ffi_FS_ListDir); err != nil {
 		return fmt.Errorf("failed to register FS_ListDir: %w", err)
 	}
 	if err := r.Register("HexEncode", _ffi_HexEncode); err != nil {

--- a/compiler/ffi/fs.go
+++ b/compiler/ffi/fs.go
@@ -4,31 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sync"
-
-	"github.com/akonwi/ard/checker"
-	"github.com/akonwi/ard/runtime"
 )
-
-var (
-	fsDirEntryType     checker.Type
-	fsDirEntryTypeOnce sync.Once
-)
-
-func getFSDirEntryType() checker.Type {
-	fsDirEntryTypeOnce.Do(func() {
-		mod, ok := checker.FindEmbeddedModule("ard/fs")
-		if !ok {
-			panic("failed to load ard/fs embedded module")
-		}
-		sym := mod.Get("DirEntry")
-		if sym.Type == nil {
-			panic("DirEntry type not found in ard/fs module")
-		}
-		fsDirEntryType = sym.Type
-	})
-	return fsDirEntryType
-}
 
 func FS_Exists(path string) bool {
 	_, err := os.Stat(path)
@@ -131,23 +107,17 @@ func FS_DeleteDir(path string) error {
 	return os.RemoveAll(path)
 }
 
-func FS_ListDir(args []*runtime.Object) *runtime.Object {
-	path := args[0].Raw().(string)
+// FS_ListDir returns a map of entry names to is_file flag.
+// Returns error if the directory cannot be read.
+func FS_ListDir(path string) (map[string]bool, error) {
 	entries, err := os.ReadDir(path)
 	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+		return nil, err
 	}
 
-	dirEntryType := getFSDirEntryType()
-
-	var dirEntries []*runtime.Object
+	result := make(map[string]bool, len(entries))
 	for _, entry := range entries {
-		dirEntryObj := runtime.MakeStruct(dirEntryType, map[string]*runtime.Object{
-			"name":    runtime.MakeStr(entry.Name()),
-			"is_file": runtime.MakeBool(!entry.IsDir()),
-		})
-		dirEntries = append(dirEntries, dirEntryObj)
+		result[entry.Name()] = !entry.IsDir()
 	}
-
-	return runtime.MakeOk(runtime.MakeList(dirEntryType, dirEntries...))
+	return result, nil
 }

--- a/compiler/std_lib/fs.ard
+++ b/compiler/std_lib/fs.ard
@@ -31,4 +31,14 @@ extern fn create_dir(path: Str) Void!Str = "FS_CreateDir"
 
 extern fn delete_dir(path: Str) Void!Str = "FS_DeleteDir"
 
-extern fn list_dir(path: Str) [DirEntry]!Str = "FS_ListDir"
+// Private FFI returns map of name -> is_file
+private extern fn _list_dir_map(path: Str) [Str: Bool]!Str = "FS_ListDir"
+
+fn list_dir(path: Str) [DirEntry]!Str {
+  let entries_map = try _list_dir_map(path)
+  mut entries: [DirEntry] = []
+  for name, is_file in entries_map {
+    entries.push(DirEntry{name: name, is_file: is_file})
+  }
+  Result::ok(entries)
+}


### PR DESCRIPTION
## Summary

Extends the FFI generator to support `map[string]bool`, `map[string]int`, and `map[string]float64` (previously only `map[string]string` was supported).

## Changes

### Generator Extension
- Extended `GoType` struct with `MapValue` field (replaces `IsStringMap bool`)
- Updated `parseGoType` to recognize `map[string]bool`, `map[string]int`, `map[string]float64`
- Updated code generation in `generateParamUnwrap` and `generateReturnWrap`

### FS_ListDir Refactor
- Converted from **raw FFI** to **idiomatic FFI**
- Now returns `map[string]bool` (name → is_file) instead of constructing `DirEntry` structs in Go
- Ard code builds `DirEntry` structs from the map
- **Eliminated `getFSDirEntryType()` type lookup entirely**

## Before/After

### Before (Raw FFI)
```go
func FS_ListDir(args []*runtime.Object) *runtime.Object {
    // ... type lookup for DirEntry
    dirEntryType := getFSDirEntryType()
    // ... manual struct construction
}
```

### After (Idiomatic FFI)
```go
func FS_ListDir(path string) (map[string]bool, error) {
    entries, err := os.ReadDir(path)
    // ... return simple map
}
```

```ard
// std_lib/fs.ard
private extern fn _list_dir_map(path: Str) [Str: Bool]!Str = "FS_ListDir"

fn list_dir(path: Str) [DirEntry]!Str {
  let entries_map = try _list_dir_map(path)
  mut entries: [DirEntry] = []
  for name, is_file in entries_map {
    entries.push(DirEntry{name: name, is_file: is_file})
  }
  Result::ok(entries)
}
```

## Benefits
- Reduced raw FFI count: **15 → 14**
- Eliminated one type lookup (`GetStdType` pattern)
- Simpler Go code, more logic in Ard

## Testing
- All unit tests pass
- `map[string]bool` correctly generates `.AsBool()` for unwrapping and `MakeBool` for wrapping
- `map[string]int` correctly generates `.AsInt()` for unwrapping and `MakeInt` for wrapping