### PR TITLE
fix(go): resolve server lowering edge cases

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,5 @@
 # TODO
+- [ ] try to improve FFI perf by autocasting args to externs
 - [ ] allow FFI in user land
 - [ ] make duplicate FFI binding registration return an error
 - [ ] Dependency system
@@ -14,10 +15,6 @@
   * most current non-checker usages are runtime FFI helpers (`compiler/ffi/decoders.go`, `compiler/ffi/http.go`)
   * this is probably not something to solve in the checker-validation pass right now
   * revisit once JS runtime/backend work makes those runtime paths concrete
-- [ ] strengthen AIR result/maybe typing in nested contextual expressions
-  * current Go target had to compensate during lowering when nested blocks/match arms/try expressions carried weaker AIR types like `Int!Void` even though the enclosing context required `Int!Str`
-  * investigate whether AIR should normalize these nested contextual `Result`/`Maybe` expression types earlier so backends need less context-sensitive repair
-  * treat this as an AIR-wide design follow-up, not just a Go-target workaround, because it may affect vm_next, diagnostics, and other backends
 - [ ] automate current Go-target sample/server/manual checks into durable regression tests
   * cover the existing interactive stdin flows and server route assertions for `--target go`
   * normalize volatile response fields like `Date` where needed

--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -1500,7 +1500,7 @@ func (fl *functionLowerer) lowerBlockWithDefault(stmts []checker.Statement, defa
 			continue
 		}
 		if i == last && stmt.Expr != nil {
-			expr, err := fl.lowerExprWithExpected(stmt.Expr, defaultType)
+			expr, _, err := fl.lowerContextualExpr(stmt.Expr, defaultType)
 			if err != nil {
 				return block, err
 			}
@@ -1516,7 +1516,27 @@ func (fl *functionLowerer) lowerBlockWithDefault(stmts []checker.Statement, defa
 	return block, nil
 }
 
+func (fl *functionLowerer) lowerContextualExpr(expr checker.Expression, expected TypeID) (*Expr, TypeID, error) {
+	lowered, err := fl.lowerExprWithExpectedRaw(expr, expected)
+	if err != nil {
+		return nil, expected, err
+	}
+	if normalized := fl.normalizeContextualType(lowered, expected); normalized != NoType && normalized != expected {
+		lowered, err = fl.lowerExprWithExpectedRaw(expr, normalized)
+		if err != nil {
+			return nil, normalized, err
+		}
+		return lowered, normalized, nil
+	}
+	return lowered, expected, nil
+}
+
 func (fl *functionLowerer) lowerExprWithExpected(expr checker.Expression, expected TypeID) (*Expr, error) {
+	lowered, _, err := fl.lowerContextualExpr(expr, expected)
+	return lowered, err
+}
+
+func (fl *functionLowerer) lowerExprWithExpectedRaw(expr checker.Expression, expected TypeID) (*Expr, error) {
 	if wrapped, ok, err := fl.lowerUnionWrapIfNeeded(expr, expected); ok || err != nil {
 		return wrapped, err
 	}
@@ -1567,6 +1587,283 @@ func (fl *functionLowerer) lowerExprWithExpected(expr checker.Expression, expect
 		return fl.lowerConditionalMatch(expected, match)
 	}
 	return fl.lowerExpr(expr)
+}
+
+func (fl *functionLowerer) normalizeContextualType(expr *Expr, expected TypeID) TypeID {
+	if expr == nil || !validTypeID(&fl.l.program, expected) || !fl.isWeakContextType(expected) {
+		return NoType
+	}
+	expectedInfo, _ := fl.l.typeInfo(expected)
+	switch expectedInfo.Kind {
+	case TypeMaybe:
+		return fl.inferMaybeType(expr)
+	case TypeResult:
+		return fl.inferResultType(expr, expected)
+	case TypeVoid:
+		if inferred := fl.inferValueType(expr); inferred != NoType {
+			return inferred
+		}
+		if inferred := fl.inferMaybeType(expr); inferred != NoType {
+			return inferred
+		}
+		return fl.inferResultType(expr, expected)
+	default:
+		return NoType
+	}
+}
+
+func (fl *functionLowerer) inferValueType(expr *Expr) TypeID {
+	if expr == nil {
+		return NoType
+	}
+	switch expr.Kind {
+	case ExprTryMaybe:
+		if expr.Target != nil {
+			if targetInfo, ok := fl.l.typeInfo(expr.Target.Type); ok && targetInfo.Kind == TypeMaybe {
+				return targetInfo.Elem
+			}
+		}
+	case ExprTryResult:
+		if expr.Target != nil {
+			if targetInfo, ok := fl.l.typeInfo(expr.Target.Type); ok && targetInfo.Kind == TypeResult {
+				return targetInfo.Value
+			}
+		}
+	case ExprBlock:
+		return fl.inferValueType(expr.Body.Result)
+	case ExprIf:
+		return fl.mergeValueTypes(fl.inferValueType(expr.Then.Result), fl.inferValueType(expr.Else.Result))
+	case ExprMatchInt:
+		return fl.inferValueTypeFromCases(expr.IntCases, expr.RangeCases, expr.CatchAll)
+	case ExprMatchMaybe:
+		return fl.mergeValueTypes(fl.inferValueType(expr.Some.Result), fl.inferValueType(expr.None.Result))
+	case ExprMatchResult:
+		return fl.mergeValueTypes(fl.inferValueType(expr.Ok.Result), fl.inferValueType(expr.Err.Result))
+	case ExprMatchEnum:
+		value := NoType
+		for _, c := range expr.EnumCases {
+			value = fl.mergeValueTypes(value, fl.inferValueType(c.Body.Result))
+		}
+		return fl.mergeValueTypes(value, fl.inferValueType(expr.CatchAll.Result))
+	case ExprMatchUnion:
+		value := NoType
+		for _, c := range expr.UnionCases {
+			value = fl.mergeValueTypes(value, fl.inferValueType(c.Body.Result))
+		}
+		return fl.mergeValueTypes(value, fl.inferValueType(expr.CatchAll.Result))
+	}
+	return NoType
+}
+
+func (fl *functionLowerer) inferMaybeType(expr *Expr) TypeID {
+	if expr == nil {
+		return NoType
+	}
+	if info, ok := fl.l.typeInfo(expr.Type); ok && info.Kind == TypeMaybe && !fl.isWeakContextType(expr.Type) {
+		return expr.Type
+	}
+	switch expr.Kind {
+	case ExprMakeMaybeSome:
+		if expr.Target != nil {
+			return fl.internMaybeType(expr.Target.Type)
+		}
+	case ExprBlock:
+		return fl.inferMaybeType(expr.Body.Result)
+	case ExprIf:
+		return fl.mergeValueTypes(fl.inferMaybeType(expr.Then.Result), fl.inferMaybeType(expr.Else.Result))
+	case ExprMatchInt:
+		return fl.inferMaybeTypeFromCases(expr.IntCases, expr.RangeCases, expr.CatchAll)
+	case ExprMatchMaybe:
+		return fl.mergeValueTypes(fl.inferMaybeType(expr.Some.Result), fl.inferMaybeType(expr.None.Result))
+	case ExprMatchResult:
+		return fl.mergeValueTypes(fl.inferMaybeType(expr.Ok.Result), fl.inferMaybeType(expr.Err.Result))
+	case ExprMatchEnum:
+		value := NoType
+		for _, c := range expr.EnumCases {
+			value = fl.mergeValueTypes(value, fl.inferMaybeType(c.Body.Result))
+		}
+		return fl.mergeValueTypes(value, fl.inferMaybeType(expr.CatchAll.Result))
+	case ExprMatchUnion:
+		value := NoType
+		for _, c := range expr.UnionCases {
+			value = fl.mergeValueTypes(value, fl.inferMaybeType(c.Body.Result))
+		}
+		return fl.mergeValueTypes(value, fl.inferMaybeType(expr.CatchAll.Result))
+	}
+	return NoType
+}
+
+func (fl *functionLowerer) inferResultType(expr *Expr, fallback TypeID) TypeID {
+	valueType, errType := fl.inferResultParts(expr)
+	if info, ok := fl.l.typeInfo(fallback); ok && info.Kind == TypeResult {
+		if valueType == NoType && validTypeID(&fl.l.program, info.Value) && !fl.isVoidType(info.Value) {
+			valueType = info.Value
+		}
+		if errType == NoType && validTypeID(&fl.l.program, info.Error) && !fl.isVoidType(info.Error) {
+			errType = info.Error
+		}
+	}
+	if valueType == NoType || errType == NoType {
+		return NoType
+	}
+	return fl.internResultType(valueType, errType)
+}
+
+func (fl *functionLowerer) inferResultParts(expr *Expr) (TypeID, TypeID) {
+	if expr == nil {
+		return NoType, NoType
+	}
+	if info, ok := fl.l.typeInfo(expr.Type); ok && info.Kind == TypeResult && !fl.isWeakContextType(expr.Type) {
+		return info.Value, info.Error
+	}
+	switch expr.Kind {
+	case ExprMakeResultOk:
+		if expr.Target != nil {
+			return expr.Target.Type, NoType
+		}
+	case ExprMakeResultErr:
+		if expr.Target != nil {
+			return NoType, expr.Target.Type
+		}
+	case ExprBlock:
+		return fl.inferResultParts(expr.Body.Result)
+	case ExprIf:
+		leftValue, leftErr := fl.inferResultParts(expr.Then.Result)
+		rightValue, rightErr := fl.inferResultParts(expr.Else.Result)
+		return fl.mergeResultParts(leftValue, leftErr, rightValue, rightErr)
+	case ExprMatchInt:
+		return fl.inferResultPartsFromCases(expr.IntCases, expr.RangeCases, expr.CatchAll)
+	case ExprMatchMaybe:
+		leftValue, leftErr := fl.inferResultParts(expr.Some.Result)
+		rightValue, rightErr := fl.inferResultParts(expr.None.Result)
+		return fl.mergeResultParts(leftValue, leftErr, rightValue, rightErr)
+	case ExprMatchResult:
+		leftValue, leftErr := fl.inferResultParts(expr.Ok.Result)
+		rightValue, rightErr := fl.inferResultParts(expr.Err.Result)
+		return fl.mergeResultParts(leftValue, leftErr, rightValue, rightErr)
+	case ExprMatchEnum:
+		valueType, errType := NoType, NoType
+		for _, c := range expr.EnumCases {
+			rightValue, rightErr := fl.inferResultParts(c.Body.Result)
+			valueType, errType = fl.mergeResultParts(valueType, errType, rightValue, rightErr)
+		}
+		rightValue, rightErr := fl.inferResultParts(expr.CatchAll.Result)
+		return fl.mergeResultParts(valueType, errType, rightValue, rightErr)
+	case ExprMatchUnion:
+		valueType, errType := NoType, NoType
+		for _, c := range expr.UnionCases {
+			rightValue, rightErr := fl.inferResultParts(c.Body.Result)
+			valueType, errType = fl.mergeResultParts(valueType, errType, rightValue, rightErr)
+		}
+		rightValue, rightErr := fl.inferResultParts(expr.CatchAll.Result)
+		return fl.mergeResultParts(valueType, errType, rightValue, rightErr)
+	}
+	return NoType, NoType
+}
+
+func (fl *functionLowerer) inferValueTypeFromCases(intCases []IntMatchCase, rangeCases []IntRangeMatchCase, catchAll Block) TypeID {
+	value := NoType
+	for _, c := range intCases {
+		value = fl.mergeValueTypes(value, fl.inferValueType(c.Body.Result))
+	}
+	for _, c := range rangeCases {
+		value = fl.mergeValueTypes(value, fl.inferValueType(c.Body.Result))
+	}
+	return fl.mergeValueTypes(value, fl.inferValueType(catchAll.Result))
+}
+
+func (fl *functionLowerer) inferMaybeTypeFromCases(intCases []IntMatchCase, rangeCases []IntRangeMatchCase, catchAll Block) TypeID {
+	value := NoType
+	for _, c := range intCases {
+		value = fl.mergeValueTypes(value, fl.inferMaybeType(c.Body.Result))
+	}
+	for _, c := range rangeCases {
+		value = fl.mergeValueTypes(value, fl.inferMaybeType(c.Body.Result))
+	}
+	return fl.mergeValueTypes(value, fl.inferMaybeType(catchAll.Result))
+}
+
+func (fl *functionLowerer) inferResultPartsFromCases(intCases []IntMatchCase, rangeCases []IntRangeMatchCase, catchAll Block) (TypeID, TypeID) {
+	valueType, errType := NoType, NoType
+	for _, c := range intCases {
+		rightValue, rightErr := fl.inferResultParts(c.Body.Result)
+		valueType, errType = fl.mergeResultParts(valueType, errType, rightValue, rightErr)
+	}
+	for _, c := range rangeCases {
+		rightValue, rightErr := fl.inferResultParts(c.Body.Result)
+		valueType, errType = fl.mergeResultParts(valueType, errType, rightValue, rightErr)
+	}
+	rightValue, rightErr := fl.inferResultParts(catchAll.Result)
+	return fl.mergeResultParts(valueType, errType, rightValue, rightErr)
+}
+
+func (fl *functionLowerer) mergeValueTypes(left TypeID, right TypeID) TypeID {
+	if left == NoType {
+		return right
+	}
+	if right == NoType || left == right {
+		return left
+	}
+	return NoType
+}
+
+func (fl *functionLowerer) mergeResultParts(leftValue TypeID, leftErr TypeID, rightValue TypeID, rightErr TypeID) (TypeID, TypeID) {
+	valueType := fl.mergeValueTypes(leftValue, rightValue)
+	if valueType == NoType && leftValue != NoType && rightValue != NoType {
+		return NoType, NoType
+	}
+	errType := fl.mergeValueTypes(leftErr, rightErr)
+	if errType == NoType && leftErr != NoType && rightErr != NoType {
+		return NoType, NoType
+	}
+	return valueType, errType
+}
+
+func (fl *functionLowerer) internMaybeType(elem TypeID) TypeID {
+	if !validTypeID(&fl.l.program, elem) {
+		return NoType
+	}
+	id, err := fl.l.internSyntheticType(fl.l.typeName(elem)+"?", TypeInfo{Kind: TypeMaybe, Elem: elem})
+	if err != nil {
+		return NoType
+	}
+	return id
+}
+
+func (fl *functionLowerer) internResultType(value TypeID, errType TypeID) TypeID {
+	if !validTypeID(&fl.l.program, value) || !validTypeID(&fl.l.program, errType) {
+		return NoType
+	}
+	id, err := fl.l.internSyntheticType(fl.l.typeName(value)+"!"+fl.l.typeName(errType), TypeInfo{Kind: TypeResult, Value: value, Error: errType})
+	if err != nil {
+		return NoType
+	}
+	return id
+}
+
+func (fl *functionLowerer) isVoidType(typeID TypeID) bool {
+	if !validTypeID(&fl.l.program, typeID) {
+		return false
+	}
+	info, _ := fl.l.typeInfo(typeID)
+	return info.Kind == TypeVoid
+}
+
+func (fl *functionLowerer) isWeakContextType(typeID TypeID) bool {
+	if !validTypeID(&fl.l.program, typeID) {
+		return false
+	}
+	info, _ := fl.l.typeInfo(typeID)
+	switch info.Kind {
+	case TypeVoid:
+		return true
+	case TypeMaybe:
+		return !validTypeID(&fl.l.program, info.Elem) || fl.isVoidType(info.Elem)
+	case TypeResult:
+		return !validTypeID(&fl.l.program, info.Value) || !validTypeID(&fl.l.program, info.Error) || fl.isVoidType(info.Value) || fl.isVoidType(info.Error)
+	default:
+		return false
+	}
 }
 
 func (fl *functionLowerer) lowerDynamicWrapIfNeeded(expr checker.Expression, expected TypeID) (*Expr, bool, error) {
@@ -1663,12 +1960,12 @@ func (fl *functionLowerer) lowerStmt(stmt checker.Statement) (*Stmt, error) {
 		if err != nil {
 			return nil, err
 		}
-		local := fl.defineLocal(s.Name, typeID, s.Mutable)
-		value, err := fl.lowerExprWithExpected(s.Value, typeID)
+		value, actualType, err := fl.lowerContextualExpr(s.Value, typeID)
 		if err != nil {
 			return nil, err
 		}
-		return &Stmt{Kind: StmtLet, Local: local, Name: s.Name, Type: typeID, Mutable: s.Mutable, Value: value}, nil
+		local := fl.defineLocal(s.Name, actualType, s.Mutable)
+		return &Stmt{Kind: StmtLet, Local: local, Name: s.Name, Type: actualType, Mutable: s.Mutable, Value: value}, nil
 	case *checker.Reassignment:
 		switch target := s.Target.(type) {
 		case *checker.Variable:

--- a/compiler/air/lower_test.go
+++ b/compiler/air/lower_test.go
@@ -520,6 +520,67 @@ func TestLowerTraitObjectDispatch(t *testing.T) {
 	}
 }
 
+func TestLowerContextualMaybeTypesInNestedExpressions(t *testing.T) {
+	program := lowerSource(t, `
+		use ard/maybe
+
+		fn pick(choices: [Dynamic]) Dynamic? {
+			let first_choice = match choices.size() {
+				0 => maybe::none(),
+				_ => maybe::some(choices.at(0)),
+			}
+			let choice = try first_choice -> _ { maybe::none() }
+			maybe::some(choice)
+		}
+	`)
+
+	pick := findFunction(t, program, "pick")
+	if got := testTypeInfo(t, program, pick.Locals[1].Type).Name; got != "Dynamic?" {
+		t.Fatalf("first_choice type = %q, want Dynamic?", got)
+	}
+	if got := testTypeInfo(t, program, pick.Locals[2].Type).Name; got != "Dynamic" {
+		t.Fatalf("choice type = %q, want Dynamic", got)
+	}
+	if got := testTypeInfo(t, program, pick.Body.Stmts[0].Value.Type).Name; got != "Dynamic?" {
+		t.Fatalf("first_choice expr type = %q, want Dynamic?", got)
+	}
+	if got := testTypeInfo(t, program, pick.Body.Stmts[1].Value.Type).Name; got != "Dynamic" {
+		t.Fatalf("choice expr type = %q, want Dynamic", got)
+	}
+	if pick.Body.Result == nil || pick.Body.Result.Target == nil {
+		t.Fatalf("result tree missing maybe::some target: %#v", pick.Body.Result)
+	}
+	if got := testTypeInfo(t, program, pick.Body.Result.Target.Type).Name; got != "Dynamic" {
+		t.Fatalf("result some target type = %q, want Dynamic", got)
+	}
+}
+
+func TestLowerContextualResultTypesInNestedExpressions(t *testing.T) {
+	program := lowerSource(t, `
+		fn pick(flag: Bool) Int!Str {
+			let value = match flag {
+				true => Result::ok(1),
+				false => Result::err("bad"),
+			}
+			value
+		}
+	`)
+
+	pick := findFunction(t, program, "pick")
+	if got := testTypeInfo(t, program, pick.Locals[1].Type).Name; got != "Int!Str" {
+		t.Fatalf("value local type = %q, want Int!Str", got)
+	}
+	if got := testTypeInfo(t, program, pick.Body.Stmts[0].Value.Type).Name; got != "Int!Str" {
+		t.Fatalf("value expr type = %q, want Int!Str", got)
+	}
+	if pick.Body.Result == nil {
+		t.Fatalf("result = nil")
+	}
+	if got := testTypeInfo(t, program, pick.Body.Result.Type).Name; got != "Int!Str" {
+		t.Fatalf("result type = %q, want Int!Str", got)
+	}
+}
+
 func TestLowerTryOps(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/maybe

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -3,6 +3,7 @@ package gotarget
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -102,16 +103,16 @@ func TestGenerateSourcesSupportsStructsAndEnums(t *testing.T) {
 	for _, source := range sources {
 		combined += string(source)
 	}
-	if !strings.Contains(combined, "type type__Direction int") {
+	if !regexp.MustCompile(`type type_\d+__Direction int`).MatchString(combined) {
 		t.Fatalf("generated source missing enum type:\n%s", combined)
 	}
-	if !strings.Contains(combined, "type__Direction__Down") {
+	if !regexp.MustCompile(`type_\d+__Direction__Down`).MatchString(combined) {
 		t.Fatalf("generated source missing enum constants:\n%s", combined)
 	}
-	if !strings.Contains(combined, "type type__User struct") {
+	if !regexp.MustCompile(`type type_\d+__User struct`).MatchString(combined) {
 		t.Fatalf("generated source missing struct type:\n%s", combined)
 	}
-	if !strings.Contains(combined, "type__User{age: 41, name: \"Ada\"}") {
+	if !regexp.MustCompile(`type_\d+__User\{age: 41, name: "Ada"\}`).MatchString(combined) {
 		t.Fatalf("generated source missing struct literal lowering:\n%s", combined)
 	}
 	if !strings.Contains(combined, ".age + 1") {
@@ -397,7 +398,7 @@ func TestGenerateSourcesUsesPointersForMutableStructParams(t *testing.T) {
 		t.Fatalf("GenerateSources error = %v", err)
 	}
 	source := string(sources["test.go"])
-	if !strings.Contains(source, "func test_ard__set_body(res *type__Response)") {
+	if !regexp.MustCompile(`func test_ard__set_body\(res \*type_\d+__Response\)`).MatchString(source) {
 		t.Fatalf("generated source missing pointer mutable param lowering:\n%s", source)
 	}
 	if !strings.Contains(source, "test_ard__set_body(&res_0)") {

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -211,6 +211,104 @@ func TestRunProgramSupportsCommonStdlibExterns(t *testing.T) {
 	}
 }
 
+func TestGenerateSourcesUsesExpectedLocalTypeForMaybeNone(t *testing.T) {
+	program := lowerSource(t, `
+		use ard/maybe
+
+		fn main() Bool {
+			let found: Int? = maybe::none()
+			found.is_none()
+		}
+	`)
+
+	sources, err := GenerateSources(program, Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("GenerateSources error = %v", err)
+	}
+	source := string(sources["test.go"])
+	if !strings.Contains(source, "runtime.Maybe[int]{}") {
+		t.Fatalf("generated source missing typed maybe none:\n%s", source)
+	}
+	if strings.Contains(source, "runtime.Maybe[struct {") {
+		t.Fatalf("generated source used untyped maybe none:\n%s", source)
+	}
+}
+
+func TestGenerateSourcesUsesExpectedDefaultTypeForResultOr(t *testing.T) {
+	program := lowerSource(t, `
+		use ard/maybe
+
+		fn fetch() Int?!Str {
+			let empty: Int? = maybe::none()
+			Result::ok(empty)
+		}
+
+		fn main() Bool {
+			let value = fetch().or(maybe::none())
+			value.is_none()
+		}
+	`)
+
+	sources, err := GenerateSources(program, Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("GenerateSources error = %v", err)
+	}
+	source := string(sources["test.go"])
+	if strings.Contains(source, "runtime.Maybe[struct {") {
+		t.Fatalf("generated source used untyped maybe default:\n%s", source)
+	}
+}
+
+func TestGenerateSourcesSkipsVoidAssignmentForStatementMatchBranches(t *testing.T) {
+	program := lowerSource(t, `
+		use ard/maybe
+
+		fn main() Bool {
+			match maybe::some(1) {
+				value => value == 1,
+				_ => (),
+			}
+			false
+		}
+	`)
+
+	sources, err := GenerateSources(program, Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("GenerateSources error = %v", err)
+	}
+	source := string(sources["test.go"])
+	if strings.Contains(source, "= nil") {
+		t.Fatalf("generated source assigned nil in statement match lowering:\n%s", source)
+	}
+}
+
+func TestRunProgramSupportsVoidFiberFunctions(t *testing.T) {
+	program := lowerSource(t, `
+		use ard/async
+
+		fn job() Void {
+			()
+		}
+
+		fn main() Void {
+			async::start(job)
+		}
+	`)
+
+	if err := RunProgram(program, []string{"ard", "run", "sample.ard"}); err != nil {
+		t.Fatalf("RunProgram error = %v", err)
+	}
+}
+
+func TestTypeNameUsesUniqueFallbackWhenModuleOwnershipIsMissing(t *testing.T) {
+	program := &air.Program{}
+	left := typeName(program, air.TypeInfo{ID: 1, Name: "Request"})
+	right := typeName(program, air.TypeInfo{ID: 2, Name: "Request"})
+	if left == right {
+		t.Fatalf("fallback type names should be unique, got %q", left)
+	}
+}
+
 func TestGenerateSourcesSupportsResultExpectAndStringPredicates(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/io

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -427,12 +427,19 @@ func (l *lowerer) lowerStmt(fn air.Function, stmt air.Stmt) ([]ast.Stmt, error) 
 		if stmt.Value == nil {
 			return nil, fmt.Errorf("let statement missing value")
 		}
-		value, err := l.lowerExpr(fn, *stmt.Value)
+		localType := l.resolvedLocalType(fn, stmt.Local)
+		value, err := l.lowerExprWithExpectedType(fn, *stmt.Value, localType)
 		if err != nil {
 			return nil, err
 		}
-		name := localName(fn, stmt.Local)
 		out := append([]ast.Stmt{}, value.stmts...)
+		if l.isVoidType(localType) || isVoidExpr(value.expr) {
+			if !isVoidExpr(value.expr) {
+				out = append(out, &ast.ExprStmt{X: value.expr})
+			}
+			return out, nil
+		}
+		name := localName(fn, stmt.Local)
 		tok := token.DEFINE
 		if l.declaredLocals[stmt.Local] {
 			tok = token.ASSIGN
@@ -450,11 +457,18 @@ func (l *lowerer) lowerStmt(fn air.Function, stmt air.Stmt) ([]ast.Stmt, error) 
 		if stmt.Value == nil {
 			return nil, fmt.Errorf("assign statement missing value")
 		}
-		value, err := l.lowerExpr(fn, *stmt.Value)
+		localType := l.resolvedLocalType(fn, stmt.Local)
+		value, err := l.lowerExprWithExpectedType(fn, *stmt.Value, localType)
 		if err != nil {
 			return nil, err
 		}
 		out := append([]ast.Stmt{}, value.stmts...)
+		if l.isVoidType(localType) || isVoidExpr(value.expr) {
+			if !isVoidExpr(value.expr) {
+				out = append(out, &ast.ExprStmt{X: value.expr})
+			}
+			return out, nil
+		}
 		out = append(out, &ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent(localName(fn, stmt.Local))},
 			Tok: token.ASSIGN,
@@ -999,7 +1013,7 @@ func (l *lowerer) lowerExpr(fn air.Function, expr air.Expr) (loweredExpr, error)
 			argExpr := loweredArg.expr
 			if i < len(target.Signature.Params) && target.Signature.Params[i].Mutable && validTypeID(l.program, target.Signature.Params[i].Type) {
 				paramType := l.program.Types[target.Signature.Params[i].Type-1]
-				if paramType.Kind == air.TypeStruct {
+				if paramType.Kind == air.TypeStruct && !l.localIsPointerParam(fn, arg) {
 					argExpr = &ast.UnaryExpr{Op: token.AND, X: argExpr}
 				}
 			}
@@ -1120,6 +1134,9 @@ func (l *lowerer) lowerValueBlock(fn air.Function, block air.Block, resultType a
 				stmts = append(stmts, &ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent("_")}, Tok: token.ASSIGN, Rhs: []ast.Expr{result.expr}})
 			}
 		} else {
+			if l.isVoidType(block.Result.Type) || isVoidExpr(result.expr) {
+				return stmts, nil
+			}
 			if target == nil {
 				return nil, fmt.Errorf("non-void block result missing target")
 			}
@@ -1141,6 +1158,9 @@ func (l *lowerer) lowerExprWithExpectedType(fn air.Function, expr air.Expr, expe
 func (l *lowerer) canOverrideExprType(expr air.Expr, expectedType air.TypeID) bool {
 	if !validTypeID(l.program, expr.Type) || !validTypeID(l.program, expectedType) {
 		return false
+	}
+	if inferred := l.inferTypeFromExprShape(&expr); inferred == expectedType {
+		return true
 	}
 	from := l.program.Types[expr.Type-1]
 	to := l.program.Types[expectedType-1]
@@ -1392,6 +1412,345 @@ func (l *lowerer) isVoidType(typeID air.TypeID) bool {
 	return validTypeID(l.program, typeID) && l.program.Types[typeID-1].Kind == air.TypeVoid
 }
 
+func (l *lowerer) resolvedLocalType(fn air.Function, local air.LocalID) air.TypeID {
+	if int(local) < 0 || int(local) >= len(fn.Locals) {
+		return air.NoType
+	}
+	typeID := fn.Locals[local].Type
+	if !l.isWeakContextType(typeID) && !l.isVoidType(typeID) {
+		return typeID
+	}
+	if inferred := l.inferLocalTypeFromBlock(fn, local, fn.Body); inferred != air.NoType {
+		return inferred
+	}
+	if initExpr := l.findLocalInitializerExpr(fn.Body, local); initExpr != nil {
+		if validTypeID(l.program, initExpr.Type) && !l.isVoidType(initExpr.Type) && !l.isWeakContextType(initExpr.Type) {
+			return initExpr.Type
+		}
+		if inferred := l.resolveExpectedTypeFromExpr(typeID, initExpr); inferred != air.NoType {
+			return inferred
+		}
+	}
+	if fn.Body.Result != nil && fn.Body.Result.Kind == air.ExprLoadLocal && fn.Body.Result.Local == local && !l.isWeakContextType(fn.Signature.Return) {
+		return fn.Signature.Return
+	}
+	return typeID
+}
+
+func (l *lowerer) findLocalInitializerExpr(block air.Block, local air.LocalID) *air.Expr {
+	for _, stmt := range block.Stmts {
+		switch stmt.Kind {
+		case air.StmtLet:
+			if stmt.Local == local {
+				return stmt.Value
+			}
+		case air.StmtWhile:
+			if expr := l.findLocalInitializerExpr(stmt.Body, local); expr != nil {
+				return expr
+			}
+		}
+		for _, expr := range []*air.Expr{stmt.Value, stmt.Expr, stmt.Target, stmt.Condition} {
+			if nested := l.findLocalInitializerExprInExpr(expr, local); nested != nil {
+				return nested
+			}
+		}
+	}
+	if nested := l.findLocalInitializerExprInExpr(block.Result, local); nested != nil {
+		return nested
+	}
+	return nil
+}
+
+func (l *lowerer) findLocalInitializerExprInExpr(expr *air.Expr, local air.LocalID) *air.Expr {
+	if expr == nil {
+		return nil
+	}
+	for _, block := range []air.Block{expr.Body, expr.Then, expr.Else, expr.CatchAll, expr.Some, expr.None, expr.Ok, expr.Err, expr.Catch} {
+		if nested := l.findLocalInitializerExpr(block, local); nested != nil {
+			return nested
+		}
+	}
+	for _, c := range expr.EnumCases {
+		if nested := l.findLocalInitializerExpr(c.Body, local); nested != nil {
+			return nested
+		}
+	}
+	for _, c := range expr.IntCases {
+		if nested := l.findLocalInitializerExpr(c.Body, local); nested != nil {
+			return nested
+		}
+	}
+	for _, c := range expr.RangeCases {
+		if nested := l.findLocalInitializerExpr(c.Body, local); nested != nil {
+			return nested
+		}
+	}
+	for _, c := range expr.UnionCases {
+		if nested := l.findLocalInitializerExpr(c.Body, local); nested != nil {
+			return nested
+		}
+	}
+	for _, child := range []*air.Expr{expr.Target, expr.Left, expr.Right} {
+		if nested := l.findLocalInitializerExprInExpr(child, local); nested != nil {
+			return nested
+		}
+	}
+	for i := range expr.Args {
+		if nested := l.findLocalInitializerExprInExpr(&expr.Args[i], local); nested != nil {
+			return nested
+		}
+	}
+	return nil
+}
+
+func (l *lowerer) inferLocalTypeFromBlock(fn air.Function, local air.LocalID, block air.Block) air.TypeID {
+	for _, stmt := range block.Stmts {
+		switch stmt.Kind {
+		case air.StmtLet, air.StmtAssign:
+			if stmt.Local == local && stmt.Value != nil && !l.isWeakContextType(stmt.Value.Type) {
+				return stmt.Value.Type
+			}
+		case air.StmtWhile:
+			if inferred := l.inferLocalTypeFromBlock(fn, local, stmt.Body); inferred != air.NoType {
+				return inferred
+			}
+		}
+		if stmt.Value != nil {
+			if inferred := l.inferLocalTypeFromExpr(fn, local, *stmt.Value); inferred != air.NoType {
+				return inferred
+			}
+		}
+		if stmt.Expr != nil {
+			if inferred := l.inferLocalTypeFromExpr(fn, local, *stmt.Expr); inferred != air.NoType {
+				return inferred
+			}
+		}
+		if stmt.Target != nil {
+			if inferred := l.inferLocalTypeFromExpr(fn, local, *stmt.Target); inferred != air.NoType {
+				return inferred
+			}
+		}
+		if stmt.Condition != nil {
+			if inferred := l.inferLocalTypeFromExpr(fn, local, *stmt.Condition); inferred != air.NoType {
+				return inferred
+			}
+		}
+	}
+	if block.Result != nil {
+		if inferred := l.inferLocalTypeFromExpr(fn, local, *block.Result); inferred != air.NoType {
+			return inferred
+		}
+	}
+	return air.NoType
+}
+
+func (l *lowerer) resolveExpectedTypeFromExpr(fallback air.TypeID, expr *air.Expr) air.TypeID {
+	if expr == nil || !validTypeID(l.program, fallback) {
+		return air.NoType
+	}
+	fallbackInfo := l.program.Types[fallback-1]
+	if inferred := l.inferTypeFromExprShape(expr); validTypeID(l.program, inferred) {
+		inferredInfo := l.program.Types[inferred-1]
+		if inferredInfo.Kind == fallbackInfo.Kind || l.isVoidType(fallback) {
+			return inferred
+		}
+	}
+	if validTypeID(l.program, expr.Type) {
+		exprInfo := l.program.Types[expr.Type-1]
+		if exprInfo.Kind == fallbackInfo.Kind && !l.isWeakContextType(expr.Type) {
+			return expr.Type
+		}
+	}
+	for _, block := range []air.Block{expr.Body, expr.Then, expr.Else, expr.CatchAll, expr.Some, expr.None, expr.Ok, expr.Err, expr.Catch} {
+		if block.Result != nil {
+			if inferred := l.resolveExpectedTypeFromExpr(fallback, block.Result); inferred != air.NoType {
+				return inferred
+			}
+		}
+	}
+	for _, c := range expr.EnumCases {
+		if c.Body.Result != nil {
+			if inferred := l.resolveExpectedTypeFromExpr(fallback, c.Body.Result); inferred != air.NoType {
+				return inferred
+			}
+		}
+	}
+	for _, c := range expr.IntCases {
+		if c.Body.Result != nil {
+			if inferred := l.resolveExpectedTypeFromExpr(fallback, c.Body.Result); inferred != air.NoType {
+				return inferred
+			}
+		}
+	}
+	for _, c := range expr.RangeCases {
+		if c.Body.Result != nil {
+			if inferred := l.resolveExpectedTypeFromExpr(fallback, c.Body.Result); inferred != air.NoType {
+				return inferred
+			}
+		}
+	}
+	for _, c := range expr.UnionCases {
+		if c.Body.Result != nil {
+			if inferred := l.resolveExpectedTypeFromExpr(fallback, c.Body.Result); inferred != air.NoType {
+				return inferred
+			}
+		}
+	}
+	if expr.Target != nil {
+		if inferred := l.resolveExpectedTypeFromExpr(fallback, expr.Target); inferred != air.NoType {
+			return inferred
+		}
+	}
+	if expr.Left != nil {
+		if inferred := l.resolveExpectedTypeFromExpr(fallback, expr.Left); inferred != air.NoType {
+			return inferred
+		}
+	}
+	if expr.Right != nil {
+		if inferred := l.resolveExpectedTypeFromExpr(fallback, expr.Right); inferred != air.NoType {
+			return inferred
+		}
+	}
+	for i := range expr.Args {
+		if inferred := l.resolveExpectedTypeFromExpr(fallback, &expr.Args[i]); inferred != air.NoType {
+			return inferred
+		}
+	}
+	return air.NoType
+}
+
+func (l *lowerer) inferTypeFromExprShape(expr *air.Expr) air.TypeID {
+	if expr == nil {
+		return air.NoType
+	}
+	switch expr.Kind {
+	case air.ExprMakeMaybeSome:
+		if expr.Target != nil {
+			return l.findMaybeTypeByElem(expr.Target.Type)
+		}
+	case air.ExprTryMaybe:
+		if expr.Target != nil && validTypeID(l.program, expr.Target.Type) {
+			targetType := l.program.Types[expr.Target.Type-1]
+			if targetType.Kind == air.TypeMaybe {
+				return targetType.Elem
+			}
+		}
+	case air.ExprTryResult:
+		if expr.Target != nil && validTypeID(l.program, expr.Target.Type) {
+			targetType := l.program.Types[expr.Target.Type-1]
+			if targetType.Kind == air.TypeResult {
+				return targetType.Value
+			}
+		}
+	}
+	return air.NoType
+}
+
+func (l *lowerer) findMaybeTypeByElem(elem air.TypeID) air.TypeID {
+	for _, info := range l.program.Types {
+		if info.Kind == air.TypeMaybe && info.Elem == elem {
+			return info.ID
+		}
+	}
+	if !validTypeID(l.program, elem) {
+		return air.NoType
+	}
+	id := air.TypeID(len(l.program.Types) + 1)
+	l.program.Types = append(l.program.Types, air.TypeInfo{ID: id, Kind: air.TypeMaybe, Name: fmt.Sprintf("Maybe<%d>", elem), Elem: elem})
+	return id
+}
+
+func (l *lowerer) inferLocalTypeFromExpr(fn air.Function, local air.LocalID, expr air.Expr) air.TypeID {
+	if expr.Target != nil {
+		if inferred := l.inferLocalTypeFromExpr(fn, local, *expr.Target); inferred != air.NoType {
+			return inferred
+		}
+	}
+	if expr.Left != nil {
+		if inferred := l.inferLocalTypeFromExpr(fn, local, *expr.Left); inferred != air.NoType {
+			return inferred
+		}
+	}
+	if expr.Right != nil {
+		if inferred := l.inferLocalTypeFromExpr(fn, local, *expr.Right); inferred != air.NoType {
+			return inferred
+		}
+	}
+	for _, arg := range expr.Args {
+		if inferred := l.inferLocalTypeFromExpr(fn, local, arg); inferred != air.NoType {
+			return inferred
+		}
+	}
+	for _, block := range []air.Block{expr.Body, expr.Then, expr.Else, expr.CatchAll, expr.Some, expr.None, expr.Ok, expr.Err, expr.Catch} {
+		if inferred := l.inferLocalTypeFromBlock(fn, local, block); inferred != air.NoType {
+			return inferred
+		}
+	}
+	for _, c := range expr.EnumCases {
+		if inferred := l.inferLocalTypeFromBlock(fn, local, c.Body); inferred != air.NoType {
+			return inferred
+		}
+	}
+	for _, c := range expr.IntCases {
+		if inferred := l.inferLocalTypeFromBlock(fn, local, c.Body); inferred != air.NoType {
+			return inferred
+		}
+	}
+	for _, c := range expr.RangeCases {
+		if inferred := l.inferLocalTypeFromBlock(fn, local, c.Body); inferred != air.NoType {
+			return inferred
+		}
+	}
+	for _, c := range expr.UnionCases {
+		if inferred := l.inferLocalTypeFromBlock(fn, local, c.Body); inferred != air.NoType {
+			return inferred
+		}
+	}
+	return air.NoType
+}
+
+func (l *lowerer) isWeakContextType(typeID air.TypeID) bool {
+	if !validTypeID(l.program, typeID) {
+		return false
+	}
+	info := l.program.Types[typeID-1]
+	switch info.Kind {
+	case air.TypeMaybe:
+		return !validTypeID(l.program, info.Elem) || l.program.Types[info.Elem-1].Kind == air.TypeVoid
+	case air.TypeResult:
+		return !validTypeID(l.program, info.Value) || !validTypeID(l.program, info.Error) || l.program.Types[info.Value-1].Kind == air.TypeVoid || l.program.Types[info.Error-1].Kind == air.TypeVoid
+	default:
+		return false
+	}
+}
+
+func (l *lowerer) resolvedExprType(fn air.Function, expr air.Expr) air.TypeID {
+	if expr.Kind == air.ExprLoadLocal {
+		if resolved := l.resolvedLocalType(fn, expr.Local); resolved != air.NoType {
+			return resolved
+		}
+	}
+	if inferred := l.inferTypeFromExprShape(&expr); inferred != air.NoType {
+		return inferred
+	}
+	return expr.Type
+}
+
+func (l *lowerer) localIsPointerParam(fn air.Function, expr air.Expr) bool {
+	if expr.Kind != air.ExprLoadLocal {
+		return false
+	}
+	local := int(expr.Local)
+	if local < 0 || local >= len(fn.Signature.Params) || !validTypeID(l.program, expr.Type) {
+		return false
+	}
+	param := fn.Signature.Params[local]
+	if !param.Mutable || !validTypeID(l.program, param.Type) {
+		return false
+	}
+	return l.program.Types[param.Type-1].Kind == air.TypeStruct
+}
+
 func (l *lowerer) qualified(alias string, importPath string, name string) ast.Expr {
 	l.currentImports[alias] = importPath
 	return &ast.SelectorExpr{X: ast.NewIdent(alias), Sel: ast.NewIdent(name)}
@@ -1508,12 +1867,38 @@ func (l *lowerer) lowerMatchInt(fn air.Function, expr air.Expr) (loweredExpr, er
 	if err != nil {
 		return loweredExpr{}, err
 	}
+	resultTypeID := expr.Type
+	if l.isWeakContextType(resultTypeID) || l.isVoidType(resultTypeID) {
+		for _, intCase := range expr.IntCases {
+			if intCase.Body.Result != nil && intCase.Body.Result.Kind == air.ExprMakeMaybeSome && intCase.Body.Result.Target != nil {
+				if inferred := l.findMaybeTypeByElem(intCase.Body.Result.Target.Type); inferred != air.NoType {
+					resultTypeID = inferred
+					break
+				}
+			}
+		}
+		if resultTypeID == expr.Type {
+			for _, rangeCase := range expr.RangeCases {
+				if rangeCase.Body.Result != nil && rangeCase.Body.Result.Kind == air.ExprMakeMaybeSome && rangeCase.Body.Result.Target != nil {
+					if inferred := l.findMaybeTypeByElem(rangeCase.Body.Result.Target.Type); inferred != air.NoType {
+						resultTypeID = inferred
+						break
+					}
+				}
+			}
+		}
+		if resultTypeID == expr.Type {
+			if inferred := l.resolveExpectedTypeFromExpr(resultTypeID, &expr); inferred != air.NoType {
+				resultTypeID = inferred
+			}
+		}
+	}
 	resultExpr := ast.NewIdent("nil")
 	stmts := append([]ast.Stmt{}, target.stmts...)
 	var assignTarget ast.Expr
-	if !l.isVoidType(expr.Type) {
+	if !l.isVoidType(resultTypeID) {
 		temp := l.nextTemp()
-		decls, err := l.declareTemp(expr.Type, temp)
+		decls, err := l.declareTemp(resultTypeID, temp)
 		if err != nil {
 			return loweredExpr{}, err
 		}
@@ -1523,14 +1908,14 @@ func (l *lowerer) lowerMatchInt(fn air.Function, expr air.Expr) (loweredExpr, er
 	}
 	cases := make([]ast.Stmt, 0, len(expr.IntCases)+len(expr.RangeCases)+1)
 	for _, intCase := range expr.IntCases {
-		body, err := l.lowerValueBlock(fn, intCase.Body, expr.Type, assignTarget)
+		body, err := l.lowerValueBlock(fn, intCase.Body, resultTypeID, assignTarget)
 		if err != nil {
 			return loweredExpr{}, err
 		}
 		cases = append(cases, &ast.CaseClause{List: []ast.Expr{&ast.BinaryExpr{X: target.expr, Op: token.EQL, Y: &ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", intCase.Value)}}}, Body: body})
 	}
 	for _, rangeCase := range expr.RangeCases {
-		body, err := l.lowerValueBlock(fn, rangeCase.Body, expr.Type, assignTarget)
+		body, err := l.lowerValueBlock(fn, rangeCase.Body, resultTypeID, assignTarget)
 		if err != nil {
 			return loweredExpr{}, err
 		}
@@ -1538,7 +1923,7 @@ func (l *lowerer) lowerMatchInt(fn air.Function, expr air.Expr) (loweredExpr, er
 		cases = append(cases, &ast.CaseClause{List: []ast.Expr{cond}, Body: body})
 	}
 	if len(expr.CatchAll.Stmts) > 0 || expr.CatchAll.Result != nil {
-		body, err := l.lowerValueBlock(fn, expr.CatchAll, expr.Type, assignTarget)
+		body, err := l.lowerValueBlock(fn, expr.CatchAll, resultTypeID, assignTarget)
 		if err != nil {
 			return loweredExpr{}, err
 		}
@@ -1667,7 +2052,7 @@ func (l *lowerer) lowerMaybeOr(fn air.Function, expr air.Expr) (loweredExpr, err
 	if err != nil {
 		return loweredExpr{}, err
 	}
-	defaultValue, err := l.lowerExpr(fn, expr.Args[0])
+	defaultValue, err := l.lowerExprWithExpectedType(fn, expr.Args[0], expr.Type)
 	if err != nil {
 		return loweredExpr{}, err
 	}
@@ -1703,7 +2088,7 @@ func (l *lowerer) lowerResultOr(fn air.Function, expr air.Expr) (loweredExpr, er
 	if err != nil {
 		return loweredExpr{}, err
 	}
-	defaultValue, err := l.lowerExpr(fn, expr.Args[0])
+	defaultValue, err := l.lowerExprWithExpectedType(fn, expr.Args[0], expr.Type)
 	if err != nil {
 		return loweredExpr{}, err
 	}
@@ -2205,19 +2590,26 @@ func (l *lowerer) lowerTryMaybe(fn air.Function, expr air.Expr) (loweredExpr, er
 	if err != nil {
 		return loweredExpr{}, err
 	}
+	targetTypeID := l.resolvedExprType(fn, *expr.Target)
 	targetTemp := l.nextTemp()
-	targetDecls, err := l.declareTemp(expr.Target.Type, targetTemp)
+	targetDecls, err := l.declareTemp(targetTypeID, targetTemp)
 	if err != nil {
 		return loweredExpr{}, err
 	}
 	targetExpr := ast.NewIdent(targetTemp)
 	stmts := append(target.stmts, targetDecls...)
 	stmts = append(stmts, &ast.AssignStmt{Lhs: []ast.Expr{targetExpr}, Tok: token.ASSIGN, Rhs: []ast.Expr{target.expr}})
+	resultTypeID := expr.Type
+	if l.isVoidType(resultTypeID) {
+		if inferred := l.inferTypeFromExprShape(&expr); inferred != air.NoType {
+			resultTypeID = inferred
+		}
+	}
 	var resultExpr ast.Expr = ast.NewIdent("nil")
 	var assignTarget ast.Expr
-	if !l.isVoidType(expr.Type) {
+	if !l.isVoidType(resultTypeID) {
 		temp := l.nextTemp()
-		decls, err := l.declareTemp(expr.Type, temp)
+		decls, err := l.declareTemp(resultTypeID, temp)
 		if err != nil {
 			return loweredExpr{}, err
 		}
@@ -2254,7 +2646,7 @@ func (l *lowerer) lowerTryMaybe(fn air.Function, expr air.Expr) (loweredExpr, er
 		}
 	} else {
 		returnExpr := ast.Expr(targetExpr)
-		if fn.Signature.Return != expr.Target.Type {
+		if fn.Signature.Return != targetTypeID {
 			returnType, err := l.goType(fn.Signature.Return)
 			if err != nil {
 				return loweredExpr{}, err
@@ -2275,8 +2667,9 @@ func (l *lowerer) lowerMatchMaybe(fn air.Function, expr air.Expr) (loweredExpr, 
 	if err != nil {
 		return loweredExpr{}, err
 	}
+	targetTypeID := l.resolvedExprType(fn, *expr.Target)
 	targetTemp := l.nextTemp()
-	targetDecls, err := l.declareTemp(expr.Target.Type, targetTemp)
+	targetDecls, err := l.declareTemp(targetTypeID, targetTemp)
 	if err != nil {
 		return loweredExpr{}, err
 	}
@@ -2367,7 +2760,17 @@ func (l *lowerer) lowerSpawnFiber(fn air.Function, expr air.Expr) (loweredExpr, 
 			return loweredExpr{}, fmt.Errorf("invalid fiber function %d", expr.Function)
 		}
 		targetFn := l.program.Functions[expr.Function]
-		targetExpr = &ast.FuncLit{Type: &ast.FuncType{Params: &ast.FieldList{}, Results: &ast.FieldList{List: []*ast.Field{{Type: mustTypeExpr(l, targetFn.Signature.Return)}}}}, Body: &ast.BlockStmt{List: []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent(functionName(l.program, targetFn))}}}}}}
+		if l.isVoidType(targetFn.Signature.Return) {
+			targetExpr = &ast.FuncLit{
+				Type: &ast.FuncType{Params: &ast.FieldList{}, Results: &ast.FieldList{List: []*ast.Field{{Type: voidTypeExpr()}}}},
+				Body: &ast.BlockStmt{List: []ast.Stmt{
+					&ast.ExprStmt{X: &ast.CallExpr{Fun: ast.NewIdent(functionName(l.program, targetFn))}},
+					&ast.ReturnStmt{Results: []ast.Expr{voidValueExpr()}},
+				}},
+			}
+		} else {
+			targetExpr = &ast.FuncLit{Type: &ast.FuncType{Params: &ast.FieldList{}, Results: &ast.FieldList{List: []*ast.Field{{Type: mustTypeExpr(l, targetFn.Signature.Return)}}}}, Body: &ast.BlockStmt{List: []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent(functionName(l.program, targetFn))}}}}}}
+		}
 	}
 	return loweredExpr{stmts: stmts, expr: &ast.CallExpr{Fun: &ast.IndexExpr{X: ast.NewIdent("ardSpawnFiber"), Index: mustTypeExpr(l, l.program.Types[expr.Type-1].Elem)}, Args: []ast.Expr{targetExpr}}}, nil
 }

--- a/compiler/go/names.go
+++ b/compiler/go/names.go
@@ -58,7 +58,7 @@ func typeName(program *air.Program, typ air.TypeInfo) string {
 	}
 	name := sanitizeName(typ.Name)
 	if moduleName == "" {
-		moduleName = "type"
+		moduleName = fmt.Sprintf("type_%d", typ.ID)
 	}
 	if name == "" {
 		name = fmt.Sprintf("type_%d", typ.ID)


### PR DESCRIPTION
## Summary
- fix several Go target lowering edge cases in the Go backend
- strengthen AIR contextual maybe/result typing so nested expressions keep the correct types
- remove the completed TODO item for that AIR typing follow-up

## Testing
- cd compiler && go test ./air -run 'TestLowerContextualMaybeTypesInNestedExpressions|TestLowerContextualResultTypesInNestedExpressions|TestLowerTryOps'
- cd compiler && go test ./go -run 'TestGenerateSourcesUsesExpectedLocalTypeForMaybeNone|TestGenerateSourcesUsesExpectedDefaultTypeForResultOr|TestGenerateSourcesSkipsVoidAssignmentForStatementMatchBranches|TestRunProgramSupportsVoidFiberFunctions|TestTypeNameUsesUniqueFallbackWhenModuleOwnershipIsMissing'
- cd compiler && go run main.go run --target go ../../ranger/server/main.ard