### PR TITLE
fix(go): classify stdlib extern methods by binding

### DIFF
--- a/compiler/go/backend.go
+++ b/compiler/go/backend.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/akonwi/ard/air"
 	"github.com/akonwi/ard/checker"
+	stdlibffi "github.com/akonwi/ard/std_lib/ffi"
 )
 
 type Options struct {
@@ -213,10 +214,30 @@ func programUsesProjectFFI(program *air.Program) bool {
 }
 
 func externModuleIsStdlib(program *air.Program, ext air.Extern) bool {
-	if program == nil || int(ext.Module) < 0 || int(ext.Module) >= len(program.Modules) {
-		return false
+	if program != nil && int(ext.Module) >= 0 && int(ext.Module) < len(program.Modules) && strings.HasPrefix(program.Modules[ext.Module].Path, "ard/") {
+		return true
 	}
-	return strings.HasPrefix(program.Modules[ext.Module].Path, "ard/")
+	return stdlibGoBinding(goExternBinding(ext))
+}
+
+func goExternBinding(ext air.Extern) string {
+	if binding := ext.Bindings["go"]; binding != "" {
+		return binding
+	}
+	return ext.Name
+}
+
+var stdlibGoBindings = func() map[string]struct{} {
+	bindings := map[string]struct{}{}
+	for binding := range stdlibffi.HostFunctions {
+		bindings[binding] = struct{}{}
+	}
+	return bindings
+}()
+
+func stdlibGoBinding(binding string) bool {
+	_, ok := stdlibGoBindings[binding]
+	return ok
 }
 
 func compilerModuleRoot() (string, bool) {

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -344,6 +344,38 @@ func Select(input *string) string {
 	}
 }
 
+func TestWriteProgramDoesNotRequireProjectFFIForStdlibExternMethods(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`
+use ard/sql
+
+fn close(db: sql::Database) Void!Str {
+	db.close()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetGo)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	workspace := filepath.Join(dir, "workspace")
+	if err := os.Mkdir(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeProgram(workspace, program, Options{PackageName: "main", ProjectInfo: loaded.ProjectInfo}); err != nil {
+		t.Fatalf("write program: %v", err)
+	}
+}
+
 func TestGenerateSourcesUsesExpectedLocalTypeForMaybeNone(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/maybe


### PR DESCRIPTION
## Summary
- treat known stdlib Go FFI bindings as stdlib externs even when AIR records the caller module
- avoid requiring project ffi.go for stdlib method calls
- add regression coverage using ard/sql method lowering

## Validation
- cd compiler && go test ./go
- cd compiler && go run main.go run ../../ranger/server/main.ard (now reaches expected DATABASE_URL runtime panic instead of invalid project FFI error)