### PR TITLE
refactor(json): convert JsonEncode to idiomatic FFI

### DIFF
--- a/compiler/bytecode/vm/registry.gen.go
+++ b/compiler/bytecode/vm/registry.gen.go
@@ -436,6 +436,15 @@ func _ffi_HTTP_ResponseClose(args []*runtime.Object) *runtime.Object {
 	return runtime.Void()
 }
 
+func _ffi_JsonEncode(args []*runtime.Object) *runtime.Object {
+	arg0 := args[0].Raw()
+	result, err := ffi.JsonEncode(arg0)
+	if err != nil {
+		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+	}
+	return runtime.MakeOk(runtime.MakeStr(result))
+}
+
 func _ffi_FloatFromStr(args []*runtime.Object) *runtime.Object {
 	arg0 := args[0].AsString()
 	result := ffi.FloatFromStr(arg0)
@@ -767,7 +776,7 @@ func (r *RuntimeFFIRegistry) RegisterGeneratedFFIFunctions() error {
 	if err := r.Register("HTTP_Serve", ffi.HTTP_Serve); err != nil {
 		return fmt.Errorf("failed to register HTTP_Serve: %w", err)
 	}
-	if err := r.Register("JsonEncode", ffi.JsonEncode); err != nil {
+	if err := r.Register("JsonEncode", _ffi_JsonEncode); err != nil {
 		return fmt.Errorf("failed to register JsonEncode: %w", err)
 	}
 	if err := r.Register("FloatFromStr", _ffi_FloatFromStr); err != nil {

--- a/compiler/ffi/json.go
+++ b/compiler/ffi/json.go
@@ -2,15 +2,13 @@ package ffi
 
 import (
 	"encoding/json/v2"
-
-	"github.com/akonwi/ard/runtime"
 )
 
-// Encode an Ard value into a JSON string
-func JsonEncode(args []*runtime.Object) *runtime.Object {
-	bytes, err := json.Marshal(args[0])
+// JsonEncode marshals an Ard value to a JSON string.
+func JsonEncode(value any) (string, error) {
+	bytes, err := json.Marshal(value)
 	if err != nil {
-		return runtime.MakeErr(runtime.MakeStr(err.Error()))
+		return "", err
 	}
-	return runtime.MakeOk(runtime.MakeStr(string(bytes)))
+	return string(bytes), nil
 }


### PR DESCRIPTION
## Summary

Converts `JsonEncode` from raw FFI to idiomatic FFI.

## Changes

**Before:**
```go
func JsonEncode(args []*runtime.Object) *runtime.Object
```

**After:**
```go
func JsonEncode(value any) (string, error)
```

## Generated Wrapper
```go
func _ffi_JsonEncode(args []*runtime.Object) *runtime.Object {
    arg0 := args[0].Raw()
    result, err := ffi.JsonEncode(arg0)
    if err != nil {
        return runtime.MakeErr(runtime.MakeStr(err.Error()))
    }
    return runtime.MakeOk(runtime.MakeStr(result))
}
```

## Cleanup
- Removed `runtime` import from `json.go`

## Stats
- Raw FFI: **10 → 9**
- Idiomatic FFI: **63 → 64**