### PR TITLE
refactor(frontend): share module loading across backends

### DIFF
--- a/compiler/frontend/load.go
+++ b/compiler/frontend/load.go
@@ -1,0 +1,70 @@
+package frontend
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/akonwi/ard/backend"
+	"github.com/akonwi/ard/checker"
+	"github.com/akonwi/ard/parse"
+)
+
+type LoadResult struct {
+	Module      checker.Module
+	ProjectInfo *checker.ProjectInfo
+}
+
+func ResolveTarget(inputPath, requestedTarget string) (string, error) {
+	if requestedTarget != "" {
+		return requestedTarget, nil
+	}
+	inputDir := filepath.Dir(inputPath)
+	if inputDir == "" {
+		inputDir = "."
+	}
+	project, err := checker.FindProjectRoot(inputDir)
+	if err != nil {
+		return "", err
+	}
+	return backend.ParseTarget(project.Target)
+}
+
+func LoadModule(inputPath string, target string) (*LoadResult, error) {
+	sourceCode, err := os.ReadFile(inputPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file %s - %v", inputPath, err)
+	}
+
+	result := parse.Parse(sourceCode, inputPath)
+	if len(result.Errors) > 0 {
+		result.PrintErrors()
+		return nil, fmt.Errorf("parse errors")
+	}
+	program := result.Program
+
+	workingDir := filepath.Dir(inputPath)
+	moduleResolver, err := checker.NewModuleResolver(workingDir)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing module resolver: %w", err)
+	}
+
+	relPath, err := filepath.Rel(workingDir, inputPath)
+	if err != nil {
+		relPath = inputPath
+	}
+
+	c := checker.New(relPath, program, moduleResolver, checker.CheckOptions{Target: target})
+	c.Check()
+	if c.HasErrors() {
+		for _, diagnostic := range c.Diagnostics() {
+			fmt.Println(diagnostic)
+		}
+		return nil, fmt.Errorf("type errors")
+	}
+
+	return &LoadResult{
+		Module:      c.Module(),
+		ProjectInfo: moduleResolver.GetProjectInfo(),
+	}, nil
+}

--- a/compiler/javascript/javascript.go
+++ b/compiler/javascript/javascript.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/akonwi/ard/backend"
 	"github.com/akonwi/ard/checker"
