### PR TITLE
chore: Add native Go benchmark comparisons

### DIFF
--- a/compiler/benchmarks/README.md
+++ b/compiler/benchmarks/README.md
@@ -4,6 +4,8 @@ This directory contains a small benchmark corpus for comparing:
 
 - the default bytecode VM target (`ard run` / `ard build`)
 - the Go backend (`ard run --target go` / `ard build --target go`)
+- the JavaScript server backend where supported (`ard run --target js-server` / `ard build --target js-server`)
+- handwritten idiomatic Go variants (`benchmarks/go/*`)
 
 The benchmarks are intentionally more realistic than tiny microbenchmarks, but still self-contained and deterministic.
 
@@ -42,7 +44,8 @@ From `compiler/`:
 
 Builds the Ard CLI once, then for each benchmark builds:
 - one VM binary
-- one Go-target binary
+- one Ard Go-target binary
+- one handwritten idiomatic Go binary
 - one `js-server` module where supported
 
 and benchmarks the resulting executables / runtime entrypoints.
@@ -53,7 +56,7 @@ and benchmarks the resulting executables / runtime entrypoints.
 
 ### End-to-end CLI comparison
 
-Benchmarks the full `ard run` / `ard run --target go` / `ard run --target js-server` path instead of prebuilt binaries:
+Benchmarks the full `ard run` / `ard run --target go` / `ard run --target js-server` path instead of prebuilt binaries. The handwritten Go variant is included via `go run`:
 
 ```bash
 ./benchmarks/run.sh --mode cli
@@ -75,6 +78,8 @@ Benchmarks the full `ard run` / `ard run --target go` / `ard run --target js-ser
 
 - `runtime` mode is the better apples-to-apples backend execution comparison.
 - `cli` mode is useful if you want to include transpilation/build overhead in backend measurements.
+- `native-go:*` command names refer to the handwritten idiomatic Go variants; `go:*` command names refer to Ard's generated Go backend.
+- The runner verifies exact output equality for compiler backends. Native Go variants are sanity-checked for output, but are allowed to differ when idiomatic Go semantics better capture the benchmark's intent than Ard implementation quirks.
 - `js-server` is included automatically for the currently supported benchmark subset:
   - `sales_pipeline`
   - `shape_catalog`

--- a/compiler/benchmarks/go/async_batches/main.go
+++ b/compiler/benchmarks/go/async_batches/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+func heavySum(start, stop int) int {
+	total := 0
+	for i := start; i <= stop; i++ {
+		total += i * i % 97
+		total += i * 3 % 17
+	}
+	return total
+}
+
+func main() {
+	results := make([]int, 25)
+	var wg sync.WaitGroup
+
+	for batch := 0; batch <= 24; batch++ {
+		start := batch * 3000
+		stop := start + 3000
+		wg.Add(1)
+		go func(batch, start, stop int) {
+			defer wg.Done()
+			results[batch] = heavySum(start, stop)
+		}(batch, start, stop)
+	}
+
+	wg.Wait()
+
+	checksum := 0
+	for idx, result := range results {
+		checksum += (idx + 1) * result
+	}
+
+	fmt.Print(checksum)
+}

--- a/compiler/benchmarks/go/decode_pipeline/main.go
+++ b/compiler/benchmarks/go/decode_pipeline/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type payloadData struct {
+	Units   []int          `json:"units"`
+	Weights []int          `json:"weights"`
+	Counts  map[string]int `json:"counts"`
+}
+
+func decodeOnce(payload string) int {
+	var raw payloadData
+	if err := json.Unmarshal([]byte(payload), &raw); err != nil {
+		panic(err)
+	}
+
+	total := 0
+	for idx, unit := range raw.Units {
+		total += unit * raw.Weights[idx]
+	}
+
+	for _, count := range raw.Counts {
+		total += count
+	}
+
+	return total
+}
+
+func main() {
+	payload := `{"units":[1,3,5,7,9,11,13,15,17,19,21,23],"weights":[2,4,6,8,10,12,14,16,18,20,22,24],"counts":{"alpha":3,"beta":5,"gamma":8,"delta":13}}`
+	checksum := 0
+
+	for i := 0; i <= 12000; i++ {
+		checksum += decodeOnce(payload)
+	}
+
+	fmt.Print(checksum)
+}

