### PR TITLE
docs: sketch value-native runtime

### DIFF
--- a/backlog/bytecode-roadmap/README.md
+++ b/backlog/bytecode-roadmap/README.md
@@ -6,6 +6,7 @@ Active backlog docs:
 - `lowering.md`: remaining AST lowering work to decouple backends
 - `go-backend.md`: optional Go codegen notes and pitfalls
 - `performance.md`: VM/FFI profiling and runtime optimization backlog
+- `value-native-vm.md`: sketch for eliminating `runtime.Object` and moving to a Go-native VM value model
 
 Historical/reference docs moved to `compiler/docs`:
 - `compiler/docs/bytecode-roadmap-overview.md`

--- a/backlog/bytecode-roadmap/README.md
+++ b/backlog/bytecode-roadmap/README.md
@@ -5,6 +5,7 @@ This folder tracks outstanding bytecode-related backlog items.
 Active backlog docs:
 - `lowering.md`: remaining AST lowering work to decouple backends
 - `go-backend.md`: optional Go codegen notes and pitfalls
+- `performance.md`: VM/FFI profiling and runtime optimization backlog
 
 Historical/reference docs moved to `compiler/docs`:
 - `compiler/docs/bytecode-roadmap-overview.md`

--- a/backlog/bytecode-roadmap/performance.md
+++ b/backlog/bytecode-roadmap/performance.md
@@ -1,0 +1,340 @@
+# Bytecode VM Performance Backlog
+
+This document captures near-term performance work for the bytecode VM and the VM-side FFI boundary.
+
+It is intentionally focused on practical profiling-led work, especially for decode-heavy programs like `benchmarks/programs/decode_pipeline.ard`.
+
+## Current observations
+
+- Decode-heavy workloads spend a large amount of time crossing the extern boundary.
+- The current VM extern path still pays for:
+  - extern lookup by binding string
+  - `runtime.Object` argument/result wrapping at the boundary
+  - allocation-heavy Dynamic/list/map materialization in decode helpers
+- Decoder combinators also exercise closure creation/calls heavily.
+- Handwritten native Go remains much faster than both the VM and generated Go on `decode_pipeline`, so there is still significant runtime overhead to remove.
+
+## Prioritized work
+
+### 1. Make extern dispatch cheaper
+
+This is the highest-priority VM performance item.
+
+Candidate directions:
+
+- replace steady-state binding lookup by string with a cheaper call path
+  - pre-resolved numeric extern IDs
+  - direct function pointer tables attached to emitted programs
+  - or another constant-time path that avoids repeated string-key map work
+- remove unnecessary synchronization from the hot call path if registration is already complete before execution
+- reduce per-call temporary allocations around argument passing
+- investigate whether some or all VM extern calls can avoid `runtime.Object` boxing at the boundary
+  - especially for scalar arguments/results and Dynamic-heavy decode helpers
+
+### 2. Avoid materializing Ard collections when decode only needs traversal
+
+Decode currently converts raw JSON-backed Go values into Ard lists/maps eagerly.
+
+Candidate directions:
+
+- avoid building full Ard `[Dynamic]` / `[Dynamic:Dynamic]` values when a decoder only needs to iterate through raw `[]any` / `map[string]any`
+- add VM/runtime support for cheaper iteration over raw decoded data
+- measure how much time and allocation volume comes specifically from:
+  - `DynamicToList`
+  - `DynamicToMap`
+  - repeated `MakeDynamic` / list / map construction
+
+### 3. Optimize closure-heavy decode paths
+
+Decoder combinators rely on closures and nested small function calls.
+
+Candidate directions:
+
+- reduce allocation overhead in `OpCallClosure`
+- reuse scratch argument slices for closure invocation the same way module/extern calls already do
+- measure closure creation count, closure call count, and average closure arity on benchmark programs
+
+### 4. Keep decode optimization general-purpose
+
+For now, avoid a fused/special-purpose decoder compiler path unless profiling proves it is necessary.
+
+Preferred approach:
+
+- first make generic VM execution and generic extern calls cheaper
+- prefer improvements that help all programs, not only `ard/decode`
+- only revisit decode-specific lowering/intrinsics if general VM/FFI work does not close enough of the gap
+
+## Instrumentation backlog
+
+Before making larger changes, collect repeatable data.
+
+Add and use instrumentation for:
+
+- total extern calls
+- per-binding extern call counts and cumulative time
+- closure creation/call counts
+- direct function call vs closure call mix
+- `runtime.Object` constructor/allocation counters
+- Dynamic/list/map construction counts during VM execution
+
+The instrumentation should:
+
+- be opt-in
+- avoid changing normal stdout program output
+- be usable from both `ard run` and embedded bytecode binaries built via `ard build`
+- print to stderr or another non-program-output channel
+
+## Initial experiments to run
+
+1. Profile `decode_pipeline` with VM instrumentation enabled.
+2. Record:
+   - total extern calls
+   - hottest extern bindings by call count and time
+   - object allocation counts by constructor kind
+   - closure creation/call counts
+3. Compare those numbers against benchmark wall-clock timings.
+4. Use the results to choose the first implementation target:
+   - cheaper extern dispatch
+   - reduced `runtime.Object` boxing
+   - cheaper Dynamic collection traversal
+   - cheaper closure invocation
+
+## Instrumentation now available
+
+Current VM profiling is implemented and opt-in.
+
+Enable it with:
+
+```bash
+ARD_VM_PROFILE=1
+```
+
+Optional tuning:
+
+```bash
+ARD_VM_PROFILE_TOP=10
+```
+
+Behavior:
+
+- works for `ard run` on the bytecode target
+- works for embedded bytecode binaries produced by `ard build`
+- writes profiling output to `stderr`
+- keeps normal program `stdout` unchanged
+
+Current reports include:
+
+- total direct/module/closure/extern call counts
+- closure creation stats
+- per-binding extern call counts and cumulative time
+- `runtime.Object` constructor and fresh-allocation counters
+
+## Initial data points: `decode_pipeline`
+
+Runtime benchmark snapshot on this branch:
+
+- VM: ~240 ms
+- Ard Go backend: ~407 ms
+- native Go: ~22 ms
+- JS: ~78 ms
+
+A profiled VM run of `benchmarks/programs/decode_pipeline.ard` produced:
+
+### Call counts
+
+- direct calls: `132,012`
+- module calls: `456,038`
+- closure calls: `456,038`
+- extern calls: `468,040`
+
+### Closure profile
+
+- closures created: `120,010`
+- average captures per closure: `1.00`
+- max captures: `2`
+- average closure call arity: `1.00`
+
+### Extern totals
+
+- timed inside `vm.ffi.Call(...)`: `58.755 ms`
+- distinct extern bindings: `7`
+
+Top bindings by total measured time:
+
+1. `JsonToDynamic` — `12,001` calls — `26.503 ms`
+2. `DecodeInt` — `336,028` calls — `12.366 ms`
+3. `DynamicToList` — `24,002` calls — `9.356 ms`
+4. `DynamicToMap` — `12,001` calls — `5.101 ms`
+5. `DecodeString` — `48,004` calls — `3.035 ms`
+6. `ExtractField` — `36,003` calls — `2.346 ms`
+
+### `runtime.Object` profile
+
+- constructor calls: `4,896,415`
+- fresh allocations: `1,223,850`
+- `make_dynamic`: `432,036`
+- `make_list`: `48,004`
+- `make_map`: `24,002`
+- `copy_calls`: `72,006`
+- `make_int`: `2,496,211` with `2,292,448` small-int cache hits
+- `make_str`: `168,016`
+- `make_bool`: `1,092,092`
+
+## What the first data says
+
+The initial profile supports a few conclusions:
+
+1. Extern call volume is very high, so cheaper extern dispatch is still a strong first target.
+2. Extern body time alone does not explain the full VM/native gap, so dispatch-only work will not be sufficient by itself.
+3. `runtime.Object` churn is substantial, which supports investigating ways to reduce boxing/unboxing and Dynamic wrapper creation at the FFI boundary.
+4. Eager Dynamic list/map materialization is visible in both time and allocation counts.
+5. Closure-heavy decode composition is also a meaningful part of the hot path.
+
+## Recommended implementation order
+
+Based on the current profile, the recommended order is:
+
+1. make extern dispatch cheaper
+2. reduce `runtime.Object` boxing/materialization on decode-heavy paths
+3. optimize closure invocation
+4. avoid eager Dynamic list/map conversion where possible
+
+## Concrete next step: redesign extern dispatch
+
+The first implementation step should target the generic VM extern call path without changing Ard semantics.
+
+### Goals
+
+- remove repeated binding-string lookup from steady-state execution
+- remove synchronization from steady-state extern calls
+- preserve current FFI registration, generator output, and panic/`Result` behavior
+- keep profiling support intact so before/after comparisons stay easy
+
+### Current hot path
+
+Today `OpCallExtern` does all of the following during execution:
+
+1. load a string constant for the binding name
+2. build/pop the argument slice
+3. call `RuntimeFFIRegistry.Call(binding, args, returnType)`
+4. inside the registry, do a map lookup under `RWMutex`
+5. invoke the function
+
+That means every extern call pays for string-based dispatch even though the target binding is already known at emit time.
+
+### Proposed phase 1: pre-resolved extern table
+
+Add an extern table to bytecode programs and resolve it once when constructing the VM.
+
+#### Bytecode/program changes
+
+Introduce a program-level extern table, for example:
+
+```go
+type ExternEntry struct {
+    ID      int
+    Binding string
+}
+
+type Program struct {
+    Constants []Constant
+    Types     []TypeEntry
+    Externs   []ExternEntry
+    Functions []Function
+}
+```
+
+Emitter changes:
+
+- add `Emitter.addExtern(binding string) int`
+- deduplicate bindings at program-build time
+- change `OpCallExtern.A` to store an extern ID instead of a string constant index
+- keep binding strings in the program only for debugging/profiling/reporting
+
+#### VM changes
+
+At `vm.New(program)` time:
+
+- resolve `program.Externs[i].Binding` once against the shared FFI registry
+- store a VM-local resolved table such as:
+
+```go
+type resolvedExtern struct {
+    Binding string
+    Func    FFIFunc
+}
+```
+
+Then `OpCallExtern` becomes:
+
+1. read extern ID from the instruction
+2. fetch the resolved function pointer from a slice
+3. call it directly
+4. apply existing panic/`Result` handling semantics
+
+This removes repeated string-constant loading and repeated map lookup from the hot path.
+
+#### Registry changes
+
+Keep the existing registration API, but treat the registry as immutable after startup.
+
+Candidate simplification:
+
+- register all builtins once during process init / lazy singleton creation
+- after registration, use plain read-only structures on the call path
+- remove `RWMutex` from steady-state extern dispatch if nothing mutates after startup
+
+Even if the public `Register(...)` API remains, execution should not pay synchronization costs after VM construction.
+
+### Proposed phase 1.5: keep compatibility while simplifying the call surface
+
+The current `RuntimeFFIRegistry.Call(...)` helper mostly exists to:
+
+- look up a binding name
+- wrap panic recovery with `Result` awareness
+
+After extern resolution moves to VM construction time, the VM can own the panic-recovery wrapper directly around the already-resolved function pointer.
+
+That would let the steady-state call path avoid the registry abstraction almost entirely.
+
+### Proposed phase 2: reduce `runtime.Object` boundary overhead
+
+Once dispatch itself is cheaper, the next likely win is reducing object boxing/unboxing for extern-heavy paths.
+
+Likely direction:
+
+- keep existing raw `FFIFunc` support for complex bindings
+- add an optional faster extern ABI for simple scalar/Dynamic-heavy bindings
+- generate wrappers that can operate on cheaper raw values where safe
+- focus first on decode-oriented helpers like:
+  - `DecodeInt`
+  - `DecodeString`
+  - `DynamicToList`
+  - `DynamicToMap`
+  - `ExtractField`
+
+The goal is not to special-case `ard/decode` in the compiler, but to make the generic extern boundary cheaper for bindings that do not need full `runtime.Object` semantics.
+
+### Validation plan for phase 1
+
+After implementing pre-resolved extern dispatch:
+
+1. re-run `decode_pipeline` benchmark
+2. re-run VM profiling on `decode_pipeline`
+3. compare:
+   - total wall time
+   - total extern timed section
+   - hottest binding totals
+   - object allocation counts
+4. confirm no output/behavior changes across VM tests and backend parity tests
+
+Success criteria for phase 1:
+
+- measurable runtime improvement on `decode_pipeline`
+- lower total time attributed to extern calls
+- no semantic change in existing test coverage
+
+## Non-goals for now
+
+- Do not introduce a fused decoder compiler path yet.
+- Do not add decode-only special cases until the generic VM/FFI data says they are needed.