-	"github.com/akonwi/ard/parse"
+	"github.com/akonwi/ard/frontend"
 )
 
 type emitOptions struct {
@@ -139,39 +139,11 @@ func Run(inputPath, target string, _ []string) error {
 }
 
 func loadModule(inputPath string, target string) (checker.Module, *checker.ProjectInfo, error) {
-	sourceCode, err := os.ReadFile(inputPath)
+	result, err := frontend.LoadModule(inputPath, target)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error reading file %s - %v", inputPath, err)
+		return nil, nil, err
 	}
-
-	result := parse.Parse(sourceCode, inputPath)
-	if len(result.Errors) > 0 {
-		result.PrintErrors()
-		return nil, nil, fmt.Errorf("parse errors")
-	}
-	program := result.Program
-
-	workingDir := filepath.Dir(inputPath)
-	moduleResolver, err := checker.NewModuleResolver(workingDir)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error initializing module resolver: %w", err)
-	}
-
-	relPath, err := filepath.Rel(workingDir, inputPath)
-	if err != nil {
-		relPath = inputPath
-	}
-
-	c := checker.New(relPath, program, moduleResolver, checker.CheckOptions{Target: target})
-	c.Check()
-	if c.HasErrors() {
-		for _, diagnostic := range c.Diagnostics() {
-			fmt.Println(diagnostic)
-		}
-		return nil, nil, fmt.Errorf("type errors")
-	}
-
-	return c.Module(), moduleResolver.GetProjectInfo(), nil
+	return result.Module, result.ProjectInfo, nil
 }
 
 func compilerJSSourcePath(parts ...string) (string, error) {

--- a/compiler/main.go
+++ b/compiler/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -16,8 +15,8 @@ import (
 	bytecodevm "github.com/akonwi/ard/bytecode/vm"
 	"github.com/akonwi/ard/checker"
 	"github.com/akonwi/ard/formatter"
+	"github.com/akonwi/ard/frontend"
 	"github.com/akonwi/ard/javascript"
-	"github.com/akonwi/ard/parse"
 	"github.com/akonwi/ard/runtime"
 	"github.com/akonwi/ard/transpile"
 	"github.com/akonwi/ard/version"
@@ -182,41 +181,11 @@ func check(inputPath string) bool {
 }
 
 func loadModule(inputPath string, target string) (checker.Module, error) {
-	sourceCode, err := os.ReadFile(inputPath)
+	result, err := frontend.LoadModule(inputPath, target)
 	if err != nil {
-		fmt.Printf("Error reading file %s - %v\n", inputPath, err)
 		return nil, err
 	}
-
-	result := parse.Parse(sourceCode, inputPath)
-	if len(result.Errors) > 0 {
-		result.PrintErrors()
-		return nil, fmt.Errorf("parse errors")
-	}
-	program := result.Program
-
-	workingDir := filepath.Dir(inputPath)
-	moduleResolver, err := checker.NewModuleResolver(workingDir)
-	if err != nil {
-		log.Fatalf("Error initializing module resolver: %v\n", err)
-	}
-
-	// Get relative path for diagnostics
-	relPath, err := filepath.Rel(workingDir, inputPath)
-	if err != nil {
-		relPath = inputPath // fallback to absolute path
-	}
-
-	c := checker.New(relPath, program, moduleResolver, checker.CheckOptions{Target: target})
-	c.Check()
-	if c.HasErrors() {
-		for _, diagnostic := range c.Diagnostics() {
-			fmt.Println(diagnostic)
-		}
-		return nil, fmt.Errorf("type errors")
-	}
-
-	return c.Module(), nil
+	return result.Module, nil
 }
 
 func parseRunArgs(args []string) (string, string, error) {
@@ -308,18 +277,7 @@ func parseBuildArgs(args []string) (string, string, string, error) {
 }
 
 func resolveTarget(inputPath, requestedTarget string) (string, error) {
-	if requestedTarget != "" {
-		return requestedTarget, nil
-	}
-	inputDir := filepath.Dir(inputPath)
-	if inputDir == "" {
-		inputDir = "."
-	}
-	project, err := checker.FindProjectRoot(inputDir)
-	if err != nil {
-		return "", err
-	}
-	return backend.ParseTarget(project.Target)
+	return frontend.ResolveTarget(inputPath, requestedTarget)
 }
 
 func parseFormatArgs(args []string) (string, bool, error) {

--- a/compiler/transpile/transpile.go
+++ b/compiler/transpile/transpile.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/akonwi/ard/backend"
 	"github.com/akonwi/ard/checker"
-	"github.com/akonwi/ard/parse"
+	"github.com/akonwi/ard/frontend"
 )
 
 const (
@@ -1070,39 +1070,11 @@ func writeImportedModule(generatedDir, projectName string, module checker.Module
 }
 
 func loadModule(inputPath string) (checker.Module, *checker.ProjectInfo, error) {
-	sourceCode, err := os.ReadFile(inputPath)
+	result, err := frontend.LoadModule(inputPath, backend.TargetGo)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error reading file %s - %v", inputPath, err)
+		return nil, nil, err
 	}
-
-	result := parse.Parse(sourceCode, inputPath)
-	if len(result.Errors) > 0 {
-		result.PrintErrors()
-		return nil, nil, fmt.Errorf("parse errors")
-	}
-	program := result.Program
-
-	workingDir := filepath.Dir(inputPath)
-	moduleResolver, err := checker.NewModuleResolver(workingDir)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error initializing module resolver: %w", err)
-	}
-
-	relPath, err := filepath.Rel(workingDir, inputPath)
-	if err != nil {
-		relPath = inputPath
-	}
-
-	c := checker.New(relPath, program, moduleResolver, checker.CheckOptions{Target: backend.TargetGo})
-	c.Check()
-	if c.HasErrors() {
-		for _, diagnostic := range c.Diagnostics() {
-			fmt.Println(diagnostic)
-		}
-		return nil, nil, fmt.Errorf("type errors")
-	}
-
-	return c.Module(), moduleResolver.GetProjectInfo(), nil
+	return result.Module, result.ProjectInfo, nil
 }
 
 func topLevelExecutableStatements(stmts []checker.Statement) []checker.Statement {


### PR DESCRIPTION
## Summary\n- add a shared frontend loader for target resolution and module loading\n- reuse it from the CLI, Go backend, and JavaScript backend\n- preserve existing backend behavior while removing duplicated parse/typecheck setup\n\n## Validation\n- cd compiler && go test ./frontend ./backend ./checker ./transpile ./javascript\n- cd compiler && go test .