--- a/compiler/benchmarks/go/fs_batch/main.go
+++ b/compiler/benchmarks/go/fs_batch/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func filePath(dir, name string) string {
+	return filepath.Join(dir, name)
+}
+
+func cleanupDir(dir string) {
+	if _, err := os.Stat(dir); err == nil {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			panic(err)
+		}
+		for _, entry := range entries {
+			if err := os.Remove(filePath(dir, entry.Name())); err != nil {
+				panic(err)
+			}
+		}
+		if err := os.Remove(dir); err != nil {
+			panic(err)
+		}
+	} else if !os.IsNotExist(err) {
+		panic(err)
+	}
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	dir := ".ard-bench-fs"
+	cleanupDir(dir)
+	must(os.Mkdir(dir, 0o755))
+
+	checksum := 0
+
+	for i := 0; i <= 400; i++ {
+		baseName := fmt.Sprintf("item-%d.txt", i)
+		copyName := fmt.Sprintf("copy-%d.txt", i)
+		finalName := fmt.Sprintf("final-%d.txt", i)
+		basePath := filePath(dir, baseName)
+		copyPath := filePath(dir, copyName)
+		finalPath := filePath(dir, finalName)
+		content := fmt.Sprintf("record:%d:%d:%d:%d", i, i%17, i*13%29, i*i%97)
+
+		must(os.WriteFile(basePath, []byte(content), 0o644))
+		must(copyFile(basePath, copyPath))
+		must(os.Rename(copyPath, finalPath))
+
+		text, err := os.ReadFile(finalPath)
+		must(err)
+		checksum += len(string(text))
+
+		if _, err := os.Stat(basePath); err == nil {
+			checksum++
+		} else if !os.IsNotExist(err) {
+			panic(err)
+		}
+
+		info, err := os.Stat(finalPath)
+		must(err)
+		if !info.IsDir() {
+			checksum += 2
+		}
+	}
+
+	entries, err := os.ReadDir(dir)
+	must(err)
+	checksum += len(entries)
+
+	for _, entry := range entries {
+		checksum += len(entry.Name())
+		must(os.Remove(filePath(dir, entry.Name())))
+	}
+
+	must(os.Remove(dir))
+	fmt.Print(checksum)
+}
+
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0o644)
+}

--- a/compiler/benchmarks/go/sales_pipeline/main.go
+++ b/compiler/benchmarks/go/sales_pipeline/main.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+type Region int
+
+const (
+	North Region = iota
+	South
+	East
+	West
+)
+
+func (r Region) weight() int {
+	switch r {
+	case North:
+		return 3
+	case South:
+		return 2
+	case East:
+		return 4
+	case West:
+		return 5
+	default:
+		return 0
+	}
+}
+
+type Sale struct {
+	rep    string
+	region Region
+	units  int
+	price  int
+}
+
+func (s Sale) revenue() int {
+	return s.units * s.price * s.region.weight()
+}
+
+type RepTotal struct {
+	rep     string
+	revenue int
+	volume  int
+}
+
+func buildSales(count int) []Sale {
+	reps := []string{"Ava", "Ben", "Cy", "Di", "Eli", "Fae"}
+	sales := make([]Sale, 0, count+1)
+
+	for i := 0; i <= count; i++ {
+		region := North
+		switch i % 4 {
+		case 1:
+			region = South
+		case 2:
+			region = East
+		case 3:
+			region = West
+		}
+
+		sales = append(sales, Sale{
+			rep:    reps[i%len(reps)],
+			region: region,
+			units:  i % (11 + 1),
+			price:  i * 7 % (13 + 5),
+		})
+	}
+
+	return sales
+}
+
+func summarize(sales []Sale) []RepTotal {
+	revenueByRep := make(map[string]int)
+	volumeByRep := make(map[string]int)
+
+	for _, sale := range sales {
+		revenueByRep[sale.rep] += sale.revenue()
+		volumeByRep[sale.rep] += sale.units
+	}
+
+	totals := make([]RepTotal, 0, len(revenueByRep))
+	for rep, revenue := range revenueByRep {
+		totals = append(totals, RepTotal{
+			rep:     rep,
+			revenue: revenue,
+			volume:  volumeByRep[rep],
+		})
+	}
+
+	sort.Slice(totals, func(i, j int) bool {
+		a := totals[i]
+		b := totals[j]
+		return a.revenue*1000+a.volume > b.revenue*1000+b.volume
+	})
+
+	return totals
+}
+
+func main() {
+	sales := buildSales(40000)
+	totals := summarize(sales)
+
+	checksum := 0
+	for idx, total := range totals {
+		checksum += (idx + 1) * total.revenue
+		checksum += total.volume
+	}
+
+	fmt.Print(checksum)
+}

