### PR TITLE
fix(vm_next/bytecode): make verifier control-flow aware

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,4 @@
 # TODO
-- [ ] make `vm_next/bytecode.Verify` control-flow aware
-  * verify per-basic-block stack heights instead of only a linear stack counter
-  * check branch target stack compatibility and return/termination behavior
-  * this matters before treating serialized vm_next bytecode as a hard safety boundary
 - [ ] allow FFI in user land
 - [ ] make duplicate FFI binding registration return an error
 - [ ] Dependency system

--- a/compiler/vm_next/bytecode/verify.go
+++ b/compiler/vm_next/bytecode/verify.go
@@ -2,6 +2,8 @@ package bytecode
 
 import "fmt"
 
+const unseenStackHeight = -1
+
 func Verify(program *Program) error {
 	if program == nil {
 		return fmt.Errorf("bytecode program is nil")
@@ -18,123 +20,277 @@ func verifyFunction(program *Program, fn *Function) error {
 	if fn == nil {
 		return fmt.Errorf("function is nil")
 	}
-	stack := 0
 	for ip, inst := range fn.Code {
-		pop, push, err := stackEffect(inst)
+		if err := validateInstruction(program, fn, ip, inst); err != nil {
+			return err
+		}
+	}
+	if len(fn.Code) == 0 {
+		return fmt.Errorf("%s: function has no code", fn.Name)
+	}
+	return verifyControlFlow(fn)
+}
+
+func validateInstruction(program *Program, fn *Function, ip int, inst Instruction) error {
+	localIndexError := func(message string) error {
+		return fmt.Errorf("%s ip=%d: %s", fn.Name, ip, message)
+	}
+	validateLocal := func(index int, message string) error {
+		if index < 0 || index >= fn.Locals {
+			return localIndexError(message)
+		}
+		return nil
+	}
+	validateCodeTarget := func(target int, message string) error {
+		if target < 0 || target >= len(fn.Code) {
+			return localIndexError(message)
+		}
+		return nil
+	}
+
+	switch inst.Op {
+	case OpConstFloat, OpConstStr:
+		if inst.B < 0 || inst.B >= len(program.Constants) {
+			return localIndexError("constant index out of range")
+		}
+	case OpLoadLocal, OpStoreLocal:
+		if err := validateLocal(inst.A, "local index out of range"); err != nil {
+			return err
+		}
+	case OpIntAddConstLocal:
+		if err := validateLocal(inst.B, "int local index out of range"); err != nil {
+			return err
+		}
+	case OpCallClosureLocal:
+		if err := validateLocal(inst.B, "closure local index out of range"); err != nil {
+			return err
+		}
+	case OpResultExpectLocal, OpResultErrValueLocal, OpResultIsOkLocal:
+		if err := validateLocal(inst.B, "result local index out of range"); err != nil {
+			return err
+		}
+	case OpUnionTagLocal, OpUnionValueLocal:
+		if err := validateLocal(inst.B, "union local index out of range"); err != nil {
+			return err
+		}
+	case OpGetFieldLocal:
+		if err := validateLocal(inst.B, "local index out of range"); err != nil {
+			return err
+		}
+	case OpListSizeLocal:
+		if err := validateLocal(inst.B, "list local index out of range"); err != nil {
+			return err
+		}
+	case OpListAtLocal, OpListAtModLocal, OpListIndexLtLocal:
+		if err := validateLocal(inst.B, "list/index local out of range"); err != nil {
+			return err
+		}
+		if err := validateLocal(inst.C, "list/index local out of range"); err != nil {
+			return err
+		}
+	case OpListPushLocal, OpListPushLocalDrop:
+		if err := validateLocal(inst.B, "list local index out of range"); err != nil {
+			return err
+		}
+	case OpMapSizeLocal:
+		if err := validateLocal(inst.B, "map local index out of range"); err != nil {
+			return err
+		}
+	case OpMapIndexLtLocal, OpMapKeyAtLocal, OpMapValueAtLocal, OpMapGetLocal, OpMapGetLocalTryMaybe, OpMapGetOrConstIntLocal, OpMapSetLocal, OpMapSetLocalDrop, OpMapIncrementIntLocal, OpMapIncrementIntLocalDrop:
+		if err := validateLocal(inst.B, "map/index local out of range"); err != nil {
+			return err
+		}
+		if err := validateLocal(inst.C, "map/index local out of range"); err != nil {
+			return err
+		}
+		if inst.Op == OpMapGetLocalTryMaybe {
+			if err := validateOptionalCodeTarget(inst.Imm, len(fn.Code), localIndexError, "try maybe jump target out of range"); err != nil {
+				return err
+			}
+		}
+	case OpMapGetOrConstIntLocalKey, OpMapSetLocalStackKeyDrop:
+		if err := validateLocal(inst.B, "map local index out of range"); err != nil {
+			return err
+		}
+	case OpJump, OpJumpIfFalse:
+		if err := validateCodeTarget(inst.A, "jump target out of range"); err != nil {
+			return err
+		}
+	case OpStoreIntAddConstLocalJump:
+		if err := validateCodeTarget(inst.A, "jump target out of range"); err != nil {
+			return err
+		}
+		if err := validateLocal(inst.B, "int local index out of range"); err != nil {
+			return err
+		}
+		if err := validateLocal(inst.C, "int local index out of range"); err != nil {
+			return err
+		}
+	case OpJumpIfListIndexGeLocal, OpJumpIfMapIndexGeLocal:
+		if err := validateCodeTarget(inst.A, "jump target out of range"); err != nil {
+			return err
+		}
+		if err := validateLocal(inst.B, "jump index/collection local out of range"); err != nil {
+			return err
+		}
+		if err := validateLocal(inst.C, "jump index/collection local out of range"); err != nil {
+			return err
+		}
+	case OpJumpIfIntGtLocal:
+		if err := validateCodeTarget(inst.A, "jump target out of range"); err != nil {
+			return err
+		}
+		if err := validateLocal(inst.B, "int local index out of range"); err != nil {
+			return err
+		}
+		if err := validateLocal(inst.C, "int local index out of range"); err != nil {
+			return err
+		}
+	case OpJumpIfIntModConstNotEqConstLocal:
+		if err := validateCodeTarget(inst.A, "jump target out of range"); err != nil {
+			return err
+		}
+		if err := validateLocal(inst.B, "int local index out of range"); err != nil {
+			return err
+		}
+	case OpTryResult, OpTryMaybe:
+		if err := validateOptionalCodeTarget(inst.B, len(fn.Code), localIndexError, "try jump target out of range"); err != nil {
+			return err
+		}
+		if inst.C >= 0 {
+			if err := validateLocal(inst.C, "try catch local index out of range"); err != nil {
+				return err
+			}
+		}
+	case OpCall:
+		if inst.A < 0 || inst.A >= len(program.Functions) {
+			return localIndexError("call target out of range")
+		}
+		if program.Functions[inst.A].Arity != inst.B {
+			return fmt.Errorf("%s ip=%d: arity mismatch for %s", fn.Name, ip, program.Functions[inst.A].Name)
+		}
+	case OpCallExtern:
+		if inst.A < 0 || inst.A >= len(program.Externs) {
+			return localIndexError("extern target out of range")
+		}
+	case OpGetField, OpSetField:
+		if inst.B < 0 {
+			return localIndexError("invalid field index")
+		}
+	}
+	if _, _, err := stackEffect(inst); err != nil {
+		return fmt.Errorf("%s ip=%d: %w", fn.Name, ip, err)
+	}
+	return nil
+}
+
+func validateOptionalCodeTarget(target int, codeLen int, errf func(string) error, message string) error {
+	if target >= 0 && target >= codeLen {
+		return errf(message)
+	}
+	return nil
+}
+
+type verifyState struct {
+	ip    int
+	stack int
+}
+
+type verifyEdge struct {
+	next  int
+	stack int
+}
+
+func verifyControlFlow(fn *Function) error {
+	entryStackHeights := make([]int, len(fn.Code))
+	for i := range entryStackHeights {
+		entryStackHeights[i] = unseenStackHeight
+	}
+	worklist := []verifyState{{ip: 0, stack: 0}}
+	for len(worklist) > 0 {
+		state := worklist[len(worklist)-1]
+		worklist = worklist[:len(worklist)-1]
+		seenStack := entryStackHeights[state.ip]
+		if seenStack != unseenStackHeight {
+			if seenStack != state.stack {
+				return fmt.Errorf("%s ip=%d: stack height mismatch, got %d and %d", fn.Name, state.ip, seenStack, state.stack)
+			}
+			continue
+		}
+		entryStackHeights[state.ip] = state.stack
+		successors, err := verifyInstructionFlow(fn, state.ip, state.stack)
 		if err != nil {
-			return fmt.Errorf("%s ip=%d: %w", fn.Name, ip, err)
+			return err
 		}
-		if stack < pop {
-			return fmt.Errorf("%s ip=%d (%s): stack underflow", fn.Name, ip, inst.Op)
-		}
-		stack -= pop
-		stack += push
-		switch inst.Op {
-		case OpConstFloat, OpConstStr:
-			if inst.B < 0 || inst.B >= len(program.Constants) {
-				return fmt.Errorf("%s ip=%d: constant index out of range", fn.Name, ip)
+		for _, successor := range successors {
+			if successor.next < 0 || successor.next >= len(fn.Code) {
+				return fmt.Errorf("%s ip=%d: reachable path can fall off end without terminating", fn.Name, state.ip)
 			}
-		case OpLoadLocal, OpStoreLocal:
-			if inst.A < 0 || inst.A >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: local index out of range", fn.Name, ip)
-			}
-		case OpIntAddConstLocal:
-			if inst.B < 0 || inst.B >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: int local index out of range", fn.Name, ip)
-			}
-		case OpCallClosureLocal:
-			if inst.B < 0 || inst.B >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: closure local index out of range", fn.Name, ip)
-			}
-		case OpResultExpectLocal, OpResultErrValueLocal, OpResultIsOkLocal:
-			if inst.B < 0 || inst.B >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: result local index out of range", fn.Name, ip)
-			}
-		case OpUnionTagLocal, OpUnionValueLocal:
-			if inst.B < 0 || inst.B >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: union local index out of range", fn.Name, ip)
-			}
-		case OpGetFieldLocal:
-			if inst.B < 0 || inst.B >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: local index out of range", fn.Name, ip)
-			}
-		case OpListSizeLocal:
-			if inst.B < 0 || inst.B >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: list local index out of range", fn.Name, ip)
-			}
-		case OpListAtLocal, OpListAtModLocal, OpListIndexLtLocal:
-			if inst.B < 0 || inst.B >= fn.Locals || inst.C < 0 || inst.C >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: list/index local out of range", fn.Name, ip)
-			}
-		case OpListPushLocal, OpListPushLocalDrop:
-			if inst.B < 0 || inst.B >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: list local index out of range", fn.Name, ip)
-			}
-		case OpMapSizeLocal:
-			if inst.B < 0 || inst.B >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: map local index out of range", fn.Name, ip)
-			}
-		case OpMapIndexLtLocal, OpMapKeyAtLocal, OpMapValueAtLocal, OpMapGetLocal, OpMapGetLocalTryMaybe, OpMapGetOrConstIntLocal, OpMapSetLocal, OpMapSetLocalDrop, OpMapIncrementIntLocal, OpMapIncrementIntLocalDrop:
-			if inst.B < 0 || inst.B >= fn.Locals || inst.C < 0 || inst.C >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: map/index local out of range", fn.Name, ip)
-			}
-			if inst.Op == OpMapGetLocalTryMaybe && inst.Imm >= 0 && inst.Imm > len(fn.Code) {
-				return fmt.Errorf("%s ip=%d: try maybe jump target out of range", fn.Name, ip)
-			}
-		case OpMapGetOrConstIntLocalKey, OpMapSetLocalStackKeyDrop:
-			if inst.B < 0 || inst.B >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: map local index out of range", fn.Name, ip)
-			}
-		case OpJump, OpJumpIfFalse:
-			if inst.A < 0 || inst.A > len(fn.Code) {
-				return fmt.Errorf("%s ip=%d: jump target out of range", fn.Name, ip)
-			}
-		case OpStoreIntAddConstLocalJump:
-			if inst.A < 0 || inst.A > len(fn.Code) {
-				return fmt.Errorf("%s ip=%d: jump target out of range", fn.Name, ip)
-			}
-			if inst.B < 0 || inst.B >= fn.Locals || inst.C < 0 || inst.C >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: int local index out of range", fn.Name, ip)
-			}
-		case OpJumpIfListIndexGeLocal, OpJumpIfMapIndexGeLocal:
-			if inst.A < 0 || inst.A > len(fn.Code) {
-				return fmt.Errorf("%s ip=%d: jump target out of range", fn.Name, ip)
-			}
-			if inst.B < 0 || inst.B >= fn.Locals || inst.C < 0 || inst.C >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: jump index/collection local out of range", fn.Name, ip)
-			}
-		case OpJumpIfIntGtLocal:
-			if inst.A < 0 || inst.A > len(fn.Code) {
-				return fmt.Errorf("%s ip=%d: jump target out of range", fn.Name, ip)
-			}
-			if inst.B < 0 || inst.B >= fn.Locals || inst.C < 0 || inst.C >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: int local index out of range", fn.Name, ip)
-			}
-		case OpJumpIfIntModConstNotEqConstLocal:
-			if inst.A < 0 || inst.A > len(fn.Code) {
-				return fmt.Errorf("%s ip=%d: jump target out of range", fn.Name, ip)
-			}
-			if inst.B < 0 || inst.B >= fn.Locals {
-				return fmt.Errorf("%s ip=%d: int local index out of range", fn.Name, ip)
-			}
-		case OpCall:
-			if inst.A < 0 || inst.A >= len(program.Functions) {
-				return fmt.Errorf("%s ip=%d: call target out of range", fn.Name, ip)
-			}
-			if program.Functions[inst.A].Arity != inst.B {
-				return fmt.Errorf("%s ip=%d: arity mismatch for %s", fn.Name, ip, program.Functions[inst.A].Name)
-			}
-		case OpCallExtern:
-			if inst.A < 0 || inst.A >= len(program.Externs) {
-				return fmt.Errorf("%s ip=%d: extern target out of range", fn.Name, ip)
-			}
-		case OpGetField, OpSetField:
-			if inst.B < 0 {
-				return fmt.Errorf("%s ip=%d: invalid field index", fn.Name, ip)
-			}
+			worklist = append(worklist, verifyState{ip: successor.next, stack: successor.stack})
 		}
 	}
 	return nil
