### PR TITLE
fix(checker): dereference bound async eval result types

### DIFF
--- a/compiler/checker/async_test.go
+++ b/compiler/checker/async_test.go
@@ -100,5 +100,20 @@ func TestAsyncEvalIsolation(t *testing.T) {
 			`,
 			diagnostics: []checker.Diagnostic{},
 		},
+		{
+			name: "async::eval get return type is concrete in expressions",
+			input: `
+			use ard/async
+
+			let a = async::eval(fn() Int {
+				1
+			})
+			let b = async::eval(fn() Int {
+				2
+			})
+			let total = a.get() + b.get()
+			`,
+			diagnostics: []checker.Diagnostic{},
+		},
 	})
 }

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -1356,14 +1356,23 @@ func (c *Checker) checkList(declaredType Type, expr *parse.ListLiteral) *ListLit
 	if declaredType != nil {
 		expectedElementType := declaredType.(*List).of
 		elements := make([]Expression, len(expr.Items))
+		hasError := false
 		for i := range expr.Items {
 			item := expr.Items[i]
 			element := c.checkExpr(item)
+			if element == nil {
+				hasError = true
+				continue
+			}
 			if !expectedElementType.equal(element.Type()) {
 				c.addError(typeMismatch(expectedElementType, element.Type()), item.GetLocation())
-				return nil
+				hasError = true
+				continue
 			}
 			elements[i] = element
+		}
+		if hasError {
+			return nil
 		}
 
 		listType := declaredType.(*List)
@@ -1388,10 +1397,11 @@ func (c *Checker) checkList(declaredType Type, expr *parse.ListLiteral) *ListLit
 		item := expr.Items[i]
 		element := c.checkExpr(item)
 		if element == nil {
+			hasError = true
 			continue
 		}
 
-		if i == 0 {
+		if elementType == nil {
 			elementType = element.Type()
 		} else if !elementType.equal(element.Type()) {
 			c.addError("Type mismatch: A list can only contain values of single type", item.GetLocation())
@@ -1402,7 +1412,7 @@ func (c *Checker) checkList(declaredType Type, expr *parse.ListLiteral) *ListLit
 		elements[i] = element
 	}
 
-	if hasError {
+	if hasError || elementType == nil {
 		return nil
 	}
 
@@ -4727,6 +4737,12 @@ func (c *Checker) checkAndProcessArguments(fnDef *FunctionDef, resolvedArgs []pa
 		}
 	} else {
 		fnToUse = fnDef
+	}
+
+	if fnToUse != nil {
+		if derefFn, ok := derefType(fnToUse).(*FunctionDef); ok {
+			fnToUse = derefFn
+		}
 	}
 
 	return allExprs, fnToUse


### PR DESCRIPTION
## Summary
- dereference bound generic function signatures before returning checked call nodes
- fix `async::eval(...).get()` leaking a bound `TypeVar` instead of a concrete type
- add a checker regression test covering `a.get() + b.get()` from async eval fibers

## Testing
- `cd compiler && go test ./checker -run "TestAsyncEvalIsolation" -v`
- `cd compiler && go test ./...`