--- a/backlog/bytecode-roadmap/performance.md
+++ b/backlog/bytecode-roadmap/performance.md
@@ -334,6 +334,49 @@ Success criteria for phase 1:
 - lower total time attributed to extern calls
 - no semantic change in existing test coverage
 
+### Status update: pre-resolved extern table implemented
+
+This phase has now been implemented.
+
+What changed:
+
+- bytecode programs now carry a deduplicated extern table
+- `OpCallExtern` now references an extern ID instead of a string constant index
+- the VM resolves extern bindings once at VM construction time
+- steady-state extern execution now calls the pre-resolved function pointer directly
+- pseudo-externs like `NewList`, `AsyncStart`, and `AsyncEval` remain lowered to VM ops instead of going through the FFI registry
+
+### Observed impact on `decode_pipeline`
+
+Profile comparison on a profiled VM run:
+
+- extern total before: `58.755 ms`
+- extern total after: `50.188 ms`
+- improvement in measured extern section: about `8.6 ms` (~15%)
+
+Selected per-binding improvements:
+
+- `DecodeInt`: `12.366 ms` -> `9.334 ms`
+- `DynamicToList`: `9.356 ms` -> `7.906 ms`
+- `DynamicToMap`: `5.101 ms` -> `4.591 ms`
+- `ExtractField`: `2.346 ms` -> `1.632 ms`
+
+Other observations:
+
+- total call counts and object-allocation counts stayed effectively the same
+- runtime benchmark improvement was small and within normal benchmark noise
+- this matches the profile: the extern dispatch section got cheaper, but `runtime.Object` churn and closure-heavy decode composition still dominate a large part of total execution time
+
+### Updated takeaway
+
+The pre-resolved extern table is still a good change because it removes avoidable dispatch work and simplifies future optimization.
+
+But the profile now makes it clearer that the next higher-leverage work is:
+
+1. reducing `runtime.Object` boxing/materialization across the extern boundary
+2. reducing eager Dynamic list/map construction
+3. reducing closure-call overhead in decode-heavy code
+
 ## Non-goals for now
 
 - Do not introduce a fused decoder compiler path yet.

--- a/backlog/bytecode-roadmap/performance.md
+++ b/backlog/bytecode-roadmap/performance.md
@@ -377,6 +377,180 @@ But the profile now makes it clearer that the next higher-leverage work is:
 2. reducing eager Dynamic list/map construction
 3. reducing closure-call overhead in decode-heavy code
 
+## Sketch: faster extern ABI for simple bindings
+
+The next experiment should keep the existing raw FFI path intact, but add a second ABI for bindings that mostly want raw Go values and do not need full `runtime.Object` semantics.
+
+### Goals
+
+- reduce `runtime.Object` allocation/churn on extern-heavy programs
+- preserve the current raw `FFIFunc` escape hatch for complex runtime-aware bindings
+- avoid compiler-visible special cases for `ard/decode`
+- reuse the existing code generator where possible
+
+### Proposed model: dual extern ABIs
+
+Keep two runtime call shapes:
+
+```go
+type FFIFunc func(args []*runtime.Object) *runtime.Object
+
+type FastFFIFunc func(args []any) any
+```
+
+Conceptually:
+
+- `FFIFunc` remains the general-purpose path
+- `FastFFIFunc` is for simple scalar/Dynamic/JSON-shaped bindings
+
+A resolved extern entry would then carry one of the two:
+
+```go
+type resolvedExtern struct {
+    Binding string
+    Raw     FFIFunc
+    Fast    FastFFIFunc
+    Kind    externKind
+}
+```
+
+where `externKind` is something like:
+
+- `externKindRawObject`
+- `externKindFastRaw`
+
+### VM-side fast-call contract
+
+For `externKindFastRaw`, `OpCallExtern` would:
+
+1. pop `[]*runtime.Object` as usual
+2. convert each argument to raw Go values once via `.Raw()` or another lightweight extraction helper
+3. invoke the fast function on `[]any`
+4. wrap the return back into a `*runtime.Object`
+
+This still pays for the final wrap, but can avoid a large amount of per-binding object construction inside the FFI implementation itself.
+
+### Why this helps
+
+Today many bindings do work like this:
+
+- unwrap `runtime.Object` to raw values
+- do simple type assertions or JSON/map/list access
+- allocate new `runtime.Object`s for intermediate Dynamic values
+- then return a final `runtime.Object`
+
+A fast ABI can shrink that path to:
+
+- VM unwrap once
+- binding works directly with Go `any`, `[]any`, `map[string]any`, scalars
+- VM wraps once at the boundary
+
+That is especially appealing for decode-related helpers.
+
+### Good first candidates
+
+The first candidates should be bindings whose logic is already mostly raw-data oriented and does not need VM/runtime internals:
+
+- `JsonToDynamic`
+- `DecodeString`
+- `DecodeInt`
+- `DecodeFloat`
+- `DecodeBool`
+- `DynamicToList`
+- `DynamicToMap`
+- `ExtractField`
+
+These are attractive because they:
+
+- are hot in the profile
+- already operate on JSON-shaped Go values
+- do not need closure execution or embedded VM control flow
+
+### What should stay on the raw-object path
+
+These should stay on `FFIFunc` for now:
+
+- bindings that construct Ard structs/enums directly
+- bindings that need embedded checker type lookup
+- bindings that invoke closures or depend on VM/runtime control flow
+- bindings that depend on `Maybe`/`Result` object mutation semantics in-place
+
+Examples likely to remain raw for now:
+
+- `HTTP_Serve`
+- `Join`
+- decode helpers that still need `ard/decode::Error` struct construction unless return wrapping is redesigned too
+
+### Minimal implementation strategy
+
+Rather than redesign every binding at once, start with a very small opt-in generator feature.
+
+#### Step 1: add runtime support
+
+Add an optional fast-call path in the VM and resolved-extern metadata.
+
+Possible supporting helpers:
+
+```go
+func objectArgsToRaw(args []*runtime.Object) []any
+func wrapFastFFIResult(v any, returnType checker.Type) *runtime.Object
+```
+
+`wrapFastFFIResult` does not need to support everything initially. It only needs the subset used by the first migrated bindings.
+
+#### Step 2: add generator support for fast-ABI wrappers
+
+Teach the FFI generator to emit a fast wrapper for a constrained subset of idiomatic signatures.
+
+Good initial supported shapes:
+
+- params: `string`, `int`, `float64`, `bool`, `any`
+- returns: same scalar set, `any`, `error`, `(T, error)`
+
+That is enough to cover much of the decode surface.
+
+#### Step 3: migrate a tiny hot set first
+
+Do not migrate the whole FFI surface immediately.
+
+Start with just:
+
+- `JsonToDynamic`
+- `DecodeInt`
+- `DecodeString`
+- `ExtractField`
+
+Then re-profile.
+
+If that moves the needle, extend to:
+
+- `DecodeFloat`
+- `DecodeBool`
+- `DynamicToList`
+- `DynamicToMap`
+
+### Important design constraint
+
+The fast ABI should not become a second ad-hoc runtime system.
+
+To keep it contained:
+
+- fast ABI remains optional
+- raw-object ABI remains the source of truth for complex cases
+- generator errors out for unsupported fast signatures
+- VM profiling should report whether a binding used raw or fast dispatch
+
+### Expected outcome
+
+If the sketch works, the likely benefits are:
+
+- lower `runtime.Object` constructor counts
+- lower fresh-allocation counts
+- lower extern total time for decode-heavy programs
+- modest but measurable end-to-end VM speedup
+
+If the profile barely moves after migrating the first hot bindings, that is a sign the next bottleneck is more likely closure overhead or collection materialization than the extern boundary itself.
+
 ## Non-goals for now
 
 - Do not introduce a fused decoder compiler path yet.