+}
+
+func verifyInstructionFlow(fn *Function, ip int, stack int) ([]verifyEdge, error) {
+	inst := fn.Code[ip]
+	nextIP := ip + 1
+	requireStack := func(pop int) error {
+		if stack < pop {
+			return fmt.Errorf("%s ip=%d (%s): stack underflow", fn.Name, ip, inst.Op)
+		}
+		return nil
+	}
+	advance := func(nextStack int) ([]verifyEdge, error) {
+		return []verifyEdge{{next: nextIP, stack: nextStack}}, nil
+	}
+	branch := func(target int, targetStack int) verifyEdge {
+		return verifyEdge{next: target, stack: targetStack}
+	}
+
+	switch inst.Op {
+	case OpJump:
+		return []verifyEdge{branch(inst.A, stack)}, nil
+	case OpJumpIfFalse:
+		if err := requireStack(1); err != nil {
+			return nil, err
+		}
+		nextStack := stack - 1
+		return []verifyEdge{branch(inst.A, nextStack), branch(nextIP, nextStack)}, nil
+	case OpJumpIfListIndexGeLocal, OpJumpIfMapIndexGeLocal, OpJumpIfIntGtLocal, OpJumpIfIntModConstNotEqConstLocal:
+		return []verifyEdge{branch(inst.A, stack), branch(nextIP, stack)}, nil
+	case OpStoreIntAddConstLocalJump:
+		return []verifyEdge{branch(inst.A, stack)}, nil
+	case OpTryResult, OpTryMaybe:
+		if err := requireStack(1); err != nil {
+			return nil, err
+		}
+		successors := []verifyEdge{branch(nextIP, stack)}
+		if inst.B >= 0 {
+			successors = append(successors, branch(inst.B, stack-1))
+		}
+		return successors, nil
+	case OpMapGetLocalTryMaybe:
+		successors := []verifyEdge{branch(nextIP, stack+1)}
+		if inst.Imm >= 0 {
+			successors = append(successors, branch(inst.Imm, stack))
+		}
+		return successors, nil
+	case OpReturn, OpPanic:
+		if err := requireStack(1); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	default:
+		pop, push, err := stackEffect(inst)
+		if err != nil {
+			return nil, fmt.Errorf("%s ip=%d: %w", fn.Name, ip, err)
+		}
+		if err := requireStack(pop); err != nil {
+			return nil, err
+		}
+		return advance(stack - pop + push)
+	}
 }
 
 func stackEffect(inst Instruction) (pop int, push int, err error) {
@@ -170,9 +326,8 @@ func stackEffect(inst Instruction) (pop int, push int, err error) {
 		OpStrConcat, OpEq, OpNotEq, OpLt, OpLte, OpGt, OpGte, OpAnd, OpOr:
 		return 2, 1, nil
 	case OpNot, OpNeg, OpToStr, OpCopy, OpGetField, OpTraitUpcast, OpUnionWrap, OpUnionTag, OpUnionValue,
-		OpListSize, OpMapKeys, OpMapSize, OpStrSize, OpStrIsEmpty, OpStrTrim,
-		OpMakeMaybeSome, OpMaybeExpect, OpMaybeIsNone, OpMaybeIsSome,
-		OpMakeResultOk, OpMakeResultErr, OpResultExpect, OpResultErrValue, OpResultIsOk, OpResultIsErr,
+		OpMakeMaybeSome,
+		OpMakeResultOk, OpMakeResultErr,
 		OpTryResult, OpTryMaybe, OpToDynamic, OpPanic, OpFiberGet, OpFiberJoin:
 		return 1, 1, nil
 	case OpGetFieldLocal:
@@ -199,16 +354,16 @@ func stackEffect(inst Instruction) (pop int, push int, err error) {
 		return inst.B, 1, nil
 	case OpMakeMap:
 		return inst.B * 2, 1, nil
-	case OpListAt, OpListPrepend, OpListPush, OpMapGet, OpMapDrop, OpMapHas, OpMapKeyAt, OpMapValueAt,
-		OpStrAt, OpStrContains, OpStrSplit, OpStrStartsWith, OpMaybeOr, OpMaybeMap,
-		OpMaybeAndThen, OpResultOr, OpResultMap, OpResultMapErr, OpResultAndThen:
-		return 2, 1, nil
+	case OpStrAt, OpStrSize, OpStrIsEmpty, OpStrContains, OpStrSplit, OpStrStartsWith, OpStrTrim,
+		OpMaybeExpect, OpMaybeIsNone, OpMaybeIsSome, OpMaybeOr, OpMaybeMap, OpMaybeAndThen,
+		OpResultExpect, OpResultErrValue, OpResultOr, OpResultIsOk, OpResultIsErr, OpResultMap, OpResultMapErr, OpResultAndThen,
+		OpListAt, OpListPrepend, OpListPush, OpListSize, OpListSort,
+		OpMapKeys, OpMapSize, OpMapGet, OpMapDrop, OpMapHas, OpMapKeyAt, OpMapValueAt:
+		return inst.B + 1, 1, nil
 	case OpSpawnFiber:
 		return inst.B, 1, nil
 	case OpListSet, OpListSwap, OpMapSet, OpStrReplace, OpStrReplaceAll:
 		return 3, 1, nil
-	case OpListSort:
-		return 2, 1, nil
 	case OpEnumVariant, OpMakeMaybeNone:
 		return 0, 1, nil
 	default:

--- a/compiler/vm_next/bytecode/verify_test.go
+++ b/compiler/vm_next/bytecode/verify_test.go
@@ -1,0 +1,317 @@
+package bytecode
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVerifyAcceptsStraightLineStackUsage(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name:   "main",
+		Locals: 0,
+		Code: []Instruction{
+			{Op: OpConstInt},
+			{Op: OpReturn},
+		},
+	})
+
+	if err := Verify(program); err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+}
+
+func TestVerifyAcceptsCompatibleStackHeightAtJoin(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name:   "main",
+		Locals: 0,
+		Code: []Instruction{
+			{Op: OpConstBool},         // stack: 1
+			{Op: OpJumpIfFalse, A: 4}, // stack: 0 on both edges
+			{Op: OpConstInt},          // true branch stack: 1
+			{Op: OpJump, A: 5},
+			{Op: OpConstInt}, // false branch stack: 1
+			{Op: OpReturn},
+		},
+	})
+
+	if err := Verify(program); err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+}
+
+func TestVerifyRejectsInconsistentStackHeightAtJoin(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name:   "main",
+		Locals: 0,
+		Code: []Instruction{
+			{Op: OpConstBool},         // stack: 1
+			{Op: OpJumpIfFalse, A: 4}, // stack: 0 on both edges
+			{Op: OpConstInt},          // true branch stack: 1
+			{Op: OpJump, A: 5},
+			{Op: OpNoop},   // false branch stack: 0
+			{Op: OpReturn}, // join reached with stack 1 or 0
+		},
+	})
+
+	err := Verify(program)
+	if err == nil {
+		t.Fatalf("Verify() error = nil, want stack mismatch")
+	}
+	if !strings.Contains(err.Error(), "stack") {
+		t.Fatalf("Verify() error = %q, want stack-related message", err)
+	}
+}
+
+func TestVerifyAcceptsLoopBackedgeWithStableStackHeight(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name:   "main",
+		Locals: 2,
+		Code: []Instruction{
+			{Op: OpJumpIfIntGtLocal, A: 3, B: 0, C: 1},
+			{Op: OpJump, A: 0},
+			{Op: OpNoop},
+			{Op: OpConstInt},
+			{Op: OpReturn},
+		},
+	})
+
+	if err := Verify(program); err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+}
+
+func TestVerifyAcceptsTryResultWithCatch(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name:   "main",
+		Locals: 1,
+		Code: []Instruction{
+			{Op: OpConstInt},
+			{Op: OpMakeResultErr},
+			{Op: OpTryResult, B: 4, C: 0},
+			{Op: OpReturn},
+			{Op: OpLoadLocal, A: 0},
+			{Op: OpReturn},
+		},
+	})
+
+	if err := Verify(program); err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+}
+
+func TestVerifyRejectsTryResultNoCatchWhenSuccessPathUnderflows(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name:   "main",
+		Locals: 0,
+		Code: []Instruction{
+			{Op: OpConstInt},
+			{Op: OpMakeResultOk},
+			{Op: OpTryResult, B: -1, C: -1},
+			{Op: OpPop},
+			{Op: OpReturn},
+		},
+	})
+
+	err := Verify(program)
+	if err == nil {
+		t.Fatalf("Verify() error = nil, want success-path underflow")
+	}
+	if !strings.Contains(err.Error(), "underflow") {
+		t.Fatalf("Verify() error = %q, want underflow message", err)
+	}
+}
+
+func TestVerifyAcceptsTryMaybeWithCatch(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name:   "main",
+		Locals: 0,
+		Code: []Instruction{
+			{Op: OpMakeMaybeNone},
+			{Op: OpTryMaybe, B: 3, C: -1},
+			{Op: OpReturn},
+			{Op: OpConstInt},
+			{Op: OpReturn},
+		},
+	})
+
+	if err := Verify(program); err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+}
+
+func TestVerifyRejectsTryMaybeNoCatchWhenSuccessPathUnderflows(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name:   "main",
+		Locals: 0,
+		Code: []Instruction{
+			{Op: OpConstInt},
+			{Op: OpMakeMaybeSome},
+			{Op: OpTryMaybe, B: -1, C: -1},
+			{Op: OpPop},
+			{Op: OpReturn},
+		},
+	})
+
+	err := Verify(program)
+	if err == nil {
+		t.Fatalf("Verify() error = nil, want success-path underflow")
+	}
+	if !strings.Contains(err.Error(), "underflow") {
+		t.Fatalf("Verify() error = %q, want underflow message", err)
+	}
+}
+
+func TestVerifyAcceptsMapGetLocalTryMaybeWithCatch(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name:   "main",
+		Locals: 2,
+		Code: []Instruction{
+			{Op: OpMapGetLocalTryMaybe, B: 0, C: 1, Imm: 2},
+			{Op: OpReturn},
+			{Op: OpConstInt},
+			{Op: OpReturn},
+		},
+	})
+
+	if err := Verify(program); err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+}
+
+func TestVerifyRejectsMapGetLocalTryMaybeNoCatchWhenSuccessPathUnderflows(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name:   "main",
+		Locals: 2,
+		Code: []Instruction{
+			{Op: OpMapGetLocalTryMaybe, B: 0, C: 1, Imm: -1},
+			{Op: OpPop},
+			{Op: OpReturn},
+		},
+	})
+
+	err := Verify(program)
+	if err == nil {
+		t.Fatalf("Verify() error = nil, want success-path underflow")
+	}
+	if !strings.Contains(err.Error(), "underflow") {
+		t.Fatalf("Verify() error = %q, want underflow message", err)
+	}
+}
+
+func TestVerifyRejectsReachableStackUnderflow(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name: "main",
+		Code: []Instruction{
+			{Op: OpPop},
+		},
+	})
+
+	err := Verify(program)
+	if err == nil {
+		t.Fatalf("Verify() error = nil, want stack underflow")
+	}
+	if !strings.Contains(err.Error(), "underflow") {
+		t.Fatalf("Verify() error = %q, want underflow message", err)
+	}
+}
+
+func TestVerifyRejectsBranchTargetOutOfRange(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name: "main",
+		Code: []Instruction{
+			{Op: OpJump, A: 1},
+		},
+	})
+
+	err := Verify(program)
+	if err == nil {
+		t.Fatalf("Verify() error = nil, want jump target rejection")
+	}
+	if !strings.Contains(err.Error(), "jump target") {
+		t.Fatalf("Verify() error = %q, want jump target message", err)
+	}
+}
+
+func TestVerifyRejectsTryCatchTargetOutOfRange(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name: "main",
+		Code: []Instruction{
+			{Op: OpConstInt},
+			{Op: OpTryMaybe, B: 2, C: -1},
+		},
+	})
+
+	err := Verify(program)
+	if err == nil {
+		t.Fatalf("Verify() error = nil, want try target rejection")
+	}
+	if !strings.Contains(err.Error(), "try jump target") {
+		t.Fatalf("Verify() error = %q, want try jump target message", err)
+	}
+}
+
+func TestVerifyIgnoresUnreachableCodeForStackValidation(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name: "main",
+		Code: []Instruction{
+			{Op: OpConstInt},
+			{Op: OpReturn},
+			{Op: OpPop},
+		},
+	})
+
+	if err := Verify(program); err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+}
+
+func TestVerifyRejectsReachableFallthroughOffEnd(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name:   "main",
+		Locals: 0,
+		Code: []Instruction{
+			{Op: OpConstInt},          // return value
+			{Op: OpConstBool},         // condition
+			{Op: OpJumpIfFalse, A: 4}, // false branch skips return
+			{Op: OpReturn},
+			{Op: OpNoop}, // reachable fallthrough off end
+		},
+	})
+
+	err := Verify(program)
+	if err == nil {
+		t.Fatalf("Verify() error = nil, want fallthrough rejection")
+	}
+	if !strings.Contains(err.Error(), "fall") && !strings.Contains(err.Error(), "terminate") {
+		t.Fatalf("Verify() error = %q, want termination-related message", err)
+	}
+}
+
+func TestVerifyTreatsPanicAsTerminating(t *testing.T) {
+	program := verifierTestProgram(Function{
+		Name:   "main",
+		Locals: 0,
+		Code: []Instruction{
+			{Op: OpConstBool},         // stack: 1
+			{Op: OpJumpIfFalse, A: 4}, // stack: 0 on both edges
+			{Op: OpConstStr, B: 0},    // true branch stack: 1
+			{Op: OpPanic},             // true branch terminates
+			{Op: OpReturn},            // false branch underflows unless panic is terminating
+		},
+	}, Constant{Kind: ConstStr, Str: "boom"})
+
+	err := Verify(program)
+	if err == nil {
+		t.Fatalf("Verify() error = nil, want stack underflow on false branch")
+	}
+	if !strings.Contains(err.Error(), "stack") {
+		t.Fatalf("Verify() error = %q, want stack-related message", err)
+	}
+}
+
+func verifierTestProgram(fn Function, constants ...Constant) *Program {
+	return &Program{
+		Constants: constants,
+		Functions: []Function{fn},
+	}
+}


### PR DESCRIPTION
## Summary\n- make  do reachable control-flow-aware stack verification\n- preserve operand/index validation while tightening jump/catch target checks\n- add verifier tests for joins, loops, try/maybe behavior, termination, and unreachable code policy\n\n## Testing\n- cd compiler && go test ./vm_next/bytecode -run TestVerify\n- cd compiler && go test ./vm_next/...