--- a/compiler/benchmarks/go/shape_catalog/main.go
+++ b/compiler/benchmarks/go/shape_catalog/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+type Square struct {
+	size int
+}
+
+type Circle struct {
+	radius int
+}
+
+type Triangle struct {
+	base   int
+	height int
+}
+
+type Hexagon struct {
+	side int
+}
+
+type Shape interface {
+	shape()
+}
+
+func (Square) shape()   {}
+func (Circle) shape()   {}
+func (Triangle) shape() {}
+func (Hexagon) shape()  {}
+
+type ShapeStat struct {
+	kind  string
+	total int
+	seen  int
+}
+
+func buildShapes(count int) []Shape {
+	shapes := make([]Shape, 0, count+1)
+
+	for i := 0; i <= count; i++ {
+		switch i % 4 {
+		case 0:
+			shapes = append(shapes, Square{size: i % (23 + 2)})
+		case 1:
+			shapes = append(shapes, Circle{radius: i % (19 + 3)})
+		case 2:
+			shapes = append(shapes, Triangle{base: i % (17 + 4), height: i % (13 + 5)})
+		default:
+			shapes = append(shapes, Hexagon{side: i % (11 + 6)})
+		}
+	}
+
+	return shapes
+}
+
+func label(shape Shape) string {
+	switch shape.(type) {
+	case Square:
+		return "square"
+	case Circle:
+		return "circle"
+	case Triangle:
+		return "triangle"
+	case Hexagon:
+		return "hexagon"
+	default:
+		return ""
+	}
+}
+
+func score(shape Shape) int {
+	switch s := shape.(type) {
+	case Square:
+		return s.size * s.size
+	case Circle:
+		return s.radius * s.radius * 3
+	case Triangle:
+		return s.base * s.height / 2
+	case Hexagon:
+		return s.side * s.side * 2
+	default:
+		return 0
+	}
+}
+
+func summarize(shapes []Shape) []ShapeStat {
+	totals := make(map[string]int)
+	counts := make(map[string]int)
+
+	for _, shape := range shapes {
+		kind := label(shape)
+		totals[kind] += score(shape)
+		counts[kind]++
+	}
+
+	stats := make([]ShapeStat, 0, len(totals))
+	for kind, total := range totals {
+		stats = append(stats, ShapeStat{
+			kind:  kind,
+			total: total,
+			seen:  counts[kind],
+		})
+	}
+
+	sort.Slice(stats, func(i, j int) bool {
+		return stats[i].total > stats[j].total
+	})
+
+	return stats
+}
+
+func main() {
+	shapes := buildShapes(50000)
+	stats := summarize(shapes)
+
+	checksum := 0
+	for idx, stat := range stats {
+		checksum += (idx + 1) * stat.total
+		checksum += stat.seen
+	}
+
+	fmt.Print(checksum)
+}