--- a/backlog/bytecode-roadmap/value-native-vm.md
+++ b/backlog/bytecode-roadmap/value-native-vm.md
@@ -1,0 +1,509 @@
+# Value-Native VM Runtime Sketch
+
+This document sketches a longer-term direction for the bytecode VM: eliminating `runtime.Object` as the universal runtime value container and replacing it with native Go values plus a small set of Ard-specific runtime shapes.
+
+This is motivated by two goals:
+
+- better runtime performance by removing pervasive boxing/unboxing
+- more seamless Go interop by making VM values closer to ordinary Go values
+
+It is intentionally a design sketch, not an implementation plan with exact milestones yet.
+
+## Core idea
+
+Today `runtime.Object` does too many jobs at once:
+
+- VM stack/local value container
+- type/kind metadata carrier
+- `Maybe` / `Result` tagging mechanism
+- FFI boundary transport object
+- copy/equality helper surface
+
+The value-native direction is:
+
+- use native Go values for native Ard primitives
+- use explicit runtime structs only for Ard-specific composite/control-flow shapes
+- let VM frames store `[]any` rather than `[]*runtime.Object`
+- let FFI operate on ordinary Go values by default
+
+## Value model
+
+### Native values
+
+These Ard values should map directly to Go values inside the VM:
+
+- `Str` -> `string`
+- `Int` -> `int`
+- `Float` -> `float64`
+- `Bool` -> `bool`
+- `Dynamic` -> `any`
+- closures/functions -> `*Closure`
+
+### Void
+
+Use a dedicated sentinel for `Void` rather than overloading plain `nil`.
+
+Reason:
+
+- `nil` is already useful for Dynamic/raw interop
+- explicit sentinel avoids ambiguity between `Void`, missing values, and `Dynamic(nil)`
+
+Candidate shape:
+
+```go
+type VoidValue struct{}
+
+var Void = VoidValue{}
+```
+
+## Ard-specific runtime shapes
+
+### Maybe
+
+Use an explicit erased maybe runtime value in the VM core.
+
+Locked-in direction:
+
+```go
+type MaybeValue struct {
+    Value any
+    None  bool
+}
+```
+
+Why:
+
+- gives the VM one uniform maybe shape
+- avoids relying on flags on a universal object wrapper
+- keeps `try`, `or`, and maybe-method logic simple
+- matches the fact that VM stack/local storage will already be erased to `any`
+
+Notes:
+
+- `Some(x)` -> `MaybeValue{Value: x}`
+- `None` -> `MaybeValue{None: true}`
+- checker/bytecode metadata still determines the Ard-visible contained type
+
+### Result
+
+Use an explicit erased result runtime value in the VM core.
+
+Locked-in direction:
+
+```go
+type ResultValue struct {
+    Ok    any
+    Err   any
+    IsErr bool
+}
+```
+
+Why:
+
+- gives the VM one uniform result shape
+- avoids object-flag encoding
+- keeps `try`, `map`, `map_err`, `and_then`, and unwrap logic direct
+- matches the erased nature of the VM stack/runtime representation
+
+Notes:
+
+- `Ok(x)` -> `ResultValue{Ok: x}`
+- `Err(e)` -> `ResultValue{Err: e, IsErr: true}`
+- only one of `Ok` or `Err` is semantically active at a time
+- checker/bytecode metadata still determines Ard-visible ok/err types
+
+Optional helper constructors or generic convenience APIs may still exist on the Go side, but they should lower to these erased runtime structs rather than defining a second core runtime representation.
+
+## Lists and maps
+
+### Lists
+
+Lists should become native slices of values:
+
+```go
+type ListValue []any
+```
+
+This is one of the main performance wins:
+
+- no boxed object per element by default
+- simpler interop with Go slices
+- simpler iteration in the VM
+
+Copy semantics would still require explicit deep-copy helpers when Ard mutation rules demand them.
+
+### Maps
+
+Maps should use raw Go scalar keys internally, not normalized string keys and not a custom `MapKey` wrapper.
+
+Ard allows exactly these scalar map key types:
+
+- `Str`
+- `Int`
+- `Float`
+- `Bool`
+
+That means the VM can preserve native Go keys directly.
+
+Locked-in direction:
+
+```go
+type ScalarKey interface {
+    ~string | ~int | ~float64 | ~bool
+}
+
+type VMMap interface {
+    Len() int
+    GetAny(key any) (any, bool)
+    SetAny(key any, value any) bool
+    DropAny(key any) bool
+    HasAny(key any) bool
+    Keys() []any
+    Copy() VMMap
+}
+
+type Map[K ScalarKey] struct {
+    Entries map[K]any
+}
+
+type MapValue struct {
+    KeyType   bytecode.TypeID
+    ValueType bytecode.TypeID
+    Storage   VMMap
+}
+```
+
+Rationale:
+
+- preserves raw Go scalar keys directly
+- avoids lossy or implicit string normalization
+- avoids inventing a custom boxed key representation
+- gives the VM a uniform runtime abstraction through `VMMap`
+- aligns better with the long-term goal of seamless Go interop
+
+Operational model:
+
+- `[Str:T]` uses `*Map[string]`
+- `[Int:T]` uses `*Map[int]`
+- `[Float:T]` uses `*Map[float64]`
+- `[Bool:T]` uses `*Map[bool]`
+- VM code talks to the shared `VMMap` interface
+- concrete `Map[K]` implementations perform typed key assertions internally
+
+This design intentionally keeps value typing erased at runtime for now:
+
+- key type is represented concretely by `Map[K]`
+- value type remains `any` in storage
+- Ard-level type metadata stays available via `MapValue`
+
+### Float-key caveat
+
+Using raw Go `float64` keys means inheriting Go float-key semantics:
+
+- `NaN != NaN`
+- `0.0 == -0.0`
+
+That is acceptable for the current design sketch, but should be revisited explicitly if Ard later wants float-map-key semantics that differ from Go.
+
+## Structs and enums
+
+### Structs
+
+Struct runtime values should be index-only at the instance level.
+
+Locked-in direction:
+
+```go
+type StructValue struct {
+    TypeID bytecode.TypeID
+    Fields []any
+}
+```
+
+Why:
+
+- avoids repeated string-key lookups during execution
+- keeps instance layout compact
+- avoids per-instance field-name maps
+- supports faster field access and future layout optimization
+
+Shared metadata requirements:
+
+- field order/layout metadata associated with struct types
+- shared field name <-> field index lookup keyed by `TypeID`
+- debugging/tooling/error formatting should resolve names through shared metadata, not instance-local maps
+
+This aligns with the current FFI reality too: Ard structs are not part of the normal generated FFI boundary today except through raw/runtime-aware paths, so there is no strong reason to optimize for name-addressable per-instance struct interop inside the runtime core.
+
+### Struct layout metadata
+
+This question is now resolved.
+
+Locked-in direction:
+
+- bytecode/type metadata should gain first-class struct layout metadata
+- struct layout should be shared per type, not stored per instance
+- the metadata should be sufficient to support index-based execution without reconstructing layout indirectly from checker type names
+
+Minimum useful shared metadata per struct type:
+
+- `TypeID`
+- struct name
+- ordered field list
+- field name -> field index lookup
+- field type IDs by field index
+
+Illustrative shape:
+
+```go
+type StructFieldEntry struct {
+    Name   string
+    TypeID TypeID
+}
+
+type StructTypeEntry struct {
+    TypeID TypeID
+    Name   string
+    Fields []StructFieldEntry
+}
+```
+
+Operational consequences:
+
+- struct instances stay compact as `StructValue { TypeID, Fields []any }`
+- field access/set can resolve names through shared layout metadata
+- future optimizations can lower field access directly to indexes if desired
+
+This is intentionally more than the current `TypeEntry.Name` string, but much less than introducing a full reflective runtime type system.
+
+### Enums / union-like runtime values
+
+Candidate shape:
+
+```go
+type EnumValue struct {
+    TypeID bytecode.TypeID
+    Tag    int
+    Value  any
+}
+```
+
+This is enough for:
+
+- discriminant checks
+- payload storage
+- match lowering/runtime dispatch
+
+Exact shape may vary depending on how Ard enums/unions evolve, but the important point is that they become explicit runtime values rather than universal-object metadata.
+
+## VM frame model
+
+A value-native VM should move frame storage to plain `any`.
+
+Candidate shape:
+
+```go
+type Frame struct {
+    Fn         *bytecode.Function
+    IP         int
+    Locals     []any
+    Stack      []any
+    StackTop   int
+    MaxStack   int
+    ReturnType checker.Type
+}
+```
+
+This is the central runtime change.
+
+Consequences:
+
+- push/pop operate on `any`
+- arithmetic/method ops use type assertions on raw values or explicit runtime structs
+- FFI boundaries no longer need to box every argument into `*runtime.Object`
+
+## FFI / Go interop model
+
+This is one of the main reasons to move in this direction.
+
+### Default interop model
+
+By default, FFI should receive and return ordinary Go values.
+
+Examples:
+
+- Ard `Str` -> Go `string`
+- Ard `Int` -> Go `int`
+- Ard `Dynamic` -> Go `any`
+- Ard list -> Go `[]any`
+- Ard map -> either `MapValue` or converted Go map form depending on signature
+- Ard `extern type` -> raw Go handle/pointer stored directly as `any`
+
+### Complex interop
+
+Some bindings will still need deeper runtime access.
+
+For those, keep `runtime.Object`-based FFI as the unsafe/legacy escape hatch during migration.
+
+Locked-in direction:
+
+- default ABI: value-native Go values
+- unsafe/legacy ABI: VM-aware `runtime.Object`-based functions
+
+Important note:
+
+- no extra unsafe annotation is required
+- the Go signature itself is the signal
+- if a binding takes or returns `runtime.Object`-based types, it is clearly in the unsafe/legacy bucket
+
+That gives the runtime a clean default path while preserving an explicit escape hatch for complex VM-coupled bindings.
+
+## Copy semantics
+
+Removing `runtime.Object` does not remove Ard's copy semantics.
+
+Instead, copy logic becomes explicit per runtime shape.
+
+Need helpers like:
+
+```go
+func CopyValue(v any) any
+func CopyList(v ListValue) ListValue
+func CopyMap(v MapValue) MapValue
+func CopyStruct(v StructValue) StructValue
+```
+
+Copy rules:
+
+- primitives copy by value naturally
+- lists/maps/structs deep-copy where Ard semantics require it
+- closures and opaque extern handles remain shared references unless language semantics require otherwise
+- `MaybeValue` / `ResultValue` copy their active payloads according to the payload shape
+
+## Equality
+
+Equality should become explicit runtime logic over native values and explicit runtime structs.
+
+Need a helper such as:
+
+```go
+func EqualValues(left, right any, leftType checker.Type, rightType checker.Type) bool
+```
+
+This should handle:
+
+- scalar equality directly
+- `Maybe` equality by none/some + payload equality
+- `Result` equality by ok/err + payload equality
+- list/map/struct equality according to Ard semantics
+- extern handles / dynamic values only where checker rules allow it
+
+## Why this should help performance
+
+Potential wins:
+
+- fewer allocations
+- fewer pointers on stack/local paths
+- less wrapper churn at FFI boundaries
+- less duplicated kind/type metadata per runtime value
+- more direct use of Go data structures for Dynamic-heavy workloads
+
+In particular, decode-heavy programs may benefit from:
+
+- `Dynamic` staying as raw `any`
+- JSON arrays staying closer to `[]any`
+- JSON objects staying closer to keyed raw Go data
+- less boxing/unboxing in primitive decode helpers
+
+## Migration direction
+
+This should be staged rather than rewritten all at once.
+
+### Phase 0: define the runtime value types
+
+Before changing execution, define the canonical runtime shapes for:
+
+- `Void`
+- `Maybe`
+- `Result`
+- lists
+- maps + key representation
+- structs
+- enums
+- closures
+
+### Phase 1: add adapters
+
+Introduce conversion helpers between the current object model and the new value-native model.
+
+This allows incremental migration of:
+
+- VM ops
+- FFI
+- tests
+
+### Phase 2: move stack/locals to `any`
+
+Change frame storage first, then migrate op implementations incrementally.
+
+### Phase 3: make value-native FFI the default
+
+Ordinary FFI should work on native Go values by default.
+
+During migration, `runtime.Object`-based FFI remains supported as the unsafe/legacy escape hatch.
+
+### Phase 4: remove `runtime.Object` from hot paths
+
+Once stack, locals, and common FFI no longer need it, remove it from steady-state execution.
+
+### Phase 5: delete or quarantine the old object model
+
+If compatibility adapters are still needed for niche cases, isolate them clearly rather than leaving them in the runtime core.
+
+## Migration adapter decision
+
+This question is now resolved.
+
+Locked-in direction:
+
+- value-native FFI is the default/safe path
+- `runtime.Object`-based FFI is the unsafe/legacy escape hatch during migration
+- no extra annotation is required because the Go signature already makes the unsafe path obvious
+- compatibility adapters should live at the boundary rather than reintroducing object boxing into the VM core
+
+This keeps the long-term direction clear:
+
+- the VM itself becomes value-native
+- `runtime.Object` is not part of the future default runtime model
+- object-based FFI exists only to preserve compatibility and support complex runtime-coupled bindings while migration is underway
+
+## `Maybe` / `Result` runtime-shape decision
+
+This question is now resolved.
+
+Locked-in direction:
+
+- the VM core uses erased runtime structs: `MaybeValue` and `ResultValue`
+- generics are not part of the core runtime representation
+- optional Go-side helper constructors or generic convenience APIs may exist, but they should lower to the erased runtime shapes rather than define a second runtime model
+
+This is the simpler and more honest design for a value-native VM because stack/local values are already erased to `any`.
+
+## Open design questions
+
+At the moment, the major open questions in this sketch have been resolved at the architectural level.
+Further work should move from high-level design questions to concrete migration planning and implementation sequencing.
+
+## Recommendation
+
+This direction is worth pursuing.
+
+It aligns performance work with the broader product goal of better Go interop instead of just shaving overhead around `runtime.Object`.
+
+The next concrete step should be to refine this sketch into a code-adjacent design that specifies:
+
+- exact runtime type definitions
+- map key representation
+- struct field layout metadata needs
+- migration adapter strategy for current FFI
+- first VM subsystem to migrate experimentally

