### PR TITLE
fix(checker): preserve else-if chains

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,4 @@
 # TODO
-- [ ] Fix Go target `else if` lowering bug
-  * Repro seen in `~/Developer/agent/vaxis-ard/counter`: an `if/else if` chain for key handling lowered so later branches collapsed into a broad fallback; `r` reset was treated as decrement.
-  * Add a compiler regression with an `else if` chain where an early branch, middle branch, and final fallback produce distinct values/effects.
 - [ ] try to improve FFI perf by autocasting args to externs
 - [ ] allow FFI in user land
 - [ ] make duplicate FFI binding registration return an error

--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -2741,53 +2741,39 @@ func (fl *functionLowerer) lowerConditionalCases(typeID TypeID, cases []checker.
 }
 
 func (fl *functionLowerer) lowerIf(typeID TypeID, expr *checker.If) (*Expr, error) {
-	condition, err := fl.lowerExpr(expr.Condition)
-	if err != nil {
-		return nil, err
+	if len(expr.Branches) == 0 {
+		return nil, fmt.Errorf("if expression missing branches")
 	}
-	thenBlock, err := fl.lowerBlockWithDefault(expr.Body.Stmts, typeID)
-	if err != nil {
-		return nil, err
-	}
-	elseBlock, err := fl.lowerElse(expr, typeID)
-	if err != nil {
-		return nil, err
-	}
-	return &Expr{Kind: ExprIf, Type: typeID, Condition: condition, Then: thenBlock, Else: elseBlock}, nil
+	return fl.lowerIfBranches(typeID, expr.Branches, expr.Else)
 }
 
-func (fl *functionLowerer) lowerElse(expr *checker.If, defaultType TypeID) (Block, error) {
-	if expr.ElseIf != nil {
-		condition, err := fl.lowerExpr(expr.ElseIf.Condition)
-		if err != nil {
-			return Block{}, err
-		}
-		thenBlock, err := fl.lowerBlockWithDefault(expr.ElseIf.Body.Stmts, defaultType)
-		if err != nil {
-			return Block{}, err
-		}
-		elseBlock, err := fl.lowerElse(expr.ElseIf, defaultType)
-		if err != nil {
-			return Block{}, err
-		}
-		if expr.Else != nil {
-			elseBlock, err = fl.lowerBlockWithDefault(expr.Else.Stmts, defaultType)
-			if err != nil {
-				return Block{}, err
-			}
-		}
-		return Block{Result: &Expr{
-			Kind:      ExprIf,
-			Type:      defaultType,
-			Condition: condition,
-			Then:      thenBlock,
-			Else:      elseBlock,
-		}}, nil
+func (fl *functionLowerer) lowerIfBranches(typeID TypeID, branches []checker.IfBranch, elseBlock *checker.Block) (*Expr, error) {
+	if len(branches) == 0 {
+		return nil, fmt.Errorf("if expression missing branches")
 	}
-	if expr.Else != nil {
-		return fl.lowerBlockWithDefault(expr.Else.Stmts, defaultType)
+	branch := branches[0]
+	condition, err := fl.lowerExpr(branch.Condition)
+	if err != nil {
+		return nil, err
 	}
-	return Block{}, nil
+	thenBlock, err := fl.lowerBlockWithDefault(branch.Body.Stmts, typeID)
+	if err != nil {
+		return nil, err
+	}
+	var airElse Block
+	if len(branches) > 1 {
+		nested, err := fl.lowerIfBranches(typeID, branches[1:], elseBlock)
+		if err != nil {
+			return nil, err
+		}
+		airElse = Block{Result: nested}
+	} else if elseBlock != nil {
+		airElse, err = fl.lowerBlockWithDefault(elseBlock.Stmts, typeID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Expr{Kind: ExprIf, Type: typeID, Condition: condition, Then: thenBlock, Else: airElse}, nil
 }
 
 func (fl *functionLowerer) lowerResultConstructor(kind ExprKind, typeID TypeID, call *checker.ModuleFunctionCall) (*Expr, error) {

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -2142,6 +2142,49 @@ func (c *Checker) extractGenericBindingsFromSpecializedStruct(originalDef, speci
 	return bindings
 }
 
+func (c *Checker) checkIfChain(s *parse.IfStatement) Expression {
+	if s == nil || s.Condition == nil {
+		return nil
+	}
+	branches := []IfBranch{}
+	var elseBlock *Block
+	var referenceType Type
+	current := s
+	for current != nil {
+		if current.Condition == nil {
+			block := c.checkBlock(current.Body, nil)
+			if referenceType != nil && !block.Type().equal(referenceType) {
+				c.addError("All branches must have the same result type", current.GetLocation())
+				return nil
+			}
+			elseBlock = block
+			break
+		}
+		condition := c.checkExpr(current.Condition)
+		if condition == nil {
+			return nil
+		}
+		if condition.Type() != Bool {
+			c.addError("If conditions must be boolean expressions", current.GetLocation())
+			return nil
+		}
+		body := c.checkBlock(current.Body, nil)
+		if referenceType == nil {
+			referenceType = body.Type()
+		} else if !body.Type().equal(referenceType) {
+			c.addError("All branches must have the same result type", current.GetLocation())
+			return nil
+		}
+		branches = append(branches, IfBranch{Condition: condition, Body: body})
+		next, ok := current.Else.(*parse.IfStatement)
+		if !ok {
+			break
+		}
+		current = next
+	}
+	return &If{Branches: branches, Else: elseBlock}
+}
+
 func (c *Checker) checkExpr(expr parse.Expression) Expression {
 	if c.halted {
 		return nil
@@ -3022,65 +3065,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 			}
 		}
 	case *parse.IfStatement:
-		{
-			cond := c.checkExpr(s.Condition)
-			if cond == nil {
-				return nil
-			}
-			if cond.Type() != Bool {
-				c.addError("If conditions must be boolean expressions", s.GetLocation())
-				return nil
-			}
-
-			body := c.checkBlock(s.Body, nil)
-
-			var elseIf *If
-			var elseBody *Block
-
-			// does not recurse. reach into AST for each level since it's fixed
-			if s.Else != nil {
-				next := s.Else.(*parse.IfStatement)
-				if next.Condition != nil {
-					cond := c.checkExpr(next.Condition)
-					if cond == nil {
-						return nil
-					}
-					if cond.Type() != Bool {
-						c.addError("If conditions must be boolean expressions", next.GetLocation())
-						return nil
-					}
-
-					elseIfBody := c.checkBlock(next.Body, nil)
-					if elseIfBody.Type() != body.Type() {
-						c.addError("All branches must have the same result type", next.GetLocation())
-						return nil
-					}
-
-					elseIf = &If{
-						Condition: cond,
-						Body:      elseIfBody,
-					}
-
-					if next, ok := next.Else.(*parse.IfStatement); ok {
-						elseBody = c.checkBlock(next.Body, nil)
-					}
-				} else {
-					b := c.checkBlock(next.Body, nil)
-					if b.Type() != body.Type() {
-						c.addError("All branches must have the same result type", next.GetLocation())
-						return nil
-					}
-					elseBody = b
-				}
-			}
-
-			return &If{
-				Condition: cond,
-				Body:      body,
-				ElseIf:    elseIf,
-				Else:      elseBody,
-			}
-		}
+		return c.checkIfChain(s)
 	case *parse.FunctionDeclaration:
 		return c.checkFunction(s, nil)
 	case *parse.ExternalFunction:

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -1038,12 +1038,14 @@ func TestIfStatements(t *testing.T) {
 					},
 					{
 						Expr: &checker.If{
-							Condition: &checker.Variable{},
-							Body: &checker.Block{
-								Stmts: []checker.Statement{
-									{Expr: &checker.StrLiteral{"on"}},
+							Branches: []checker.IfBranch{{
+								Condition: &checker.Variable{},
+								Body: &checker.Block{
+									Stmts: []checker.Statement{
+										{Expr: &checker.StrLiteral{"on"}},
+									},
 								},
-							},
+							}},
 						},
 					},
 				},
@@ -1073,12 +1075,14 @@ func TestIfStatements(t *testing.T) {
 				Statements: []checker.Statement{
 					{
 						Expr: &checker.If{
-							Condition: &checker.BoolLiteral{true},
-							Body: &checker.Block{
-								Stmts: []checker.Statement{
-									{Expr: &checker.StrLiteral{"bar"}},
+							Branches: []checker.IfBranch{{
+								Condition: &checker.BoolLiteral{true},
+								Body: &checker.Block{
+									Stmts: []checker.Statement{
+										{Expr: &checker.StrLiteral{"bar"}},
+									},
 								},
-							},
+							}},
 							Else: &checker.Block{
 								Stmts: []checker.Statement{
 									{Expr: &checker.StrLiteral{"baz"}},
@@ -1104,17 +1108,21 @@ func TestIfStatements(t *testing.T) {
 				Statements: []checker.Statement{
 					{
 						Expr: &checker.If{
-							Condition: &checker.BoolLiteral{true},
-							Body: &checker.Block{
-								Stmts: []checker.Statement{
-									{Expr: &checker.StrLiteral{"bar"}},
+							Branches: []checker.IfBranch{
+								{
+									Condition: &checker.BoolLiteral{true},
+									Body: &checker.Block{
+										Stmts: []checker.Statement{
+											{Expr: &checker.StrLiteral{"bar"}},
+										},
+									},
 								},
-							},
-							ElseIf: &checker.If{
-								Condition: &checker.BoolLiteral{false},
-								Body: &checker.Block{
-									Stmts: []checker.Statement{
-										{Expr: &checker.StrLiteral{"baz"}},
+								{
+									Condition: &checker.BoolLiteral{false},
+									Body: &checker.Block{
+										Stmts: []checker.Statement{
+											{Expr: &checker.StrLiteral{"baz"}},
+										},
 									},
 								},
 							},

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -844,15 +844,21 @@ func (b *Block) Type() Type {
 	return Void
 }
 
-type If struct {
+type IfBranch struct {
 	Condition Expression
 	Body      *Block
-	ElseIf    *If
-	Else      *Block
+}
+
+type If struct {
+	Branches []IfBranch
+	Else     *Block
 }
 
 func (i *If) Type() Type {
-	return i.Body.Type()
+	if len(i.Branches) == 0 || i.Branches[0].Body == nil {
+		return Void
+	}
+	return i.Branches[0].Body.Type()
 }
 
 type ForIntRange struct {

--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -61,6 +61,30 @@ func TestGoTargetParityCoreCorpus(t *testing.T) {
 			`,
 		},
 		{
+			name: "if else if chain preserves all conditions",
+			input: `
+				fn classify(key: Str) Int {
+					mut result = 0
+					if key == "q" {
+						result = 1
+					} else if key == "up" {
+						result = 2
+					} else if key == "down" {
+						result = 3
+					} else if key == "r" {
+						result = 4
+					} else {
+						result = 5
+					}
+					result
+				}
+
+				fn main() Bool {
+					classify("q") == 1 and classify("up") == 2 and classify("down") == 3 and classify("r") == 4 and classify("?") == 5
+				}
+			`,
+		},
+		{
 			name: "inline block expression",
 			input: `
 				fn main() Int {


### PR DESCRIPTION
## Summary
- flatten checked if/else-if chains into branch lists instead of nested ElseIf nodes
- lower flat checked branches back into AIR nested if expressions
- add Go parity regression covering every branch in a multi-level else-if chain
- remove completed TODO item for the discovered else-if bug

## Validation
- `cd compiler && go test ./parse ./checker ./air ./go -run 'TestGoTargetParityCoreCorpus/if_else_if_chain_preserves_all_conditions|TestGoTargetParityCoreCorpus/if_else_if_else|TestIf|TestLowerIfExpression'`
- `cd compiler && go test ./checker ./air ./go -run 'TestGoTargetParityCoreCorpus/if_else_if|TestExternType|TestLowerIf'`
- `cd compiler && go build`