--- a/compiler/benchmarks/go/sql_batch/main.go
+++ b/compiler/benchmarks/go/sql_batch/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	dbPath := ".ard-bench-sql.db"
+	if _, err := os.Stat(dbPath); err == nil {
+		must(os.Remove(dbPath))
+	} else if !os.IsNotExist(err) {
+		panic(err)
+	}
+
+	db, err := sql.Open("sqlite3", dbPath)
+	must(err)
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE items(name TEXT, qty INTEGER, price INTEGER, region TEXT)")
+	must(err)
+
+	tx, err := db.Begin()
+	must(err)
+	insert, err := tx.Prepare("INSERT INTO items(name, qty, price, region) VALUES (?, ?, ?, ?)")
+	must(err)
+	for i := 0; i <= 5000; i++ {
+		region := "north"
+		switch i % 3 {
+		case 1:
+			region = "south"
+		case 2:
+			region = "west"
+		}
+
+		_, err := insert.Exec(fmt.Sprintf("item-%d", i), i%11+1, i*7%19+3, region)
+		must(err)
+	}
+	must(insert.Close())
+	must(tx.Commit())
+
+	rows, err := db.Query("SELECT name, qty, price, region FROM items")
+	must(err)
+	defer rows.Close()
+
+	checksum := 0
+	for rows.Next() {
+		var name string
+		var qty int
+		var price int
+		var region string
+		must(rows.Scan(&name, &qty, &price, &region))
+
+		checksum++
+		checksum += len(name)
+		checksum += qty * price
+		checksum += len(region)
+	}
+	must(rows.Err())
+
+	must(db.Close())
+	must(os.Remove(dbPath))
+	fmt.Print(checksum)
+}

--- a/compiler/benchmarks/go/word_frequency_batch/main.go
+++ b/compiler/benchmarks/go/word_frequency_batch/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+type WordCount struct {
+	word  string
+	count int
+}
+
+func expandWords(rounds int) []string {
+	base := []string{"ard", "go", "vm", "parser", "checker", "runtime", "async", "trait", "result", "maybe"}
+
+	words := make([]string, 0, (rounds+1)*3)
+	for i := 0; i <= rounds; i++ {
+		words = append(words, base[i%len(base)])
+		words = append(words, base[(i+3)%len(base)])
+		words = append(words, base[(i+7)%len(base)])
+	}
+
+	return words
+}
+
+func countWords(words []string) []WordCount {
+	counts := make(map[string]int)
+
+	for _, word := range words {
+		counts[word]++
+	}
+
+	res := make([]WordCount, 0, len(counts))
+	for word, count := range counts {
+		res = append(res, WordCount{word: word, count: count})
+	}
+
+	sort.Slice(res, func(i, j int) bool {
+		return res[i].count > res[j].count
+	})
+
+	return res
+}
+
+func main() {
+	words := expandWords(40000)
+	counts := countWords(words)
+
+	checksum := 0
+	for idx, entry := range counts {
+		checksum += (idx + 1) * entry.count
+		checksum += len(entry.word)
+	}
+
+	fmt.Print(checksum)
+}

--- a/compiler/benchmarks/run.sh
+++ b/compiler/benchmarks/run.sh
@@ -25,6 +25,8 @@ Usage: benchmarks/run.sh [options] [benchmark-name ...]
 
 Options:
   --mode runtime|cli   Benchmark built binaries or `ard run` commands (default: runtime)
+                       Runtime mode also compares prebuilt idiomatic Go binaries;
+                       CLI mode compares `go run` for the idiomatic Go variants.
   --runs N             Hyperfine run count (default: 10)
   --warmup N           Hyperfine warmup runs (default: 2)
   --export-dir PATH    Export per-benchmark hyperfine JSON into PATH
@@ -78,6 +80,41 @@ supports_js_server() {
   esac
 }
 