--- a/compiler/bytecode/emitter.go
+++ b/compiler/bytecode/emitter.go
@@ -10,6 +10,7 @@ import (
 type Emitter struct {
 	program      Program
 	typeIndex    map[string]TypeID
+	externIndex  map[string]int
 	funcIndex    map[string]int
 	funcTypes    map[string]checker.Type
 	anonCount    int
@@ -40,9 +41,11 @@ func NewEmitter() *Emitter {
 		program: Program{
 			Constants: []Constant{},
 			Types:     []TypeEntry{},
+			Externs:   []ExternEntry{},
 			Functions: []Function{},
 		},
 		typeIndex:   map[string]TypeID{},
+		externIndex: map[string]int{},
 		funcIndex:   map[string]int{},
 		funcTypes:   map[string]checker.Type{},
 		visitedMods: map[string]struct{}{},
@@ -144,6 +147,16 @@ func (e *Emitter) addConst(c Constant) int {
 	index := len(e.program.Constants)
 	e.program.Constants = append(e.program.Constants, c)
 	return index
+}
+
+func (e *Emitter) addExtern(binding string) int {
+	if idx, ok := e.externIndex[binding]; ok {
+		return idx
+	}
+	idx := len(e.program.Externs)
+	e.externIndex[binding] = idx
+	e.program.Externs = append(e.program.Externs, ExternEntry{ID: idx, Binding: binding})
+	return idx
 }
 
 func topLevelExecutableStatements(stmts []checker.Statement) []checker.Statement {
@@ -488,8 +501,26 @@ func (e *Emitter) emitExternWrapper(name string, def *checker.ExternalFunctionDe
 		fnEmitter.defineLocal(param.Name)
 	}
 
-	// Emit scalar-to-Dynamic conversions as OpToDynamic instead of FFI calls
+	// Emit lowered intrinsics for pseudo-externs instead of going through FFI.
 	switch def.ExternalBinding {
+	case "NewList":
+		listType, ok := def.ReturnType.(*checker.List)
+		if !ok {
+			return 0, fmt.Errorf("NewList return type is not a list: %T", def.ReturnType)
+		}
+		typeID := e.addType(listType)
+		fnEmitter.emit(Instruction{Op: OpMakeList, A: int(typeID), B: 0})
+		fnEmitter.adjustStack(0, 1)
+	case "AsyncStart":
+		fiberTypeID := e.addType(def.ReturnType)
+		fnEmitter.emit(Instruction{Op: OpLoadLocal, A: 0})
+		fnEmitter.emit(Instruction{Op: OpAsyncStart, C: int(fiberTypeID)})
+		fnEmitter.adjustStack(0, 1)
+	case "AsyncEval":
+		fiberTypeID := e.addType(def.ReturnType)
+		fnEmitter.emit(Instruction{Op: OpLoadLocal, A: 0})
+		fnEmitter.emit(Instruction{Op: OpAsyncEval, C: int(fiberTypeID)})
+		fnEmitter.adjustStack(0, 1)
 	case "StrToDynamic", "IntToDynamic", "FloatToDynamic", "BoolToDynamic":
 		fnEmitter.emit(Instruction{Op: OpLoadLocal, A: 0})
 		fnEmitter.emit(Instruction{Op: OpToDynamic})
@@ -502,9 +533,9 @@ func (e *Emitter) emitExternWrapper(name string, def *checker.ExternalFunctionDe
 		for i := range def.Parameters {
 			fnEmitter.emit(Instruction{Op: OpLoadLocal, A: i})
 		}
-		bindingIdx := e.addConst(Constant{Kind: ConstStr, Str: def.ExternalBinding})
+		externID := e.addExtern(def.ExternalBinding)
 		retID := e.addType(def.ReturnType)
-		fnEmitter.emit(Instruction{Op: OpCallExtern, A: bindingIdx, Imm: len(def.Parameters), C: int(retID)})
+		fnEmitter.emit(Instruction{Op: OpCallExtern, A: externID, Imm: len(def.Parameters), C: int(retID)})
 		fnEmitter.adjustStack(len(def.Parameters), 1)
 	}
 	fnEmitter.ensureReturn()
@@ -1388,9 +1419,9 @@ func (f *funcEmitter) emitFunctionCall(call *checker.FunctionCall) error {
 				return err
 			}
 		}
-		bindingIdx := f.emitter.addConst(Constant{Kind: ConstStr, Str: call.ExternalBinding})
+		externID := f.emitter.addExtern(call.ExternalBinding)
 		retID := f.emitter.addType(call.ReturnType)
-		f.emit(Instruction{Op: OpCallExtern, A: bindingIdx, Imm: argc, C: int(retID)})
+		f.emit(Instruction{Op: OpCallExtern, A: externID, Imm: argc, C: int(retID)})
 		f.adjustStack(argc, 1)
 		return nil
 	}
@@ -1461,9 +1492,9 @@ func (f *funcEmitter) emitModuleFunctionCall(call *checker.ModuleFunctionCall) e
 				return err
 			}
 		}
-		bindingIdx := f.emitter.addConst(Constant{Kind: ConstStr, Str: call.Call.ExternalBinding})
+		externID := f.emitter.addExtern(call.Call.ExternalBinding)
 		retID := f.emitter.addType(call.Call.ReturnType)
-		f.emit(Instruction{Op: OpCallExtern, A: bindingIdx, Imm: argc, C: int(retID)})
+		f.emit(Instruction{Op: OpCallExtern, A: externID, Imm: argc, C: int(retID)})
 		f.adjustStack(argc, 1)
 		return nil
 	}

