### PR TITLE
feat(generator): add support for []any and map[string]any

### DIFF
--- a/compiler/bytecode/vm/ffi_generate.go
+++ b/compiler/bytecode/vm/ffi_generate.go
@@ -22,10 +22,12 @@ const (
 
 // GoType represents a supported Go type for idiomatic FFI functions.
 type GoType struct {
-	Base       string // "string", "int", "float64", "bool", "error"
+	Base       string // "string", "int", "float64", "bool", "error", "any"
 	IsPtr      bool   // *string, *int, etc. → maps to Maybe
 	IsSlice    bool   // []string, []int, etc. → maps to List
 	MapValue   string // "string", "int", "float64", "bool" for map[string]T
+	IsAnySlice bool   // []any → maps to [Dynamic]
+	IsAnyMap   bool   // map[string]any → maps to [Str:Dynamic]
 }
 
 type FFIFunction struct {
@@ -277,16 +279,22 @@ func parseGoType(expr ast.Expr) (GoType, bool) {
 				switch ident.Name {
 				case "string", "int", "float64", "bool":
 					return GoType{Base: ident.Name, IsSlice: true}, true
+				case "any":
+					return GoType{IsAnySlice: true}, true
 				}
 			}
 		}
 	case *ast.MapType:
 		keyIdent, keyOK := t.Key.(*ast.Ident)
 		valueIdent, valueOK := t.Value.(*ast.Ident)
-		if keyOK && valueOK && keyIdent.Name == "string" {
-			switch valueIdent.Name {
-			case "string", "int", "float64", "bool":
-				return GoType{MapValue: valueIdent.Name}, true
+		if keyOK && keyIdent.Name == "string" {
+			if valueOK {
+				switch valueIdent.Name {
+				case "string", "int", "float64", "bool":
+					return GoType{MapValue: valueIdent.Name}, true
+				case "any":
+					return GoType{IsAnyMap: true}, true
+				}
 			}
 		}
 	}
@@ -307,12 +315,12 @@ func generateRegistry(functions []FFIFunction) error {
 		}
 		hasIdiomatic = true
 		for _, t := range fn.Returns {
-			if t.IsPtr || t.IsSlice || t.MapValue != "" {
+			if t.IsPtr || t.IsSlice || t.MapValue != "" || t.IsAnySlice || t.IsAnyMap {
 				needsChecker = true
 			}
 		}
 		for _, t := range fn.Params {
-			if t.IsPtr || t.IsSlice || t.MapValue != "" {
+			if t.IsPtr || t.IsSlice || t.MapValue != "" || t.IsAnySlice || t.IsAnyMap {
 				needsChecker = true
 			}
 		}
@@ -423,11 +431,25 @@ func generateParamUnwrap(sb *strings.Builder, idx int, t GoType) {
 		sb.WriteString(fmt.Sprintf("\t\t%s[_i%d] = %s\n", varName, idx, unwrapScalar(fmt.Sprintf("_e%d", idx), t.Base)))
 		sb.WriteString("\t}\n")
 
+	case t.IsAnySlice:
+		sb.WriteString(fmt.Sprintf("\t_sl%d := %s.AsList()\n", idx, argRef))
+		sb.WriteString(fmt.Sprintf("\t%s := make([]any, len(_sl%d))\n", varName, idx))
+		sb.WriteString(fmt.Sprintf("\tfor _i%d, _e%d := range _sl%d {\n", idx, idx, idx))
+		sb.WriteString(fmt.Sprintf("\t\t%s[_i%d] = _e%d.Raw()\n", varName, idx, idx))
+		sb.WriteString("\t}\n")
+
 	case t.MapValue != "":
 		sb.WriteString(fmt.Sprintf("\t_rawMap%d := %s.AsMap()\n", idx, argRef))
 		sb.WriteString(fmt.Sprintf("\t%s := make(map[string]%s, len(_rawMap%d))\n", varName, t.MapValue, idx))
 		sb.WriteString(fmt.Sprintf("\tfor _k%d, _v%d := range _rawMap%d {\n", idx, idx, idx))
 		sb.WriteString(fmt.Sprintf("\t\t%s[_k%d] = %s\n", varName, idx, unwrapScalar(fmt.Sprintf("_v%d", idx), t.MapValue)))
+		sb.WriteString("\t}\n")
+
+	case t.IsAnyMap:
+		sb.WriteString(fmt.Sprintf("\t_rawMap%d := %s.AsMap()\n", idx, argRef))
+		sb.WriteString(fmt.Sprintf("\t%s := make(map[string]any, len(_rawMap%d))\n", varName, idx))
+		sb.WriteString(fmt.Sprintf("\tfor _k%d, _v%d := range _rawMap%d {\n", idx, idx, idx))
+		sb.WriteString(fmt.Sprintf("\t\t%s[_k%d] = _v%d.Raw()\n", varName, idx, idx))
 		sb.WriteString("\t}\n")
 
 	default:
@@ -481,11 +503,25 @@ func generateReturnWrap(sb *strings.Builder, t GoType, varName string, isResult 
 		sb.WriteString("\t}\n")
 		wrap(fmt.Sprintf("runtime.MakeList(%s, _items...)", checkerType))
 
+	case t.IsAnySlice:
+		sb.WriteString(fmt.Sprintf("\t_items := make([]*runtime.Object, len(%s))\n", varName))
+		sb.WriteString(fmt.Sprintf("\tfor _i, _v := range %s {\n", varName))
+		sb.WriteString("\t\t_items[_i] = runtime.MakeDynamic(_v)\n")
+		sb.WriteString("\t}\n")
+		wrap("runtime.MakeList(checker.Dynamic, _items...)")
+
 	case t.MapValue != "":
 		valueCheckerType := checkerTypeStr(t.MapValue)
 		sb.WriteString(fmt.Sprintf("\t_map := runtime.MakeMap(checker.Str, %s)\n", valueCheckerType))
 		sb.WriteString(fmt.Sprintf("\tfor _k, _v := range %s {\n", varName))
 		sb.WriteString(fmt.Sprintf("\t\t_map.Map_Set(runtime.MakeStr(_k), %s)\n", wrapScalar("_v", t.MapValue)))
+		sb.WriteString("\t}\n")
+		wrap("_map")
+
+	case t.IsAnyMap:
+		sb.WriteString("\t_map := runtime.MakeMap(checker.Str, checker.Dynamic)\n")
+		sb.WriteString(fmt.Sprintf("\tfor _k, _v := range %s {\n", varName))
+		sb.WriteString("\t\t_map.Map_Set(runtime.MakeStr(_k), runtime.MakeDynamic(_v))\n")
 		sb.WriteString("\t}\n")
 		wrap("_map")
 

--- a/compiler/bytecode/vm/registry.gen.go
+++ b/compiler/bytecode/vm/registry.gen.go
@@ -171,6 +171,26 @@ func _ffi_CryptoUUID(args []*runtime.Object) *runtime.Object {
 	return runtime.MakeStr(result)
 }
 
+func _ffi_ListToDynamic(args []*runtime.Object) *runtime.Object {
+	_sl0 := args[0].AsList()
+	arg0 := make([]any, len(_sl0))
+	for _i0, _e0 := range _sl0 {
+		arg0[_i0] = _e0.Raw()
+	}
+	result := ffi.ListToDynamic(arg0)
+	return runtime.MakeDynamic(result)
+}
+
+func _ffi_MapToDynamic(args []*runtime.Object) *runtime.Object {
+	_rawMap0 := args[0].AsMap()
+	arg0 := make(map[string]any, len(_rawMap0))
+	for _k0, _v0 := range _rawMap0 {
+		arg0[_k0] = _v0.Raw()
+	}
+	result := ffi.MapToDynamic(arg0)
+	return runtime.MakeDynamic(result)
+}
+
 func _ffi_JsonToDynamic(args []*runtime.Object) *runtime.Object {
 	arg0 := args[0].AsString()
 	result, err := ffi.JsonToDynamic(arg0)
@@ -599,10 +619,10 @@ func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
 	if err := r.Register("CryptoUUID", _ffi_CryptoUUID); err != nil {
 		return fmt.Errorf("failed to register CryptoUUID: %w", err)
 	}
-	if err := r.Register("ListToDynamic", ffi.ListToDynamic); err != nil {
+	if err := r.Register("ListToDynamic", _ffi_ListToDynamic); err != nil {
 		return fmt.Errorf("failed to register ListToDynamic: %w", err)
 	}
-	if err := r.Register("MapToDynamic", ffi.MapToDynamic); err != nil {
+	if err := r.Register("MapToDynamic", _ffi_MapToDynamic); err != nil {
 		return fmt.Errorf("failed to register MapToDynamic: %w", err)
 	}
 	if err := r.Register("JsonToDynamic", _ffi_JsonToDynamic); err != nil {

--- a/compiler/ffi/decoders.go
+++ b/compiler/ffi/decoders.go
@@ -31,22 +31,18 @@ func getDecodeErrorType() checker.Type {
 	return decodeErrorType
 }
 
-func ListToDynamic(args []*runtime.Object) *runtime.Object {
-	arg := args[0].AsList()
-	raw := make([]any, len(arg))
-	for i, item := range arg {
-		raw[i] = item.Raw()
-	}
-	return runtime.MakeDynamic(raw)
+func ListToDynamic(items []any) any {
+	raw := make([]any, len(items))
+	copy(raw, items)
+	return raw
 }
 
-func MapToDynamic(args []*runtime.Object) *runtime.Object {
-	arg := args[0].AsMap()
-	raw := map[string]any{}
-	for key, val := range arg {
-		raw[key] = val.Raw()
+func MapToDynamic(m map[string]any) any {
+	raw := make(map[string]any, len(m))
+	for k, v := range m {
+		raw[k] = v
 	}
-	return runtime.MakeDynamic(raw)
+	return raw
 }
 
 // Parse external data (JSON text) into Dynamic object


### PR DESCRIPTION
## Summary

Extends the FFI generator to support `[]any` (slice of any) and `map[string]any` types, and converts two raw FFI functions to idiomatic.

## Changes

### Generator Extension
- Extended `GoType` struct with `IsAnySlice` and `IsAnyMap` fields
- Updated `parseGoType` to recognize `[]any` and `map[string]any`
- Updated code generation for both parameter unwrapping and return wrapping:

**`[]any` parameter:**
```go
_sl0 := args[0].AsList()
arg0 := make([]any, len(_sl0))
for _i0, _e0 := range _sl0 {
    arg0[_i0] = _e0.Raw()
}
```

**`[]any` return:**
```go
_items := make([]*runtime.Object, len(result))
for _i, _v := range result {
    _items[_i] = runtime.MakeDynamic(_v)
}
return runtime.MakeList(checker.Dynamic, _items...)
```

**`map[string]any` parameter:**
```go
_rawMap0 := args[0].AsMap()
arg0 := make(map[string]any, len(_rawMap0))
for _k0, _v0 := range _rawMap0 {
    arg0[_k0] = _v0.Raw()
}
```

**`map[string]any` return:**
```go
_map := runtime.MakeMap(checker.Str, checker.Dynamic)
for _k, _v := range result {
    _map.Map_Set(runtime.MakeStr(_k), runtime.MakeDynamic(_v))
}
return _map
```

### Function Conversions

| Function | Before | After |
|----------|--------|-------|
| `ListToDynamic` | Raw FFI (`[]*runtime.Object`) | Idiomatic (`[]any) any` |
| `MapToDynamic` | Raw FFI (`[]*runtime.Object`) | Idiomatic (`map[string]any) any` |

## Stats
- Raw FFI: **14 → 12**
- Idiomatic FFI: **59 → 61**

## Testing
- All unit tests pass
- Verified generated code for `[]any` and `map[string]any`