+native_go_program() {
+  printf './benchmarks/go/%s\n' "$1"
+}
+
+cleanup_generated_program_dir() {
+  local program_dir="${1%/*}"
+  rm -rf "$ROOT_DIR/$program_dir/generated"
+}
+
+assert_same_output() {
+  local benchmark="$1"
+  local expected_name="$2"
+  local expected="$3"
+  local actual_name="$4"
+  local actual="$5"
+
+  if [[ "$actual" != "$expected" ]]; then
+    echo "error: output mismatch for $benchmark: $actual_name differs from $expected_name" >&2
+    echo "  $expected_name: $expected" >&2
+    echo "  $actual_name: $actual" >&2
+    exit 1
+  fi
+}
+
+assert_printed_output() {
+  local benchmark="$1"
+  local command_name="$2"
+  local output="$3"
+
+  if [[ -z "$output" ]]; then
+    echo "error: $command_name:$benchmark produced no output" >&2
+    exit 1
+  fi
+}
+
 selected_benchmarks() {
   if [[ "$#" -eq 0 ]]; then
     for entry in "${BENCHMARKS[@]}"; do
@@ -104,10 +141,17 @@ run_runtime_benchmark() {
   local go_bin="$tmp_dir/${name}-go"
   local js_out="$tmp_dir/${name}.mjs"
   local js_runner="$tmp_dir/${name}-runner.mjs"
+  local native_go_src
+  native_go_src="$(native_go_program "$name")"
+  local native_go_bin="$tmp_dir/${name}-native-go"
+
+  cleanup_generated_program_dir "$rel_path"
 
   echo "==> building runtime binaries for $name"
   (cd "$ROOT_DIR" && "$ARD_BIN" build "$rel_path" --out "$vm_bin")
   (cd "$ROOT_DIR" && "$ARD_BIN" build "$rel_path" --target go --out "$go_bin")
+  cleanup_generated_program_dir "$rel_path"
+  (cd "$ROOT_DIR" && go build -o "$native_go_bin" "$native_go_src")
 
   local export_args=()
   if [[ -n "$EXPORT_DIR" ]]; then
@@ -118,6 +162,7 @@ run_runtime_benchmark() {
   local commands=(
     --command-name "vm:$name" "$vm_bin"
     --command-name "go:$name" "$go_bin"
+    --command-name "native-go:$name" "$native_go_bin"
   )
 
   if supports_js_server "$name"; then
@@ -131,11 +176,25 @@ EOF
     echo "==> skipping js-server for $name (unsupported target/module set)"
   fi
 
+  echo "==> verifying outputs for $name"
+  local expected actual
+  expected="$($vm_bin)"
+  actual="$($go_bin)"
+  assert_same_output "$name" "vm" "$expected" "go" "$actual"
+  actual="$($native_go_bin)"
+  assert_printed_output "$name" "native-go" "$actual"
+  if supports_js_server "$name"; then
+    actual="$(node "$js_runner")"
+    assert_same_output "$name" "vm" "$expected" "js" "$actual"
+  fi
+
   hyperfine \
     --warmup "$WARMUP" \
     --runs "$RUNS" \
     "${commands[@]}" \
     "${export_args[@]}"
+
+  cleanup_generated_program_dir "$rel_path"
 }
 
 run_cli_benchmark() {
@@ -148,9 +207,29 @@ run_cli_benchmark() {
     export_args+=(--export-json "$EXPORT_DIR/${name}.cli.json")
   fi
 
+  local native_go_src
+  native_go_src="$(native_go_program "$name")"
+
+  cleanup_generated_program_dir "$rel_path"
+
+  echo "==> verifying outputs for $name"
+  local expected actual
+  expected="$(cd "$ROOT_DIR" && "$ARD_BIN" run "$rel_path")"
+  actual="$(cd "$ROOT_DIR" && "$ARD_BIN" run --target go "$rel_path")"
+  assert_same_output "$name" "vm" "$expected" "go" "$actual"
+  cleanup_generated_program_dir "$rel_path"
+  actual="$(cd "$ROOT_DIR" && go run "$native_go_src")"
+  assert_printed_output "$name" "native-go" "$actual"
+  if supports_js_server "$name"; then
+    actual="$(cd "$ROOT_DIR" && "$ARD_BIN" run --target js-server "$rel_path")"
+    assert_same_output "$name" "vm" "$expected" "js" "$actual"
+    cleanup_generated_program_dir "$rel_path"
+  fi
+
   local commands=(
     --command-name "vm:$name" "cd '$ROOT_DIR' && '$ARD_BIN' run '$rel_path'"
     --command-name "go:$name" "cd '$ROOT_DIR' && '$ARD_BIN' run --target go '$rel_path'"
+    --command-name "native-go:$name" "cd '$ROOT_DIR' && go run '$native_go_src'"
   )
 
   if supports_js_server "$name"; then
@@ -164,6 +243,8 @@ run_cli_benchmark() {
     --runs "$RUNS" \
     "${commands[@]}" \
     "${export_args[@]}"
+
+  cleanup_generated_program_dir "$rel_path"
 }
 
 main() {


### PR DESCRIPTION
## Context

I want to have an idiomatic Go reference for the sample programs to see how Ard flavors perform against raw Go

## What's changed

Nothing in the compiler