--- a/compiler/bytecode/program.go
+++ b/compiler/bytecode/program.go
@@ -24,6 +24,11 @@ type TypeEntry struct {
 	Name string
 }
 
+type ExternEntry struct {
+	ID      int
+	Binding string
+}
+
 type Function struct {
 	Name     string
 	Arity    int
@@ -36,5 +41,6 @@ type Function struct {
 type Program struct {
 	Constants []Constant
 	Types     []TypeEntry
+	Externs   []ExternEntry
 	Functions []Function
 }

--- a/compiler/bytecode/serialize_test.go
+++ b/compiler/bytecode/serialize_test.go
@@ -52,3 +52,52 @@ func TestSerializeProgram(t *testing.T) {
 		t.Fatalf("Expected 5, got %v", got)
 	}
 }
+
+func TestSerializeProgramWithExterns(t *testing.T) {
+	result := parse.Parse([]byte("let val = Int::from_str(\"2\").or(0)\nval + 3"), "test.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("Parse errors: %v", result.Errors[0].Message)
+	}
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	resolver, err := checker.NewModuleResolver(workingDir)
+	if err != nil {
+		t.Fatalf("Failed to init module resolver: %v", err)
+	}
+	c := checker.New("test.ard", result.Program, resolver)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("Diagnostics found: %v", c.Diagnostics())
+	}
+
+	emitter := bytecode.NewEmitter()
+	program, err := emitter.EmitProgram(c.Module())
+	if err != nil {
+		t.Fatalf("Emit error: %v", err)
+	}
+	if len(program.Externs) == 0 {
+		t.Fatal("expected serialized program to contain extern entries")
+	}
+
+	data, err := bytecode.SerializeProgram(program)
+	if err != nil {
+		t.Fatalf("Serialize error: %v", err)
+	}
+	decoded, err := bytecode.DeserializeProgram(data)
+	if err != nil {
+		t.Fatalf("Deserialize error: %v", err)
+	}
+	if len(decoded.Externs) == 0 {
+		t.Fatal("expected decoded program to contain extern entries")
+	}
+
+	res, err := vm.New(decoded).Run("main")
+	if err != nil {
+		t.Fatalf("VM error: %v", err)
+	}
+	if got := res.GoValue(); got != 5 {
+		t.Fatalf("Expected 5, got %v", got)
+	}
+}

