### PR TITLE
fix(js): write default builds under ard-out

### DIFF
--- a/compiler/main.go
+++ b/compiler/main.go
@@ -699,6 +699,7 @@ func buildJSProgram(inputPath string, outputPath string, target string) (string,
 	}); err != nil {
 		return "", err
 	}
+	outputPath = resolveJSBuildOutputPath(inputPath, outputPath, target, loaded.ProjectInfo)
 	var builtPath string
 	if err := profile.Time("javascript.build", func() error {
 		var buildErr error
@@ -708,6 +709,27 @@ func buildJSProgram(inputPath string, outputPath string, target string) (string,
 		return "", err
 	}
 	return builtPath, nil
+}
+
+func resolveJSBuildOutputPath(inputPath string, outputPath string, target string, projectInfo *checker.ProjectInfo) string {
+	defaultOutput := filepath.Base(strings.TrimSuffix(inputPath, filepath.Ext(inputPath)))
+	if defaultOutput == "" || defaultOutput == "." || defaultOutput == string(filepath.Separator) {
+		defaultOutput = "main"
+	}
+	if outputPath != defaultOutput {
+		return outputPath
+	}
+	rootDir := ""
+	if projectInfo != nil {
+		rootDir = strings.TrimSpace(projectInfo.RootPath)
+	}
+	if rootDir == "" {
+		rootDir = filepath.Dir(inputPath)
+		if rootDir == "" || rootDir == "." {
+			rootDir = "."
+		}
+	}
+	return filepath.Join(rootDir, "ard-out", "js", target, "build", defaultOutput+".mjs")
 }
 
 func buildGoBinary(inputPath string, outputPath string, target string) (string, error) {

--- a/compiler/main_test.go
+++ b/compiler/main_test.go
@@ -535,6 +535,32 @@ func TestParseBuildArgs(t *testing.T) {
 	}
 }
 
+func TestBuildJSProgramDefaultWritesArdOut(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sourcePath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(sourcePath, []byte(`fn main() { "ok" }`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	builtPath, err := buildJSProgram(sourcePath, "main", backend.TargetJSBrowser)
+	if err != nil {
+		t.Fatalf("buildJSProgram error = %v", err)
+	}
+	want := filepath.Join(dir, "ard-out", "js", backend.TargetJSBrowser, "build", "main.mjs")
+	if builtPath != want {
+		t.Fatalf("built path = %q, want %q", builtPath, want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("expected generated root module: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(want), "ard.prelude.mjs")); err != nil {
+		t.Fatalf("expected generated prelude next to root module: %v", err)
+	}
+}
+
 func TestParseFormatArgs(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary
- route default JavaScript build output into project ard-out/js/<target>/build
- give default JS builds a .mjs root module path instead of writing extensionless files in the cwd
- add a regression covering the default js-browser build layout

## Validation
- cd compiler && go test . ./javascript
- cd compiler && go install
- cd ../ard-js && npm test