### PR TITLE
fix(runtime): preserve repeated stdin line reads

### DIFF
--- a/compiler/ffi/runtime.go
+++ b/compiler/ffi/runtime.go
@@ -3,7 +3,9 @@ package ffi
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -21,17 +23,33 @@ func Print(str string) {
 	fmt.Println(str)
 }
 
+var (
+	stdinReaderMu sync.Mutex
+	stdinReader   *bufio.Reader
+	stdinSource   *os.File
+)
+
 // ReadLine reads a line from stdin
 func ReadLine() (string, error) {
-	scanner := bufio.NewScanner(os.Stdin)
-	if !scanner.Scan() {
-		if err := scanner.Err(); err != nil {
-			return "", err
-		}
-		// EOF - return empty string as success
-		return "", nil
+	stdinReaderMu.Lock()
+	defer stdinReaderMu.Unlock()
+
+	if stdinReader == nil || stdinSource != os.Stdin {
+		stdinSource = os.Stdin
+		stdinReader = bufio.NewReader(os.Stdin)
 	}
-	return scanner.Text(), nil
+
+	line, err := stdinReader.ReadString('\n')
+	if err != nil {
+		if err == io.EOF {
+			if line == "" {
+				return "", nil
+			}
+			return strings.TrimRight(line, "\r\n"), nil
+		}
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
 }
 
 // PanicWithMessage panics with a message

--- a/compiler/ffi/runtime_test.go
+++ b/compiler/ffi/runtime_test.go
@@ -1,0 +1,52 @@
+package ffi
+
+import (
+	"os"
+	"testing"
+)
+
+func TestReadLineReadsMultipleLines(t *testing.T) {
+	oldStdin := os.Stdin
+	defer func() {
+		os.Stdin = oldStdin
+		stdinReaderMu.Lock()
+		stdinReader = nil
+		stdinSource = nil
+		stdinReaderMu.Unlock()
+	}()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdin pipe: %v", err)
+	}
+	defer reader.Close()
+
+	if _, err := writer.WriteString("first\nsecond\n"); err != nil {
+		t.Fatalf("failed to seed stdin: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("failed to close stdin writer: %v", err)
+	}
+
+	os.Stdin = reader
+	stdinReaderMu.Lock()
+	stdinReader = nil
+	stdinSource = nil
+	stdinReaderMu.Unlock()
+
+	first, err := ReadLine()
+	if err != nil {
+		t.Fatalf("first ReadLine failed: %v", err)
+	}
+	if first != "first" {
+		t.Fatalf("expected first line, got %q", first)
+	}
+
+	second, err := ReadLine()
+	if err != nil {
+		t.Fatalf("second ReadLine failed: %v", err)
+	}
+	if second != "second" {
+		t.Fatalf("expected second line, got %q", second)
+	}
+}


### PR DESCRIPTION
## Summary
- keep a reusable stdin reader for `ffi.ReadLine()` instead of creating a new scanner each call
- trim trailing newlines while preserving the existing EOF-as-empty-string behavior
- add a regression test covering two consecutive reads from the same stdin stream

## Why
Creating a fresh `bufio.Scanner(os.Stdin)` per call can buffer future input on the first read, causing later `io::read_line()` calls to observe empty input/EOF unexpectedly.

## Validation
- `cd compiler && go test ./ffi`
- `cd compiler && printf "10
50
47
" | go run main.go run samples/guess.ard`