--- a/compiler/bytecode/verifier.go
+++ b/compiler/bytecode/verifier.go
@@ -47,6 +47,10 @@ func verifyFunction(program Program, fn Function) error {
 			if target.Arity != inst.B {
 				return fmt.Errorf("%s ip=%d: arity mismatch for %s", fn.Name, ip, target.Name)
 			}
+		case OpCallExtern:
+			if inst.A < 0 || inst.A >= len(program.Externs) {
+				return fmt.Errorf("%s ip=%d: extern target out of range", fn.Name, ip)
+			}
 		case OpMakeClosure:
 			if inst.A < 0 || inst.A >= len(program.Functions) {
 				return fmt.Errorf("%s ip=%d: closure target out of range", fn.Name, ip)

--- a/compiler/bytecode/vm/ffi_registry.go
+++ b/compiler/bytecode/vm/ffi_registry.go
@@ -12,6 +12,11 @@ import (
 
 type FFIFunc func(args []*runtime.Object) *runtime.Object
 
+type resolvedExtern struct {
+	Binding string
+	Func    FFIFunc
+}
+
 type RuntimeFFIRegistry struct {
 	functions map[string]FFIFunc
 	mutex     sync.RWMutex
@@ -35,12 +40,7 @@ func (r *RuntimeFFIRegistry) Get(binding string) (FFIFunc, bool) {
 	return fn, exists
 }
 
-func (r *RuntimeFFIRegistry) Call(binding string, args []*runtime.Object, returnType checker.Type) (result *runtime.Object, err error) {
-	fn, exists := r.Get(binding)
-	if !exists {
-		return nil, fmt.Errorf("External function not found: %s", binding)
-	}
-
+func callFFI(binding string, fn FFIFunc, args []*runtime.Object, returnType checker.Type) (result *runtime.Object, err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			panicMsg := fmt.Sprintf("panic in FFI function '%s': %v", binding, recovered)
@@ -55,6 +55,22 @@ func (r *RuntimeFFIRegistry) Call(binding string, args []*runtime.Object, return
 
 	result = fn(args)
 	return result, nil
+}
+
+func (r *RuntimeFFIRegistry) Resolve(binding string) (resolvedExtern, error) {
+	fn, exists := r.Get(binding)
+	if !exists {
+		return resolvedExtern{}, fmt.Errorf("External function not found: %s", binding)
+	}
+	return resolvedExtern{Binding: binding, Func: fn}, nil
+}
+
+func (r *RuntimeFFIRegistry) Call(binding string, args []*runtime.Object, returnType checker.Type) (*runtime.Object, error) {
+	resolved, err := r.Resolve(binding)
+	if err != nil {
+		return nil, err
+	}
+	return callFFI(resolved.Binding, resolved.Func, args, returnType)
 }
 
 func (r *RuntimeFFIRegistry) RegisterBuiltinFFIFunctions() error {

--- a/compiler/bytecode/vm/profile.go
+++ b/compiler/bytecode/vm/profile.go
@@ -1,0 +1,210 @@
+package vm
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	profileEnvVar    = "ARD_VM_PROFILE"
+	profileTopEnvVar = "ARD_VM_PROFILE_TOP"
+)
+
+func ProfilingEnabled() bool {
+	raw, ok := os.LookupEnv(profileEnvVar)
+	if !ok {
+		return false
+	}
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	return raw != "" && raw != "0" && raw != "false" && raw != "off"
+}
+
+func profileTopN() int {
+	raw := strings.TrimSpace(os.Getenv(profileTopEnvVar))
+	if raw == "" {
+		return 10
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 10
+	}
+	return n
+}
+
+type bindingProfile struct {
+	binding  string
+	calls    int
+	argcSum  int
+	maxArity int
+	total    time.Duration
+}
+
+type executionProfile struct {
+	started time.Time
+
+	mu sync.Mutex
+
+	directCalls      int
+	moduleCalls      int
+	closureCalls     int
+	closureArgSum    int
+	closureMaxArity  int
+	closureCreations int
+	captureSlots     int
+	maxCaptures      int
+	externCalls      int
+	externArgSum     int
+	externMaxArity   int
+	externTotal      time.Duration
+	externByBinding  map[string]*bindingProfile
+}
+
+func newExecutionProfile() *executionProfile {
+	if !ProfilingEnabled() {
+		return nil
+	}
+	return &executionProfile{
+		started:         time.Now(),
+		externByBinding: make(map[string]*bindingProfile),
+	}
+}
+
+func (p *executionProfile) RecordDirectCall() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.directCalls++
+	p.mu.Unlock()
+}
+
+func (p *executionProfile) RecordModuleCall() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.moduleCalls++
+	p.mu.Unlock()
+}
+
+func (p *executionProfile) RecordClosureCreation(captures int) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closureCreations++
+	p.captureSlots += captures
+	if captures > p.maxCaptures {
+		p.maxCaptures = captures
+	}
+}
+
+func (p *executionProfile) RecordClosureCall(argc int) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closureCalls++
+	p.closureArgSum += argc
+	if argc > p.closureMaxArity {
+		p.closureMaxArity = argc
+	}
+}
+
+func (p *executionProfile) RecordExternCall(binding string, argc int, dur time.Duration) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.externCalls++
+	p.externArgSum += argc
+	p.externTotal += dur
+	if argc > p.externMaxArity {
+		p.externMaxArity = argc
+	}
+
+	stat := p.externByBinding[binding]
+	if stat == nil {
+		stat = &bindingProfile{binding: binding}
+		p.externByBinding[binding] = stat
+	}
+	stat.calls++
+	stat.argcSum += argc
+	stat.total += dur
+	if argc > stat.maxArity {
+		stat.maxArity = argc
+	}
+}
+
+func formatProfileDuration(d time.Duration) string {
+	if d >= time.Microsecond {
+		return d.Round(time.Microsecond).String()
+	}
+	return d.String()
+}
+
+func (p *executionProfile) Report() string {
+	if p == nil {
+		return ""
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	var out strings.Builder
+	wall := time.Since(p.started)
+	fmt.Fprintf(&out, "[ard vm profile]\n")
+	fmt.Fprintf(&out, "wall=%s\n", wall.Round(time.Microsecond))
+	fmt.Fprintf(&out, "calls direct=%d module=%d closure=%d extern=%d\n", p.directCalls, p.moduleCalls, p.closureCalls, p.externCalls)
+	if p.closureCalls > 0 || p.closureCreations > 0 {
+		avgClosureArity := 0.0
+		if p.closureCalls > 0 {
+			avgClosureArity = float64(p.closureArgSum) / float64(p.closureCalls)
+		}
+		avgCaptures := 0.0
+		if p.closureCreations > 0 {
+			avgCaptures = float64(p.captureSlots) / float64(p.closureCreations)
+		}
+		fmt.Fprintf(&out, "closures created=%d avg_captures=%.2f max_captures=%d avg_call_arity=%.2f max_call_arity=%d\n", p.closureCreations, avgCaptures, p.maxCaptures, avgClosureArity, p.closureMaxArity)
+	}
+	if p.externCalls > 0 {
+		avgExternArity := float64(p.externArgSum) / float64(p.externCalls)
+		avgExternTime := p.externTotal / time.Duration(p.externCalls)
+		fmt.Fprintf(&out, "extern total=%s avg=%s avg_arity=%.2f max_arity=%d distinct_bindings=%d\n", p.externTotal.Round(time.Microsecond), formatProfileDuration(avgExternTime), avgExternArity, p.externMaxArity, len(p.externByBinding))
+
+		bindings := make([]*bindingProfile, 0, len(p.externByBinding))
+		for _, stat := range p.externByBinding {
+			bindings = append(bindings, stat)
+		}
+		sort.Slice(bindings, func(i, j int) bool {
+			if bindings[i].total == bindings[j].total {
+				if bindings[i].calls == bindings[j].calls {
+					return bindings[i].binding < bindings[j].binding
+				}
+				return bindings[i].calls > bindings[j].calls
+			}
+			return bindings[i].total > bindings[j].total
+		})
+
+		limit := profileTopN()
+		if limit > len(bindings) {
+			limit = len(bindings)
+		}
+		fmt.Fprintf(&out, "top extern bindings (by total time):\n")
+		for i := 0; i < limit; i++ {
+			stat := bindings[i]
+			avg := stat.total / time.Duration(stat.calls)
+			avgArity := float64(stat.argcSum) / float64(stat.calls)
+			fmt.Fprintf(&out, "  %2d. %s calls=%d total=%s avg=%s avg_arity=%.2f max_arity=%d\n", i+1, stat.binding, stat.calls, stat.total.Round(time.Microsecond), formatProfileDuration(avg), avgArity, stat.maxArity)
+		}
+	}
+	return strings.TrimRight(out.String(), "\n")
+}

--- a/compiler/bytecode/vm/profile_test.go
+++ b/compiler/bytecode/vm/profile_test.go
@@ -1,0 +1,37 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExecutionProfileReportIncludesSummaryAndBindings(t *testing.T) {
+	profile := &executionProfile{
+		started:         time.Now().Add(-25 * time.Millisecond),
+		externByBinding: make(map[string]*bindingProfile),
+	}
+
+	profile.RecordDirectCall()
+	profile.RecordModuleCall()
+	profile.RecordClosureCreation(2)
+	profile.RecordClosureCall(1)
+	profile.RecordExternCall("DecodeInt", 1, 3*time.Millisecond)
+	profile.RecordExternCall("JsonToDynamic", 1, 8*time.Millisecond)
+	profile.RecordExternCall("DecodeInt", 1, 2*time.Millisecond)
+
+	report := profile.Report()
+	checks := []string{
+		"[ard vm profile]",
+		"calls direct=1 module=1 closure=1 extern=3",
+		"closures created=1",
+		"extern total=13ms",
+		"JsonToDynamic calls=1 total=8ms",
+		"DecodeInt calls=2 total=5ms",
+	}
+	for _, check := range checks {
+		if !strings.Contains(report, check) {
+			t.Fatalf("expected report to contain %q, got:\n%s", check, report)
+		}
+	}
+}

--- a/compiler/bytecode/vm/vm.go
+++ b/compiler/bytecode/vm/vm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/akonwi/ard/bytecode"
 	"github.com/akonwi/ard/checker"
@@ -76,10 +77,10 @@ func (c *Closure) eval(args ...*runtime.Object) (*runtime.Object, error) {
 }
 
 type VM struct {
-	Program     bytecode.Program
-	Frames      []*Frame
-	freeFrames  []*Frame
-	typeCache   map[bytecode.TypeID]checker.Type
+	Program           bytecode.Program
+	Frames            []*Frame
+	freeFrames        []*Frame
+	typeCache         map[bytecode.TypeID]checker.Type
 	modules           *ModuleRegistry
 	methodIndex       map[string]map[string]int
 	functionLookup    map[string]int
@@ -87,11 +88,19 @@ type VM struct {
 	moduleArgsScratch []*runtime.Object
 	externArgsScratch []*runtime.Object
 	ffi               *RuntimeFFIRegistry
+	profile           *executionProfile
 }
 
 func New(program bytecode.Program) *VM {
-	vm := &VM{Program: program, Frames: make([]*Frame, 0, 8), freeFrames: make([]*Frame, 0, 8), modules: defaultModuleRegistry(), ffi: defaultFFIRegistry()}
+	vm := &VM{Program: program, Frames: make([]*Frame, 0, 8), freeFrames: make([]*Frame, 0, 8), modules: defaultModuleRegistry(), ffi: defaultFFIRegistry(), profile: newExecutionProfile()}
 	return vm
+}
+
+func (vm *VM) ProfileReport() string {
+	if vm == nil || vm.profile == nil {
+		return ""
+	}
+	return vm.profile.Report()
 }
 
 func (vm *VM) Run(functionName string) (*runtime.Object, error) {
@@ -284,6 +293,7 @@ func (vm *VM) run() (*runtime.Object, error) {
 			}
 			vm.push(vm.Frames[len(vm.Frames)-1], val)
 		case bytecode.OpCall:
+			vm.profile.RecordDirectCall()
 			fnDef := &vm.Program.Functions[inst.A]
 			argc := inst.B
 			retType, _ := vm.typeFor(bytecode.TypeID(inst.C))
@@ -293,6 +303,7 @@ func (vm *VM) run() (*runtime.Object, error) {
 			}
 			vm.Frames = append(vm.Frames, frame)
 		case bytecode.OpMakeClosure:
+			vm.profile.RecordClosureCreation(inst.B)
 			fnIndex := inst.A
 			if fnIndex < 0 || fnIndex >= len(vm.Program.Functions) {
 				return nil, fmt.Errorf("function index out of range")
@@ -321,6 +332,7 @@ func (vm *VM) run() (*runtime.Object, error) {
 			vm.push(curr, runtime.Make(closure, fnType))
 		case bytecode.OpCallClosure:
 			argc := inst.B
+			vm.profile.RecordClosureCall(argc)
 			args := make([]*runtime.Object, argc)
 			for i := argc - 1; i >= 0; i-- {
 				args[i] = vm.popUnsafe(curr)
@@ -771,6 +783,7 @@ func (vm *VM) run() (*runtime.Object, error) {
 			frame.Locals[0] = vm.popUnsafe(curr)
 			vm.Frames = append(vm.Frames, frame)
 		case bytecode.OpCallModule:
+			vm.profile.RecordModuleCall()
 			modConst, err := vm.constAt(inst.A)
 			if err != nil {
 				return nil, err
@@ -815,7 +828,14 @@ func (vm *VM) run() (*runtime.Object, error) {
 			if err != nil {
 				return nil, err
 			}
+			start := time.Time{}
+			if vm.profile != nil {
+				start = time.Now()
+			}
 			res, err := vm.ffi.Call(bindingConst.Str, args, retType)
+			if vm.profile != nil {
+				vm.profile.RecordExternCall(bindingConst.Str, argc, time.Since(start))
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/compiler/bytecode/vm/vm.go
+++ b/compiler/bytecode/vm/vm.go
@@ -88,11 +88,14 @@ type VM struct {
 	moduleArgsScratch []*runtime.Object
 	externArgsScratch []*runtime.Object
 	ffi               *RuntimeFFIRegistry
+	resolvedExterns   []resolvedExtern
+	initErr           error
 	profile           *executionProfile
 }
 
 func New(program bytecode.Program) *VM {
 	vm := &VM{Program: program, Frames: make([]*Frame, 0, 8), freeFrames: make([]*Frame, 0, 8), modules: defaultModuleRegistry(), ffi: defaultFFIRegistry(), profile: newExecutionProfile()}
+	vm.resolveExterns()
 	return vm
 }
 
@@ -103,7 +106,31 @@ func (vm *VM) ProfileReport() string {
 	return vm.profile.Report()
 }
 
+func (vm *VM) resolveExterns() {
+	if vm.initErr != nil {
+		return
+	}
+	if len(vm.Program.Externs) == 0 {
+		vm.resolvedExterns = nil
+		return
+	}
+	vm.resolvedExterns = make([]resolvedExtern, len(vm.Program.Externs))
+	for i := range vm.Program.Externs {
+		entry := vm.Program.Externs[i]
+		resolved, err := vm.ffi.Resolve(entry.Binding)
+		if err != nil {
+			vm.initErr = err
+			vm.resolvedExterns = nil
+			return
+		}
+		vm.resolvedExterns[i] = resolved
+	}
+}
+
 func (vm *VM) Run(functionName string) (*runtime.Object, error) {
+	if vm.initErr != nil {
+		return nil, vm.initErr
+	}
 	fn, ok := vm.lookupFunction(functionName)
 	if !ok {
 		return nil, fmt.Errorf("function not found: %s", functionName)
@@ -812,10 +839,10 @@ func (vm *VM) run() (*runtime.Object, error) {
 			}
 			vm.push(curr, res)
 		case bytecode.OpCallExtern:
-			bindingConst, err := vm.constAt(inst.A)
-			if err != nil {
-				return nil, err
+			if inst.A < 0 || inst.A >= len(vm.resolvedExterns) {
+				return nil, fmt.Errorf("extern target out of range")
 			}
+			resolved := vm.resolvedExterns[inst.A]
 			argc := inst.Imm
 			if cap(vm.externArgsScratch) < argc {
 				vm.externArgsScratch = make([]*runtime.Object, argc)
@@ -832,9 +859,9 @@ func (vm *VM) run() (*runtime.Object, error) {
 			if vm.profile != nil {
 				start = time.Now()
 			}
-			res, err := vm.ffi.Call(bindingConst.Str, args, retType)
+			res, err := callFFI(resolved.Binding, resolved.Func, args, retType)
 			if vm.profile != nil {
-				vm.profile.RecordExternCall(bindingConst.Str, argc, time.Since(start))
+				vm.profile.RecordExternCall(resolved.Binding, argc, time.Since(start))
 			}
 			if err != nil {
 				return nil, err
@@ -880,6 +907,9 @@ func (vm *VM) spawn() *VM {
 	child.modules = vm.modules
 	child.methodIndex = vm.methodIndex
 	child.functionLookup = vm.functionLookup
+	child.ffi = vm.ffi
+	child.resolvedExterns = vm.resolvedExterns
+	child.initErr = vm.initErr
 	return child
 }
 

--- a/compiler/main.go
+++ b/compiler/main.go
@@ -79,10 +79,7 @@ func main() {
 					fmt.Println(err)
 					os.Exit(1)
 				}
-				runtime.SetOSArgs(os.Args)
-				_, runErr := bytecodevm.New(program).Run("main")
-				runtime.SetOSArgs(nil)
-				if runErr != nil {
+				if runErr := runBytecodeProgram(program, os.Args); runErr != nil {
 					fmt.Println(runErr)
 					os.Exit(1)
 				}
@@ -699,14 +696,37 @@ func maybeRunEmbedded() bool {
 		fmt.Fprintln(os.Stderr, "Invalid bytecode:", err)
 		os.Exit(1)
 	}
-	runtime.SetOSArgs(argsForEmbeddedProgram(os.Args))
-	_, runErr := bytecodevm.New(program).Run("main")
-	runtime.SetOSArgs(nil)
-	if runErr != nil {
+	if runErr := runBytecodeProgram(program, argsForEmbeddedProgram(os.Args)); runErr != nil {
 		fmt.Fprintln(os.Stderr, runErr)
 		os.Exit(1)
 	}
 	return true
+}
+
+func runBytecodeProgram(program bytecode.Program, args []string) error {
+	profiling := bytecodevm.ProfilingEnabled()
+	if profiling {
+		runtime.EnableObjectProfiling(true)
+		runtime.ResetObjectProfile()
+	} else {
+		runtime.EnableObjectProfiling(false)
+	}
+	defer runtime.EnableObjectProfiling(false)
+
+	runtime.SetOSArgs(args)
+	defer runtime.SetOSArgs(nil)
+
+	vm := bytecodevm.New(program)
+	_, runErr := vm.Run("main")
+	if profiling {
+		if report := vm.ProfileReport(); report != "" {
+			fmt.Fprintln(os.Stderr, report)
+		}
+		if report := runtime.ObjectProfileReport(); report != "" {
+			fmt.Fprintln(os.Stderr, report)
+		}
+	}
+	return runErr
 }
 
 func writeEmbeddedBinary(srcPath string, dstPath string, data []byte) error {

--- a/compiler/runtime/object.go
+++ b/compiler/runtime/object.go
@@ -195,6 +195,8 @@ func deepCopy(data any) any {
 
 // deep copies an object
 func (o *Object) Copy() *Object {
+	recordObjectConstructor(&objectProfile.copyCalls)
+	recordObjectAllocation()
 	copy := &Object{
 		raw:    o.raw,
 		_type:  o._type,
@@ -401,6 +403,8 @@ func (o *Object) EnumType() *checker.Enum {
 }
 
 func MakeStr(s string) *Object {
+	recordObjectConstructor(&objectProfile.makeStrCalls)
+	recordObjectAllocation()
 	return &Object{
 		_type: checker.Str,
 		kind:  KindStr,
@@ -410,9 +414,14 @@ func MakeStr(s string) *Object {
 }
 
 func MakeInt(i int) *Object {
+	profiling := recordObjectConstructor(&objectProfile.makeIntCalls)
 	if i >= smallIntCacheMin && i <= smallIntCacheMax {
+		if profiling {
+			objectProfile.intCacheHits.Add(1)
+		}
 		return smallInts[i-smallIntCacheMin]
 	}
+	recordObjectAllocation()
 	return &Object{
 		_type: checker.Int,
 		kind:  KindInt,
@@ -422,6 +431,8 @@ func MakeInt(i int) *Object {
 }
 
 func MakeFloat(f float64) *Object {
+	recordObjectConstructor(&objectProfile.makeFloatCalls)
+	recordObjectAllocation()
 	return &Object{
 		_type: checker.Float,
 		kind:  KindFloat,
@@ -431,6 +442,10 @@ func MakeFloat(f float64) *Object {
 }
 
 func MakeBool(b bool) *Object {
+	profiling := recordObjectConstructor(&objectProfile.makeBoolCalls)
+	if profiling {
+		objectProfile.boolCacheHits.Add(1)
+	}
 	if b {
 		return trueObj
 	}
@@ -438,6 +453,8 @@ func MakeBool(b bool) *Object {
 }
 
 func MakeNone(of checker.Type) *Object {
+	recordObjectConstructor(&objectProfile.makeNoneCalls)
+	recordObjectAllocation()
 	maybeType := maybeTypeFor(of)
 	return &Object{
 		_type:  maybeType,
@@ -491,6 +508,8 @@ func (o *Object) IsNone() bool {
 }
 
 func MakeList(of checker.Type, items ...*Object) *Object {
+	recordObjectConstructor(&objectProfile.makeListCalls)
+	recordObjectAllocation()
 	listType := checker.MakeList(of)
 	return &Object{
 		_type: listType,
@@ -506,6 +525,8 @@ func (o *Object) List_Push(item *Object) {
 }
 
 func MakeMap(keyType, valueType checker.Type) *Object {
+	recordObjectConstructor(&objectProfile.makeMapCalls)
+	recordObjectAllocation()
 	mapType := checker.MakeMap(keyType, valueType)
 	return &Object{
 		_type: mapType,
@@ -655,6 +676,8 @@ func (o *Object) UnwrapMaybeInPlace(of checker.Type) *Object {
 }
 
 func MakeStruct(of checker.Type, fields map[string]*Object) *Object {
+	recordObjectConstructor(&objectProfile.makeStructCalls)
+	recordObjectAllocation()
 	return &Object{
 		raw:   fields,
 		_type: of,
@@ -681,6 +704,8 @@ func (o *Object) Struct_Get(key string) *Object {
 }
 
 func MakeDynamic(val any) *Object {
+	recordObjectConstructor(&objectProfile.makeDynamicCalls)
+	recordObjectAllocation()
 	return &Object{
 		raw:   val,
 		_type: checker.Dynamic,
@@ -690,6 +715,7 @@ func MakeDynamic(val any) *Object {
 }
 
 func Make(val any, of checker.Type) *Object {
+	profiling := recordObjectConstructor(&objectProfile.makeGenericCalls)
 	if val != nil {
 		if of == checker.Int {
 			if i, ok := val.(int); ok {
@@ -715,6 +741,10 @@ func Make(val any, of checker.Type) *Object {
 			return MakeDynamic(val)
 		}
 	}
+	if profiling {
+		objectProfile.genericAllocations.Add(1)
+	}
+	recordObjectAllocation()
 	return &Object{
 		raw:   val,
 		_type: of,
@@ -752,6 +782,10 @@ var (
 )
 
 func Void() *Object {
+	profiling := recordObjectConstructor(&objectProfile.voidCalls)
+	if profiling {
+		objectProfile.voidCacheHits.Add(1)
+	}
 	return void
 }
 

--- a/compiler/runtime/object_profile.go
+++ b/compiler/runtime/object_profile.go
@@ -1,0 +1,137 @@
+package runtime
+
+import (
+	"fmt"
+	"strings"
+	"sync/atomic"
+)
+
+type objectProfileCounters struct {
+	enabled               atomic.Bool
+	totalConstructorCalls atomic.Uint64
+	totalAllocations      atomic.Uint64
+	makeStrCalls          atomic.Uint64
+	makeIntCalls          atomic.Uint64
+	intCacheHits          atomic.Uint64
+	makeFloatCalls        atomic.Uint64
+	makeBoolCalls         atomic.Uint64
+	boolCacheHits         atomic.Uint64
+	makeNoneCalls         atomic.Uint64
+	makeListCalls         atomic.Uint64
+	makeMapCalls          atomic.Uint64
+	makeStructCalls       atomic.Uint64
+	makeDynamicCalls      atomic.Uint64
+	makeGenericCalls      atomic.Uint64
+	genericAllocations    atomic.Uint64
+	copyCalls             atomic.Uint64
+	voidCalls             atomic.Uint64
+	voidCacheHits         atomic.Uint64
+}
+
+var objectProfile objectProfileCounters
+
+type ObjectProfileSnapshot struct {
+	Enabled               bool
+	TotalConstructorCalls uint64
+	TotalAllocations      uint64
+	MakeStrCalls          uint64
+	MakeIntCalls          uint64
+	IntCacheHits          uint64
+	MakeFloatCalls        uint64
+	MakeBoolCalls         uint64
+	BoolCacheHits         uint64
+	MakeNoneCalls         uint64
+	MakeListCalls         uint64
+	MakeMapCalls          uint64
+	MakeStructCalls       uint64
+	MakeDynamicCalls      uint64
+	MakeGenericCalls      uint64
+	GenericAllocations    uint64
+	CopyCalls             uint64
+	VoidCalls             uint64
+	VoidCacheHits         uint64
+}
+
+func EnableObjectProfiling(enabled bool) {
+	objectProfile.enabled.Store(enabled)
+}
+
+func ObjectProfilingEnabled() bool {
+	return objectProfile.enabled.Load()
+}
+
+func ResetObjectProfile() {
+	objectProfile.totalConstructorCalls.Store(0)
+	objectProfile.totalAllocations.Store(0)
+	objectProfile.makeStrCalls.Store(0)
+	objectProfile.makeIntCalls.Store(0)
+	objectProfile.intCacheHits.Store(0)
+	objectProfile.makeFloatCalls.Store(0)
+	objectProfile.makeBoolCalls.Store(0)
+	objectProfile.boolCacheHits.Store(0)
+	objectProfile.makeNoneCalls.Store(0)
+	objectProfile.makeListCalls.Store(0)
+	objectProfile.makeMapCalls.Store(0)
+	objectProfile.makeStructCalls.Store(0)
+	objectProfile.makeDynamicCalls.Store(0)
+	objectProfile.makeGenericCalls.Store(0)
+	objectProfile.genericAllocations.Store(0)
+	objectProfile.copyCalls.Store(0)
+	objectProfile.voidCalls.Store(0)
+	objectProfile.voidCacheHits.Store(0)
+}
+
+func SnapshotObjectProfile() ObjectProfileSnapshot {
+	return ObjectProfileSnapshot{
+		Enabled:               ObjectProfilingEnabled(),
+		TotalConstructorCalls: objectProfile.totalConstructorCalls.Load(),
+		TotalAllocations:      objectProfile.totalAllocations.Load(),
+		MakeStrCalls:          objectProfile.makeStrCalls.Load(),
+		MakeIntCalls:          objectProfile.makeIntCalls.Load(),
+		IntCacheHits:          objectProfile.intCacheHits.Load(),
+		MakeFloatCalls:        objectProfile.makeFloatCalls.Load(),
+		MakeBoolCalls:         objectProfile.makeBoolCalls.Load(),
+		BoolCacheHits:         objectProfile.boolCacheHits.Load(),
+		MakeNoneCalls:         objectProfile.makeNoneCalls.Load(),
+		MakeListCalls:         objectProfile.makeListCalls.Load(),
+		MakeMapCalls:          objectProfile.makeMapCalls.Load(),
+		MakeStructCalls:       objectProfile.makeStructCalls.Load(),
+		MakeDynamicCalls:      objectProfile.makeDynamicCalls.Load(),
+		MakeGenericCalls:      objectProfile.makeGenericCalls.Load(),
+		GenericAllocations:    objectProfile.genericAllocations.Load(),
+		CopyCalls:             objectProfile.copyCalls.Load(),
+		VoidCalls:             objectProfile.voidCalls.Load(),
+		VoidCacheHits:         objectProfile.voidCacheHits.Load(),
+	}
+}
+
+func ObjectProfileReport() string {
+	snapshot := SnapshotObjectProfile()
+	if !snapshot.Enabled {
+		return ""
+	}
+	var out strings.Builder
+	fmt.Fprintf(&out, "[ard runtime object profile]\n")
+	fmt.Fprintf(&out, "constructor_calls=%d fresh_allocations=%d\n", snapshot.TotalConstructorCalls, snapshot.TotalAllocations)
+	fmt.Fprintf(&out, "make_str=%d make_int=%d int_cache_hits=%d make_float=%d\n", snapshot.MakeStrCalls, snapshot.MakeIntCalls, snapshot.IntCacheHits, snapshot.MakeFloatCalls)
+	fmt.Fprintf(&out, "make_bool=%d bool_cache_hits=%d make_none=%d void_calls=%d void_cache_hits=%d\n", snapshot.MakeBoolCalls, snapshot.BoolCacheHits, snapshot.MakeNoneCalls, snapshot.VoidCalls, snapshot.VoidCacheHits)
+	fmt.Fprintf(&out, "make_dynamic=%d make_list=%d make_map=%d make_struct=%d\n", snapshot.MakeDynamicCalls, snapshot.MakeListCalls, snapshot.MakeMapCalls, snapshot.MakeStructCalls)
+	fmt.Fprintf(&out, "make_generic=%d generic_allocations=%d copy_calls=%d\n", snapshot.MakeGenericCalls, snapshot.GenericAllocations, snapshot.CopyCalls)
+	return strings.TrimRight(out.String(), "\n")
+}
+
+func recordObjectConstructor(counter *atomic.Uint64) bool {
+	if !objectProfile.enabled.Load() {
+		return false
+	}
+	objectProfile.totalConstructorCalls.Add(1)
+	counter.Add(1)
+	return true
+}
+
+func recordObjectAllocation() {
+	if !objectProfile.enabled.Load() {
+		return
+	}
+	objectProfile.totalAllocations.Add(1)
+}

--- a/compiler/runtime/object_profile_test.go
+++ b/compiler/runtime/object_profile_test.go
@@ -1,0 +1,50 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/akonwi/ard/checker"
+)
+
+func TestObjectProfileTracksConstructorsAndAllocations(t *testing.T) {
+	EnableObjectProfiling(true)
+	ResetObjectProfile()
+	defer EnableObjectProfiling(false)
+
+	_ = MakeStr("hello")
+	_ = MakeInt(7)
+	_ = MakeInt(300)
+	_ = MakeBool(true)
+	_ = MakeDynamic("raw")
+	_ = MakeList(checker.Dynamic)
+	_ = Void()
+
+	snapshot := SnapshotObjectProfile()
+	if !snapshot.Enabled {
+		t.Fatal("expected profiling to be enabled")
+	}
+	if snapshot.MakeStrCalls != 1 {
+		t.Fatalf("expected 1 string constructor call, got %d", snapshot.MakeStrCalls)
+	}
+	if snapshot.MakeIntCalls != 2 {
+		t.Fatalf("expected 2 int constructor calls, got %d", snapshot.MakeIntCalls)
+	}
+	if snapshot.IntCacheHits != 1 {
+		t.Fatalf("expected 1 int cache hit, got %d", snapshot.IntCacheHits)
+	}
+	if snapshot.MakeBoolCalls != 1 || snapshot.BoolCacheHits != 1 {
+		t.Fatalf("expected bool call/cache hit to be 1/1, got %d/%d", snapshot.MakeBoolCalls, snapshot.BoolCacheHits)
+	}
+	if snapshot.MakeDynamicCalls != 1 {
+		t.Fatalf("expected 1 dynamic constructor call, got %d", snapshot.MakeDynamicCalls)
+	}
+	if snapshot.MakeListCalls != 1 {
+		t.Fatalf("expected 1 list constructor call, got %d", snapshot.MakeListCalls)
+	}
+	if snapshot.VoidCalls != 1 || snapshot.VoidCacheHits != 1 {
+		t.Fatalf("expected void call/cache hit to be 1/1, got %d/%d", snapshot.VoidCalls, snapshot.VoidCacheHits)
+	}
+	if snapshot.TotalAllocations != 4 {
+		t.Fatalf("expected 4 fresh allocations, got %d", snapshot.TotalAllocations)
+	}
+}


### PR DESCRIPTION
## Summary
- add opt-in VM profiling for extern calls, closure calls, and `runtime.Object` construction/allocation hot paths
- pre-resolve bytecode extern bindings at VM construction time to remove repeated binding lookup from steady-state execution
- document the profiling findings, extern dispatch work, and the longer-term value-native VM/runtime direction

## Details
### Profiling
- adds `ARD_VM_PROFILE=1` support for bytecode runs
- reports call counts, per-binding extern timing, and object constructor/allocation counts to stderr
- works for both `ard run` and embedded bytecode binaries produced by `ard build`

### Extern dispatch
- bytecode programs now carry a deduplicated extern table
- `OpCallExtern` now references extern IDs instead of string constant indexes
- VM resolves extern bindings once up front and calls the resolved function pointer directly

### Docs
- captures the profiling results and follow-up perf plan in `backlog/bytecode-roadmap/performance.md`
- adds `backlog/bytecode-roadmap/value-native-vm.md` to sketch a value-native VM that treats `runtime.Object` as an unsafe/legacy escape hatch during migration

## Validation
- `cd compiler && go test ./...`
- `cd compiler && ./benchmarks/run.sh --runs 10 --warmup 2 decode_pipeline`
- profiled `decode_pipeline` before/after extern pre-resolution via `ARD_VM_PROFILE=1`

## Notable results
- `decode_pipeline` extern timed section improved from about `58.755ms` to `50.188ms`
- end-to-end VM runtime improvement was modest, which the profiling attributes to remaining `runtime.Object` churn, eager Dynamic list/map materialization, and heavy closure traffic
