### PR TITLE
feat(go): add project FFI support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,7 @@
 # TODO
+- [ ] Fix Go target `else if` lowering bug
+  * Repro seen in `~/Developer/agent/vaxis-ard/counter`: an `if/else if` chain for key handling lowered so later branches collapsed into a broad fallback; `r` reset was treated as decrement.
+  * Add a compiler regression with an `else if` chain where an early branch, middle branch, and final fallback produce distinct values/effects.
 - [ ] try to improve FFI perf by autocasting args to externs
 - [ ] allow FFI in user land
 - [ ] make duplicate FFI binding registration return an error

--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -1107,6 +1107,7 @@ func (l *lowerer) internType(t checker.Type) (TypeID, error) {
 		}
 	case *checker.ExternType:
 		info.Kind = TypeExtern
+		info.ExternBinding = typ.ExternalBinding
 	case *checker.FunctionDef:
 		info.Kind = TypeFunction
 		for _, param := range typ.Parameters {

--- a/compiler/air/types.go
+++ b/compiler/air/types.go
@@ -101,6 +101,8 @@ type TypeInfo struct {
 	Kind TypeKind
 	Name string
 
+	ExternBinding string
+
 	Elem  TypeID
 	Key   TypeID
 	Value TypeID

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -192,7 +192,7 @@ func derefType(t Type) Type {
 		if !changed {
 			return typ
 		}
-		return &ExternType{Name_: typ.Name_, GenericParams: append([]string(nil), typ.GenericParams...), TypeArgs: newTypeArgs, private: typ.private}
+		return &ExternType{Name_: typ.Name_, GenericParams: append([]string(nil), typ.GenericParams...), TypeArgs: newTypeArgs, ExternalBinding: typ.ExternalBinding, ExternalBindingTarget: typ.ExternalBindingTarget, ExternalBindings: cloneExternalBindings(typ.ExternalBindings), private: typ.private}
 	default:
 		return t
 	}
@@ -922,7 +922,12 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 			for i, param := range s.TypeParams {
 				typeArgs[i] = &TypeVar{name: param}
 			}
-			externType := &ExternType{Name_: s.Name, GenericParams: append([]string(nil), s.TypeParams...), TypeArgs: typeArgs, private: s.Private}
+			bindings := cloneExternalBindings(s.ExternalBindings)
+			if len(bindings) == 0 && s.ExternalBinding != "" {
+				bindings = map[string]string{backend.TargetGo: s.ExternalBinding}
+			}
+			resolvedTarget, resolvedBinding := resolveExternalBindingForTarget(c.options.Target, bindings)
+			externType := &ExternType{Name_: s.Name, GenericParams: append([]string(nil), s.TypeParams...), TypeArgs: typeArgs, ExternalBinding: resolvedBinding, ExternalBindingTarget: resolvedTarget, ExternalBindings: bindings, private: s.Private}
 			c.scope.add(s.Name, externType, false)
 			return &Statement{Stmt: externType}
 		}
@@ -4634,7 +4639,7 @@ func substituteType(t Type, typeMap map[string]Type) Type {
 		for i, typeArg := range typ.TypeArgs {
 			substitutedArgs[i] = substituteType(typeArg, typeMap)
 		}
-		return &ExternType{Name_: typ.Name_, GenericParams: append([]string(nil), typ.GenericParams...), TypeArgs: substitutedArgs, private: typ.private}
+		return &ExternType{Name_: typ.Name_, GenericParams: append([]string(nil), typ.GenericParams...), TypeArgs: substitutedArgs, ExternalBinding: typ.ExternalBinding, ExternalBindingTarget: typ.ExternalBindingTarget, ExternalBindings: cloneExternalBindings(typ.ExternalBindings), private: typ.private}
 	// Handle other compound types
 	default:
 		return t

--- a/compiler/checker/scope.go
+++ b/compiler/checker/scope.go
@@ -368,7 +368,7 @@ func replaceGeneric(t Type, genericName string, concreteType Type) Type {
 		if !changed {
 			return t
 		}
-		return &ExternType{Name_: t.Name_, GenericParams: append([]string(nil), t.GenericParams...), TypeArgs: newTypeArgs, private: t.private}
+		return &ExternType{Name_: t.Name_, GenericParams: append([]string(nil), t.GenericParams...), TypeArgs: newTypeArgs, ExternalBinding: t.ExternalBinding, ExternalBindingTarget: t.ExternalBindingTarget, ExternalBindings: cloneExternalBindings(t.ExternalBindings), private: t.private}
 	default:
 		return t
 	}
@@ -480,7 +480,7 @@ func copyTypeWithTypeVarMap(t Type, typeVarMap map[string]*TypeVar) Type {
 		for i, typeArg := range typ.TypeArgs {
 			newTypeArgs[i] = copyTypeWithTypeVarMap(typeArg, typeVarMap)
 		}
-		return &ExternType{Name_: typ.Name_, GenericParams: append([]string(nil), typ.GenericParams...), TypeArgs: newTypeArgs, private: typ.private}
+		return &ExternType{Name_: typ.Name_, GenericParams: append([]string(nil), typ.GenericParams...), TypeArgs: newTypeArgs, ExternalBinding: typ.ExternalBinding, ExternalBindingTarget: typ.ExternalBindingTarget, ExternalBindings: cloneExternalBindings(typ.ExternalBindings), private: typ.private}
 	default:
 		return t
 	}

--- a/compiler/checker/types.go
+++ b/compiler/checker/types.go
@@ -779,10 +779,13 @@ var Dynamic = &dynamicType{}
 // ExternType represents an opaque type whose values can only be created by FFI.
 // Identity is by name plus any instantiated type arguments.
 type ExternType struct {
-	Name_         string
-	GenericParams []string
-	TypeArgs      []Type
-	private       bool
+	Name_                 string
+	GenericParams         []string
+	TypeArgs              []Type
+	ExternalBinding       string
+	ExternalBindingTarget string
+	ExternalBindings      map[string]string
+	private               bool
 }
 
 func (e *ExternType) String() string {

--- a/compiler/docs/ffi.md
+++ b/compiler/docs/ffi.md
@@ -61,6 +61,45 @@ Examples:
 - `js-browser` prefers `js-browser`, then `js`, then `go`
 - `go` prefers `go`, then `bytecode`
 
+## Go project companions
+
+Project code can provide Go implementations for project-local externs when building with `--target go`.
+The compiler copies Go companion files into the generated Go workspace and calls the binding directly.
+
+Supported companion locations:
+- `ffi.go` at the project root
+- `ffi/*.go` under the project root
+
+Companion files must use `package main` because they are compiled into the generated application package.
+
+Example Ard declaration:
+
+```ard
+extern fn hostname() Str!Str = {
+  go = "Hostname"
+}
+```
+
+Example `ffi.go`:
+
+```go
+package main
+
+import "os"
+
+func Hostname() (string, error) {
+    return os.Hostname()
+}
+```
+
+Project Go FFI currently uses idiomatic direct-call adaptation:
+- scalar/list/map/function arguments pass as their generated Go values
+- `T?` arguments pass as `*T` (`nil` for `None`)
+- `T` returns directly as `T`
+- `T?` expects `*T` (`nil` becomes `None`, non-`nil` becomes `Some`)
+- `Void!Str` expects `error`
+- `T!Str` expects `(T, error)`
+
 ## JavaScript companion modules
 
 JavaScript externs are implemented through companion `.mjs` files rather than per-function module paths embedded in Ard source.

--- a/compiler/docs/ffi.md
+++ b/compiler/docs/ffi.md
@@ -338,6 +338,40 @@ struct Database {
 }
 ```
 
+For the Go target, project extern types can optionally bind to concrete Go type
+expressions. This keeps the Ard type opaque while allowing project FFI functions
+to use precise Go signatures instead of `any`:
+
+```ard
+extern type Vaxis = "*vaxis.Vaxis"
+
+extern fn tui_open() Vaxis!Str = "TuiOpen"
+extern fn tui_close(term: Vaxis) Void!Str = "TuiClose"
+```
+
+```go
+package main
+
+import "git.sr.ht/~rockorager/vaxis"
+
+func TuiOpen() (*vaxis.Vaxis, error) {
+    return vaxis.New(vaxis.Options{})
+}
+
+func TuiClose(vx *vaxis.Vaxis) error {
+    vx.Close()
+    return nil
+}
+```
+
+The binding may also use target-specific binding-block syntax when needed:
+
+```ard
+extern type Vaxis = {
+  go = "*vaxis.Vaxis"
+}
+```
+
 On the Go side, extern types map to `any`. The Go function receives/returns the raw
 Go value (e.g., a `*sqlConnection` pointer) and the runtime wraps it as a Dynamic object:
 

--- a/compiler/formatter/printer.go
+++ b/compiler/formatter/printer.go
@@ -281,7 +281,38 @@ func (p printer) renderExternTypeDeclaration(node *parse.ExternTypeDeclaration) 
 	if node.Private {
 		prefix = "private "
 	}
-	return prefix + "extern type " + node.Name + p.renderTypeParams(node.TypeParams)
+	header := prefix + "extern type " + node.Name + p.renderTypeParams(node.TypeParams)
+	if len(node.ExternalBindings) == 0 {
+		return header
+	}
+	if len(node.ExternalBindings) == 1 && node.ExternalBindings["go"] != "" {
+		binding := node.ExternalBinding
+		if binding == "" {
+			binding = node.ExternalBindings["go"]
+		}
+		return header + " = " + strconv.Quote(binding)
+	}
+
+	keys := make([]string, 0, len(node.ExternalBindings))
+	for key := range node.ExternalBindings {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return externBindingOrder(keys[i]) < externBindingOrder(keys[j]) || (externBindingOrder(keys[i]) == externBindingOrder(keys[j]) && keys[i] < keys[j])
+	})
+
+	var builder strings.Builder
+	builder.WriteString(header)
+	builder.WriteString(" = {\n")
+	for _, key := range keys {
+		builder.WriteString(strings.Repeat(" ", indentWidth))
+		builder.WriteString(key)
+		builder.WriteString(" = ")
+		builder.WriteString(strconv.Quote(node.ExternalBindings[key]))
+		builder.WriteString("\n")
+	}
+	builder.WriteString("}")
+	return builder.String()
 }
 
 func (p printer) renderExternTypeDeclarationDoc(node *parse.ExternTypeDeclaration) doc {

--- a/compiler/go/backend.go
+++ b/compiler/go/backend.go
@@ -14,6 +14,7 @@ import (
 
 type Options struct {
 	PackageName string
+	ProjectInfo *checker.ProjectInfo
 }
 
 func GenerateSources(program *air.Program, options Options) (map[string][]byte, error) {
@@ -32,12 +33,12 @@ func GenerateSources(program *air.Program, options Options) (map[string][]byte, 
 	return out, nil
 }
 
-func RunProgram(program *air.Program, args []string) error {
+func RunProgram(program *air.Program, args []string, projectInfo ...*checker.ProjectInfo) error {
 	workspaceDir, err := artifactWorkspace(inputPathFromCLIArgs(args), "run")
 	if err != nil {
 		return err
 	}
-	if err := writeProgram(workspaceDir, program, Options{PackageName: "main"}); err != nil {
+	if err := writeProgram(workspaceDir, program, Options{PackageName: "main", ProjectInfo: optionalProjectInfo(projectInfo)}); err != nil {
 		return err
 	}
 	binaryPath := filepath.Join(workspaceDir, "ard-program")
@@ -54,12 +55,12 @@ func RunProgram(program *air.Program, args []string) error {
 	return nil
 }
 
-func BuildProgram(program *air.Program, outputPath string) (string, error) {
+func BuildProgram(program *air.Program, outputPath string, projectInfo ...*checker.ProjectInfo) (string, error) {
 	workspaceDir, err := artifactWorkspace(outputPath, "build")
 	if err != nil {
 		return "", err
 	}
-	if err := writeProgram(workspaceDir, program, Options{PackageName: "main"}); err != nil {
+	if err := writeProgram(workspaceDir, program, Options{PackageName: "main", ProjectInfo: optionalProjectInfo(projectInfo)}); err != nil {
 		return "", err
 	}
 	if outputPath == "" {
@@ -86,6 +87,9 @@ func writeProgram(dir string, program *air.Program, options Options) error {
 			return err
 		}
 	}
+	if err := writeProjectFFICompanions(dir, program, options.ProjectInfo); err != nil {
+		return err
+	}
 	goMod := "module generated\n\ngo 1.26.0\n"
 	if moduleRoot, ok := compilerModuleRoot(); ok {
 		goMod += "\nrequire github.com/akonwi/ard v0.0.0\n"
@@ -95,6 +99,13 @@ func writeProgram(dir string, program *air.Program, options Options) error {
 		return err
 	}
 	return nil
+}
+
+func optionalProjectInfo(projectInfo []*checker.ProjectInfo) *checker.ProjectInfo {
+	if len(projectInfo) == 0 {
+		return nil
+	}
+	return projectInfo[0]
 }
 
 func inputPathFromCLIArgs(args []string) string {
@@ -138,6 +149,74 @@ func artifactRootDir(pathHint string) (string, error) {
 		return project.RootPath, nil
 	}
 	return candidate, nil
+}
+
+func writeProjectFFICompanions(dir string, program *air.Program, projectInfo *checker.ProjectInfo) error {
+	if !programUsesProjectFFI(program) {
+		return nil
+	}
+	if projectInfo == nil || strings.TrimSpace(projectInfo.RootPath) == "" {
+		return fmt.Errorf("go target uses project externs but project information is unavailable")
+	}
+	copied := false
+	if err := copyProjectFFIFile(filepath.Join(projectInfo.RootPath, "ffi.go"), filepath.Join(dir, "ffi.go")); err != nil {
+		return err
+	} else if fileExists(filepath.Join(projectInfo.RootPath, "ffi.go")) {
+		copied = true
+	}
+	matches, err := filepath.Glob(filepath.Join(projectInfo.RootPath, "ffi", "*.go"))
+	if err != nil {
+		return err
+	}
+	for _, sourcePath := range matches {
+		name := "ffi_" + filepath.Base(sourcePath)
+		if err := copyProjectFFIFile(sourcePath, filepath.Join(dir, name)); err != nil {
+			return err
+		}
+		copied = true
+	}
+	if !copied {
+		return fmt.Errorf("go target uses project externs but no project Go FFI companion was found at %s or %s", filepath.Join(projectInfo.RootPath, "ffi.go"), filepath.Join(projectInfo.RootPath, "ffi", "*.go"))
+	}
+	return nil
+}
+
+func copyProjectFFIFile(sourcePath, destPath string) error {
+	content, err := os.ReadFile(sourcePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read project Go FFI companion %s: %w", sourcePath, err)
+	}
+	if err := os.WriteFile(destPath, content, 0o644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func programUsesProjectFFI(program *air.Program) bool {
+	if program == nil {
+		return false
+	}
+	for _, ext := range program.Externs {
+		if !externModuleIsStdlib(program, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+func externModuleIsStdlib(program *air.Program, ext air.Extern) bool {
+	if program == nil || int(ext.Module) < 0 || int(ext.Module) >= len(program.Modules) {
+		return false
+	}
+	return strings.HasPrefix(program.Modules[ext.Module].Path, "ard/")
 }
 
 func compilerModuleRoot() (string, bool) {

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -215,6 +215,57 @@ func TestRunProgramSupportsCommonStdlibExterns(t *testing.T) {
 	}
 }
 
+func TestBuildProgramSupportsProjectGoFFIWithTypedExternType(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`
+extern type Buffer = "*bytes.Buffer"
+
+extern fn new_buffer() Buffer!Str = "NewBuffer"
+extern fn buffer_len(buffer: Buffer) Int = "BufferLen"
+
+fn main() Bool {
+	let buffer = new_buffer().expect("buffer")
+	buffer_len(buffer) == 0
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ffi.go"), []byte(`package main
+
+import "bytes"
+
+func NewBuffer() (*bytes.Buffer, error) {
+	return &bytes.Buffer{}, nil
+}
+
+func BufferLen(buffer *bytes.Buffer) int {
+	return buffer.Len()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetGo)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	binaryPath := filepath.Join(dir, "app")
+	builtPath, err := BuildProgram(program, binaryPath, loaded.ProjectInfo)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if err := exec.Command(builtPath).Run(); err != nil {
+		t.Fatalf("run built binary: %v", err)
+	}
+}
+
 func TestBuildProgramSupportsProjectGoFFI(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -2,13 +2,16 @@ package gotarget
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/akonwi/ard/air"
+	"github.com/akonwi/ard/backend"
 	"github.com/akonwi/ard/checker"
+	"github.com/akonwi/ard/frontend"
 	"github.com/akonwi/ard/parse"
 )
 
@@ -209,6 +212,84 @@ func TestRunProgramSupportsCommonStdlibExterns(t *testing.T) {
 
 	if err := RunProgram(program, []string{"ard", "run", "sample.ard"}); err != nil {
 		t.Fatalf("RunProgram error = %v", err)
+	}
+}
+
+func TestBuildProgramSupportsProjectGoFFI(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`
+extern fn lookup(flag: Bool) Str? = {
+	go = "Lookup"
+}
+
+extern fn read_value() Str!Str = {
+	go = "ReadValue"
+}
+
+extern fn mark() Void!Str = {
+	go = "Mark"
+}
+
+extern fn select(input: Str?) Str = {
+	go = "Select"
+}
+
+fn main() Bool {
+	let found = lookup(true)
+	let name = found.or("missing")
+	let value = read_value().expect("read")
+	mark().expect("mark")
+	name == "yes" and value == "ok" and select(found) == "yes"
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ffi.go"), []byte(`package main
+
+func Lookup(flag bool) *string {
+	if !flag {
+		return nil
+	}
+	value := "yes"
+	return &value
+}
+
+func ReadValue() (string, error) {
+	return "ok", nil
+}
+
+func Mark() error {
+	return nil
+}
+
+func Select(input *string) string {
+	if input == nil {
+		return "missing"
+	}
+	return *input
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetGo)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	binaryPath := filepath.Join(dir, "app")
+	builtPath, err := BuildProgram(program, binaryPath, loaded.ProjectInfo)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if err := exec.Command(builtPath).Run(); err != nil {
+		t.Fatalf("run built binary: %v", err)
 	}
 }
 

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -5,11 +5,13 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"path/filepath"
 	"sort"
 	"strings"
 	"unicode"
 
 	"github.com/akonwi/ard/air"
+	"github.com/akonwi/ard/checker"
 )
 
 type loweredExpr struct {
@@ -24,6 +26,7 @@ type lowerer struct {
 	currentImports map[string]string
 	declaredLocals map[air.LocalID]bool
 	runtimeHelpers map[string]bool
+	projectImports map[string]string
 }
 
 func lowerProgram(program *air.Program, options Options) (map[string]*ast.File, error) {
@@ -33,7 +36,7 @@ func lowerProgram(program *air.Program, options Options) (map[string]*ast.File, 
 	if err := air.Validate(program); err != nil {
 		return nil, err
 	}
-	l := &lowerer{program: program, packageName: defaultPackageName(options.PackageName), runtimeHelpers: map[string]bool{}}
+	l := &lowerer{program: program, packageName: defaultPackageName(options.PackageName), runtimeHelpers: map[string]bool{}, projectImports: collectProjectGoImports(options.ProjectInfo)}
 	files := map[string]*ast.File{}
 	rootID, hasRoot := findRootFunction(program)
 	modules := make([]air.Module, 0, len(program.Modules))
@@ -61,6 +64,44 @@ func lowerProgram(program *air.Program, options Options) (map[string]*ast.File, 
 		files[moduleFileName(module)] = file
 	}
 	return files, nil
+}
+
+func collectProjectGoImports(projectInfo *checker.ProjectInfo) map[string]string {
+	imports := map[string]string{}
+	if projectInfo == nil || strings.TrimSpace(projectInfo.RootPath) == "" {
+		return imports
+	}
+	paths := []string{filepath.Join(projectInfo.RootPath, "ffi.go")}
+	matches, err := filepath.Glob(filepath.Join(projectInfo.RootPath, "ffi", "*.go"))
+	if err == nil {
+		paths = append(paths, matches...)
+	}
+	for _, path := range paths {
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+		if err != nil {
+			continue
+		}
+		for _, spec := range file.Imports {
+			if spec.Path == nil {
+				continue
+			}
+			importPath := strings.Trim(spec.Path.Value, "\"")
+			if importPath == "" || importPath == "C" {
+				continue
+			}
+			alias := ""
+			if spec.Name != nil {
+				if spec.Name.Name == "." || spec.Name.Name == "_" {
+					continue
+				}
+				alias = spec.Name.Name
+			} else {
+				alias = filepath.Base(importPath)
+			}
+			imports[alias] = importPath
+		}
+	}
+	return imports
 }
 
 func (l *lowerer) lowerModule(module air.Module) (*ast.File, error) {
@@ -149,6 +190,23 @@ func (l *lowerer) usedImports(decls []ast.Decl) map[string]string {
 
 func (l *lowerer) markRuntimeHelper(name string) {
 	l.runtimeHelpers[name] = true
+}
+
+func (l *lowerer) registerProjectImportsForGoType(expr ast.Expr) {
+	ast.Inspect(expr, func(node ast.Node) bool {
+		selector, ok := node.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := selector.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if path, ok := l.projectImports[ident.Name]; ok && path != "" {
+			l.currentImports[ident.Name] = path
+		}
+		return true
+	})
 }
 
 func (l *lowerer) runtimePreludeDecls() []ast.Decl {
@@ -1401,7 +1459,17 @@ func (l *lowerer) goType(typeID air.TypeID) (ast.Expr, error) {
 		return ast.NewIdent(typeName(l.program, info)), nil
 	case air.TypeUnion:
 		return ast.NewIdent(typeName(l.program, info)), nil
-	case air.TypeDynamic, air.TypeExtern, air.TypeTraitObject:
+	case air.TypeExtern:
+		if strings.TrimSpace(info.ExternBinding) != "" {
+			typ, err := parser.ParseExpr(info.ExternBinding)
+			if err != nil {
+				return nil, fmt.Errorf("invalid go extern type binding %q for %s: %w", info.ExternBinding, info.Name, err)
+			}
+			l.registerProjectImportsForGoType(typ)
+			return typ, nil
+		}
+		return ast.NewIdent("any"), nil
+	case air.TypeDynamic, air.TypeTraitObject:
 		return ast.NewIdent("any"), nil
 	default:
 		return nil, fmt.Errorf("unsupported Go type kind %d", info.Kind)

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -3287,6 +3287,38 @@ func (l *lowerer) goFieldName(typ air.TypeInfo, fieldName string) string {
 	return fieldName
 }
 
+func (l *lowerer) wrapProjectMaybeCall(maybeTypeID air.TypeID, call ast.Expr) (loweredExpr, error) {
+	if !validTypeID(l.program, maybeTypeID) {
+		return loweredExpr{}, fmt.Errorf("invalid maybe type id %d", maybeTypeID)
+	}
+	info := l.program.Types[maybeTypeID-1]
+	if info.Kind != air.TypeMaybe {
+		return loweredExpr{}, fmt.Errorf("expected maybe type, got kind %d", info.Kind)
+	}
+	elemType, err := l.goType(info.Elem)
+	if err != nil {
+		return loweredExpr{}, err
+	}
+	maybeType, err := l.goType(maybeTypeID)
+	if err != nil {
+		return loweredExpr{}, err
+	}
+	ptrTemp := l.nextTemp()
+	valueTemp := l.nextTemp()
+	stmts := []ast.Stmt{
+		&ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(ptrTemp)}, Type: &ast.StarExpr{X: elemType}}}}},
+		&ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(ptrTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{call}},
+		&ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(valueTemp)}, Type: elemType}}}},
+		&ast.IfStmt{Cond: &ast.BinaryExpr{X: ast.NewIdent(ptrTemp), Op: token.NEQ, Y: ast.NewIdent("nil")}, Body: &ast.BlockStmt{List: []ast.Stmt{
+			&ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(valueTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{&ast.StarExpr{X: ast.NewIdent(ptrTemp)}}},
+		}}},
+	}
+	return loweredExpr{stmts: stmts, expr: &ast.CompositeLit{Type: maybeType, Elts: []ast.Expr{
+		&ast.KeyValueExpr{Key: ast.NewIdent("Value"), Value: ast.NewIdent(valueTemp)},
+		&ast.KeyValueExpr{Key: ast.NewIdent("Some"), Value: &ast.BinaryExpr{X: ast.NewIdent(ptrTemp), Op: token.NEQ, Y: ast.NewIdent("nil")}},
+	}}}, nil
+}
+
 func (l *lowerer) wrapStdlibMaybeCall(maybeTypeID air.TypeID, call ast.Expr) (loweredExpr, error) {
 	maybeType, err := l.goType(maybeTypeID)
 	if err != nil {
@@ -3639,6 +3671,9 @@ func (l *lowerer) lowerExternCall(fn air.Function, expr air.Expr) (loweredExpr, 
 	binding := ext.Name
 	if goBinding, ok := ext.Bindings["go"]; ok && goBinding != "" {
 		binding = goBinding
+	}
+	if !externModuleIsStdlib(l.program, ext) {
+		return l.lowerProjectExternCall(ext, binding, args, stmts, expr.Type)
 	}
 	switch binding {
 	case "Print":
@@ -4013,6 +4048,109 @@ func (l *lowerer) lowerExternCall(fn air.Function, expr air.Expr) (loweredExpr, 
 	default:
 		return loweredExpr{}, fmt.Errorf("unsupported go extern binding %q", binding)
 	}
+}
+
+func (l *lowerer) adaptProjectExternArgs(signature air.Signature, args []ast.Expr) ([]ast.Expr, []ast.Stmt, error) {
+	if len(signature.Params) != len(args) {
+		return nil, nil, fmt.Errorf("project extern argument count mismatch: signature has %d params, call has %d args", len(signature.Params), len(args))
+	}
+	adapted := append([]ast.Expr(nil), args...)
+	stmts := []ast.Stmt{}
+	for i, param := range signature.Params {
+		if !validTypeID(l.program, param.Type) {
+			continue
+		}
+		info := l.program.Types[param.Type-1]
+		if info.Kind != air.TypeMaybe {
+			continue
+		}
+		arg, err := l.projectMaybeArgPointer(param.Type, adapted[i])
+		if err != nil {
+			return nil, nil, err
+		}
+		stmts = append(stmts, arg.stmts...)
+		adapted[i] = arg.expr
+	}
+	return adapted, stmts, nil
+}
+
+func (l *lowerer) projectMaybeArgPointer(maybeTypeID air.TypeID, expr ast.Expr) (loweredExpr, error) {
+	info := l.program.Types[maybeTypeID-1]
+	elemType, err := l.goType(info.Elem)
+	if err != nil {
+		return loweredExpr{}, err
+	}
+	maybeType, err := l.goType(maybeTypeID)
+	if err != nil {
+		return loweredExpr{}, err
+	}
+	maybeTemp := l.nextTemp()
+	ptrTemp := l.nextTemp()
+	stmts := []ast.Stmt{
+		&ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(maybeTemp)}, Type: maybeType}}}},
+		&ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(maybeTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{expr}},
+		&ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(ptrTemp)}, Type: &ast.StarExpr{X: elemType}}}}},
+		&ast.IfStmt{Cond: &ast.SelectorExpr{X: ast.NewIdent(maybeTemp), Sel: ast.NewIdent("Some")}, Body: &ast.BlockStmt{List: []ast.Stmt{
+			&ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(ptrTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{&ast.UnaryExpr{Op: token.AND, X: &ast.SelectorExpr{X: ast.NewIdent(maybeTemp), Sel: ast.NewIdent("Value")}}}},
+		}}},
+	}
+	return loweredExpr{stmts: stmts, expr: ast.NewIdent(ptrTemp)}, nil
+}
+
+func (l *lowerer) lowerProjectExternCall(ext air.Extern, binding string, args []ast.Expr, stmts []ast.Stmt, returnTypeID air.TypeID) (loweredExpr, error) {
+	adaptedArgs, argStmts, err := l.adaptProjectExternArgs(ext.Signature, args)
+	if err != nil {
+		return loweredExpr{}, err
+	}
+	stmts = append(stmts, argStmts...)
+	callee, err := goBindingExpr(binding)
+	if err != nil {
+		return loweredExpr{}, err
+	}
+	call := &ast.CallExpr{Fun: callee, Args: adaptedArgs}
+	if !validTypeID(l.program, returnTypeID) {
+		return loweredExpr{stmts: stmts, expr: call}, nil
+	}
+	returnType := l.program.Types[returnTypeID-1]
+	switch returnType.Kind {
+	case air.TypeVoid:
+		return loweredExpr{stmts: stmts, expr: call}, nil
+	case air.TypeMaybe:
+		wrapped, err := l.wrapProjectMaybeCall(returnTypeID, call)
+		if err != nil {
+			return loweredExpr{}, err
+		}
+		wrapped.stmts = append(stmts, wrapped.stmts...)
+		return wrapped, nil
+	case air.TypeResult:
+		if validTypeID(l.program, returnType.Value) && l.program.Types[returnType.Value-1].Kind == air.TypeVoid {
+			wrapped, err := l.wrapErrorCall(returnTypeID, call)
+			if err != nil {
+				return loweredExpr{}, err
+			}
+			wrapped.stmts = append(stmts, wrapped.stmts...)
+			return wrapped, nil
+		}
+		wrapped, err := l.wrapValueErrorCall(returnTypeID, call)
+		if err != nil {
+			return loweredExpr{}, err
+		}
+		wrapped.stmts = append(stmts, wrapped.stmts...)
+		return wrapped, nil
+	default:
+		return loweredExpr{stmts: stmts, expr: call}, nil
+	}
+}
+
+func goBindingExpr(binding string) (ast.Expr, error) {
+	if strings.TrimSpace(binding) == "" {
+		return nil, fmt.Errorf("empty go extern binding")
+	}
+	expr, err := parser.ParseExpr(binding)
+	if err != nil {
+		return nil, fmt.Errorf("invalid go extern binding %q: %w", binding, err)
+	}
+	return expr, nil
 }
 
 func isVoidExpr(expr ast.Expr) bool {

--- a/compiler/main.go
+++ b/compiler/main.go
@@ -92,10 +92,10 @@ func main() {
 			case backend.TargetGo:
 				profile := newPipelineProfile("run go")
 				defer profile.Print()
-				var module checker.Module
+				var loaded *frontend.LoadResult
 				if err := profile.Time("frontend.load_module", func() error {
 					var loadErr error
-					module, loadErr = loadModule(inputPath, target)
+					loaded, loadErr = frontend.LoadModule(inputPath, target)
 					return loadErr
 				}); err != nil {
 					os.Exit(1)
@@ -103,13 +103,13 @@ func main() {
 				var program *air.Program
 				if err := profile.Time("air.lower", func() error {
 					var lowerErr error
-					program, lowerErr = air.Lower(module)
+					program, lowerErr = air.Lower(loaded.Module)
 					return lowerErr
 				}); err != nil {
 					fmt.Println(err)
 					os.Exit(1)
 				}
-				if err := gotarget.RunProgram(program, os.Args); err != nil {
+				if err := gotarget.RunProgram(program, os.Args, loaded.ProjectInfo); err != nil {
 					fmt.Println(err)
 					os.Exit(1)
 				}
@@ -713,10 +713,10 @@ func buildJSProgram(inputPath string, outputPath string, target string) (string,
 func buildGoBinary(inputPath string, outputPath string, target string) (string, error) {
 	profile := newPipelineProfile("build go")
 	defer profile.Print()
-	var module checker.Module
+	var loaded *frontend.LoadResult
 	if err := profile.Time("frontend.load_module", func() error {
 		var loadErr error
-		module, loadErr = loadModule(inputPath, target)
+		loaded, loadErr = frontend.LoadModule(inputPath, target)
 		return loadErr
 	}); err != nil {
 		return "", err
@@ -724,7 +724,7 @@ func buildGoBinary(inputPath string, outputPath string, target string) (string, 
 	var program *air.Program
 	if err := profile.Time("air.lower", func() error {
 		var lowerErr error
-		program, lowerErr = air.Lower(module)
+		program, lowerErr = air.Lower(loaded.Module)
 		return lowerErr
 	}); err != nil {
 		return "", err
@@ -743,7 +743,7 @@ func buildGoBinary(inputPath string, outputPath string, target string) (string, 
 	var builtPath string
 	if err := profile.Time("go.build", func() error {
 		var buildErr error
-		builtPath, buildErr = gotarget.BuildProgram(program, outputPath)
+		builtPath, buildErr = gotarget.BuildProgram(program, outputPath, loaded.ProjectInfo)
 		return buildErr
 	}); err != nil {
 		return "", err

--- a/compiler/parse/ast.go
+++ b/compiler/parse/ast.go
@@ -317,12 +317,29 @@ func (f FunctionDeclaration) String() string {
 
 type ExternTypeDeclaration struct {
 	Location
-	Name       string
-	TypeParams []string
-	Private    bool
+	Name             string
+	TypeParams       []string
+	ExternalBinding  string
+	ExternalBindings map[string]string
+	Private          bool
 }
 
 func (e ExternTypeDeclaration) String() string {
+	if len(e.ExternalBindings) > 1 || (len(e.ExternalBindings) == 1 && e.ExternalBindings["go"] == "") {
+		keys := make([]string, 0, len(e.ExternalBindings))
+		for key := range e.ExternalBindings {
+			keys = append(keys, key)
+		}
+		slices.Sort(keys)
+		parts := make([]string, 0, len(keys))
+		for _, key := range keys {
+			parts = append(parts, fmt.Sprintf("%s = %q", key, e.ExternalBindings[key]))
+		}
+		return fmt.Sprintf("extern type %s%s = { %s }", e.Name, renderTypeParams(e.TypeParams), strings.Join(parts, ", "))
+	}
+	if e.ExternalBinding != "" {
+		return fmt.Sprintf("extern type %s%s = %q", e.Name, renderTypeParams(e.TypeParams), e.ExternalBinding)
+	}
 	return fmt.Sprintf("extern type %s%s", e.Name, renderTypeParams(e.TypeParams))
 }
 

--- a/compiler/parse/functions_test.go
+++ b/compiler/parse/functions_test.go
@@ -44,6 +44,20 @@ func TestExternTypeDeclaration(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "Extern type with Go binding",
+			input: `extern type Vaxis = "*vaxis.Vaxis"`,
+			output: Program{
+				Imports: []Import{},
+				Statements: []Statement{
+					&ExternTypeDeclaration{
+						Name:             "Vaxis",
+						ExternalBinding:  "*vaxis.Vaxis",
+						ExternalBindings: map[string]string{"go": "*vaxis.Vaxis"},
+					},
+				},
+			},
+		},
 	}
 	runTests(t, tests)
 }

--- a/compiler/parse/parser.go
+++ b/compiler/parse/parser.go
@@ -2175,10 +2175,35 @@ func (p *parser) functionDef(asMethod bool, isTest bool) (Statement, error) {
 			endRow = endToken.line
 			endCol = endToken.column + len(endToken.text)
 		}
+		externalBinding := ""
+		var externalBindings map[string]string
+		if p.match(equal) {
+			if p.check(string_) {
+				bindingToken := p.advance()
+				externalBinding = trimQuotedString(bindingToken.text)
+				externalBindings = map[string]string{"go": externalBinding}
+				endRow = bindingToken.line
+				endCol = bindingToken.column + len(bindingToken.text)
+			} else if p.match(left_brace) {
+				bindings, err := p.parseExternalBindingBlock()
+				if err != nil {
+					return nil, err
+				}
+				externalBindings = bindings
+				externalBinding = bindings["go"]
+				endToken := p.previous()
+				endRow = endToken.line
+				endCol = endToken.column + len(endToken.text)
+			} else {
+				return nil, p.makeError(p.peek(), "Expected string literal or binding block for extern type binding")
+			}
+		}
 		return &ExternTypeDeclaration{
-			Name:       nameToken.text,
-			TypeParams: typeParams,
-			Private:    private,
+			Name:             nameToken.text,
+			TypeParams:       typeParams,
+			ExternalBinding:  externalBinding,
+			ExternalBindings: externalBindings,
+			Private:          private,
 			Location: Location{
 				Start: Point{Row: keyword.line, Col: keyword.column},
 				End:   Point{Row: endRow, Col: endCol},


### PR DESCRIPTION
## Summary
- add project Go FFI companions via `ffi.go` and `ffi/*.go`
- lower project externs to direct Go calls with Maybe/Result adaptation
- support typed Go extern type bindings like `extern type Terminal = "*vaxis.Vaxis"`
- auto-import package aliases used in typed extern bindings from project FFI companion imports
- document the project Go FFI model and add regression coverage

## Validation
- `cd compiler && go test ./parse ./checker ./air ./formatter ./go`
- `cd compiler && go build`
- Vaxis demo smoke checks outside this repo:
  - `cd ~/Developer/agent/vaxis-ard/counter && ./test_counter.py`
  - `cd ~/Developer/agent/vaxis-ard/tic-tac-toe && ./test_tic_tac_toe.py`
  - `cd ~/Developer/agent/vaxis-ard/todo && ard build --target go --out todo main.ard`