### PR TITLE
fix(js): improve target module ergonomics

### DIFF
--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -924,7 +924,7 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 			}
 			bindings := cloneExternalBindings(s.ExternalBindings)
 			if len(bindings) == 0 && s.ExternalBinding != "" {
-				bindings = map[string]string{backend.TargetGo: s.ExternalBinding}
+				bindings = map[string]string{shorthandExternalBindingTarget(c.options.Target): s.ExternalBinding}
 			}
 			resolvedTarget, resolvedBinding := resolveExternalBindingForTarget(c.options.Target, bindings)
 			externType := &ExternType{Name_: s.Name, GenericParams: append([]string(nil), s.TypeParams...), TypeArgs: typeArgs, ExternalBinding: resolvedBinding, ExternalBindingTarget: resolvedTarget, ExternalBindings: bindings, private: s.Private}
@@ -4363,6 +4363,15 @@ func (c *Checker) checkExprAs(expr parse.Expression, expectedType Type) Expressi
 	return checked
 }
 
+func shorthandExternalBindingTarget(target string) string {
+	switch target {
+	case backend.TargetJSBrowser, backend.TargetJSServer:
+		return target
+	default:
+		return backend.TargetGo
+	}
+}
+
 func resolveExternalBindingForTarget(target string, bindings map[string]string) (string, string) {
 	if len(bindings) == 0 {
 		return "", ""
@@ -4417,7 +4426,7 @@ func (c *Checker) checkExternalFunction(def *parse.ExternalFunction) *ExternalFu
 
 	bindings := cloneExternalBindings(def.ExternalBindings)
 	if len(bindings) == 0 && def.ExternalBinding != "" {
-		bindings = map[string]string{backend.TargetGo: def.ExternalBinding}
+		bindings = map[string]string{shorthandExternalBindingTarget(c.options.Target): def.ExternalBinding}
 	}
 	if len(bindings) == 0 {
 		c.addError("External binding cannot be empty", def.GetLocation())

--- a/compiler/checker/functions_test.go
+++ b/compiler/checker/functions_test.go
@@ -330,6 +330,35 @@ func TestExternalFunctionBindingsResolvePerTarget(t *testing.T) {
 	}
 }
 
+func TestExternalFunctionShorthandResolvesToEffectiveJSTarget(t *testing.T) {
+	source := `extern fn query_selector(selector: Str) Dynamic? = "querySelector"`
+
+	result := parse.Parse([]byte(source), "main.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected parse errors: %v", result.Errors)
+	}
+
+	jsChecker := checker.New("main.ard", result.Program, nil, checker.CheckOptions{Target: backend.TargetJSBrowser})
+	jsChecker.Check()
+	if jsChecker.HasErrors() {
+		t.Fatalf("unexpected js diagnostics: %v", jsChecker.Diagnostics())
+	}
+	jsFn := jsChecker.Module().Program().Statements[0].Expr.(*checker.ExternalFunctionDef)
+	if jsFn.ExternalBinding != "querySelector" || jsFn.ExternalBindingTarget != backend.TargetJSBrowser || jsFn.ExternalBindings[backend.TargetJSBrowser] != "querySelector" {
+		t.Fatalf("unexpected js shorthand binding: %#v", jsFn)
+	}
+
+	goChecker := checker.New("main.ard", result.Program, nil, checker.CheckOptions{Target: backend.TargetGo})
+	goChecker.Check()
+	if goChecker.HasErrors() {
+		t.Fatalf("unexpected go diagnostics: %v", goChecker.Diagnostics())
+	}
+	goFn := goChecker.Module().Program().Statements[0].Expr.(*checker.ExternalFunctionDef)
+	if goFn.ExternalBinding != "querySelector" || goFn.ExternalBindingTarget != backend.TargetGo || goFn.ExternalBindings[backend.TargetGo] != "querySelector" {
+		t.Fatalf("unexpected go shorthand binding: %#v", goFn)
+	}
+}
+
 func TestExternalFunctionBindingsResolveSharedJSFallback(t *testing.T) {
 	source := `extern fn delay(ms: Int) Void = {
   go = "Delay"

--- a/compiler/javascript/air_backend.go
+++ b/compiler/javascript/air_backend.go
@@ -63,21 +63,13 @@ func RunProgram(program *air.Program, target string, _ []string, projectInfo *ch
 }
 
 func BuildProgram(program *air.Program, outputPath string, target string, projectInfo *checker.ProjectInfo) (string, error) {
-	return buildProgram(program, outputPath, target, projectInfo, false)
-}
-
-func BuildExecutableProgram(program *air.Program, outputPath string, target string, projectInfo *checker.ProjectInfo) (string, error) {
-	return buildProgram(program, outputPath, target, projectInfo, true)
-}
-
-func buildProgram(program *air.Program, outputPath string, target string, projectInfo *checker.ProjectInfo, invokeRoot bool) (string, error) {
 	resolvedOutputPath, err := filepath.Abs(outputPath)
 	if err != nil {
 		return "", err
 	}
 	outputDir := filepath.Dir(resolvedOutputPath)
 	rootFileName := filepath.Base(resolvedOutputPath)
-	files, ffi, err := GenerateSources(program, Options{Target: target, RootFileName: rootFileName, InvokeMain: invokeRoot})
+	files, ffi, err := GenerateSources(program, Options{Target: target, RootFileName: rootFileName})
 	if err != nil {
 		return "", err
 	}

--- a/compiler/javascript/air_backend.go
+++ b/compiler/javascript/air_backend.go
@@ -99,11 +99,20 @@ func writeJSSources(outputDir string, files map[string][]byte) error {
 }
 
 type airJSLowerer struct {
-	program     *air.Program
-	target      string
-	rootFile    string
-	moduleFiles map[air.ModuleID]string
-	tempCounter int
+	program          *air.Program
+	target           string
+	rootFile         string
+	moduleFiles      map[air.ModuleID]string
+	closureFunctions map[air.FunctionID]bool
+	methodFunctions  map[air.FunctionID]jsMethodInfo
+	methodsByType    map[air.TypeID][]air.FunctionID
+	localOverrides   map[air.FunctionID]map[air.LocalID]string
+	tempCounter      int
+}
+
+type jsMethodInfo struct {
+	Owner  air.TypeID
+	Method string
 }
 
 func generateSourcesFromAIR(program *air.Program, options Options) (map[string][]byte, FFIArtifacts, error) {
@@ -121,8 +130,10 @@ func generateSourcesFromAIR(program *air.Program, options Options) (map[string][
 	if rootFile == "" {
 		rootFile = "main.mjs"
 	}
-	l := &airJSLowerer{program: program, target: target, rootFile: rootFile, moduleFiles: map[air.ModuleID]string{}}
+	l := &airJSLowerer{program: program, target: target, rootFile: rootFile, moduleFiles: map[air.ModuleID]string{}, localOverrides: map[air.FunctionID]map[air.LocalID]string{}}
 	l.planModuleFiles()
+	l.collectClosureFunctions()
+	l.collectMethodFunctions()
 	files := make(map[string][]byte, len(program.Modules))
 	moduleIDs := make([]int, 0, len(program.Modules))
 	for _, module := range program.Modules {
@@ -138,6 +149,126 @@ func generateSourcesFromAIR(program *air.Program, options Options) (map[string][
 		files[l.moduleFiles[module.ID]] = []byte(source)
 	}
 	return files, l.collectFFIArtifacts(), nil
+}
+
+func (l *airJSLowerer) collectClosureFunctions() {
+	closures := map[air.FunctionID]bool{}
+	var visitBlock func(air.Block)
+	var visitExpr func(air.Expr)
+	visitBlock = func(block air.Block) {
+		for _, stmt := range block.Stmts {
+			if stmt.Value != nil {
+				visitExpr(*stmt.Value)
+			}
+			if stmt.Expr != nil {
+				visitExpr(*stmt.Expr)
+			}
+			if stmt.Target != nil {
+				visitExpr(*stmt.Target)
+			}
+			if stmt.Condition != nil {
+				visitExpr(*stmt.Condition)
+			}
+			visitBlock(stmt.Body)
+		}
+		if block.Result != nil {
+			visitExpr(*block.Result)
+		}
+	}
+	visitExpr = func(expr air.Expr) {
+		if expr.Kind == air.ExprMakeClosure && expr.Function != air.NoFunction {
+			closures[expr.Function] = true
+		}
+		for _, arg := range expr.Args {
+			visitExpr(arg)
+		}
+		for _, entry := range expr.Entries {
+			visitExpr(entry.Key)
+			visitExpr(entry.Value)
+		}
+		for _, field := range expr.Fields {
+			visitExpr(field.Value)
+		}
+		for _, matchCase := range expr.EnumCases {
+			visitBlock(matchCase.Body)
+		}
+		for _, matchCase := range expr.IntCases {
+			visitBlock(matchCase.Body)
+		}
+		for _, matchCase := range expr.RangeCases {
+			visitBlock(matchCase.Body)
+		}
+		for _, matchCase := range expr.UnionCases {
+			visitBlock(matchCase.Body)
+		}
+		if expr.Target != nil {
+			visitExpr(*expr.Target)
+		}
+		if expr.Left != nil {
+			visitExpr(*expr.Left)
+		}
+		if expr.Right != nil {
+			visitExpr(*expr.Right)
+		}
+		if expr.Condition != nil {
+			visitExpr(*expr.Condition)
+		}
+		visitBlock(expr.Body)
+		visitBlock(expr.Then)
+		visitBlock(expr.Else)
+		visitBlock(expr.CatchAll)
+		visitBlock(expr.Some)
+		visitBlock(expr.None)
+		visitBlock(expr.Ok)
+		visitBlock(expr.Err)
+		visitBlock(expr.Catch)
+	}
+	for _, fn := range l.program.Functions {
+		visitBlock(fn.Body)
+	}
+	l.closureFunctions = closures
+}
+
+func (l *airJSLowerer) collectMethodFunctions() {
+	methods := map[air.FunctionID]jsMethodInfo{}
+	byType := map[air.TypeID][]air.FunctionID{}
+	for _, fn := range l.program.Functions {
+		info, ok := l.structMethodInfo(fn)
+		if !ok {
+			continue
+		}
+		methods[fn.ID] = info
+		byType[info.Owner] = append(byType[info.Owner], fn.ID)
+	}
+	for typeID := range byType {
+		sort.Slice(byType[typeID], func(i, j int) bool { return byType[typeID][i] < byType[typeID][j] })
+	}
+	l.methodFunctions = methods
+	l.methodsByType = byType
+}
+
+func (l *airJSLowerer) structMethodInfo(fn air.Function) (jsMethodInfo, bool) {
+	if fn.IsScript || len(fn.Signature.Params) == 0 {
+		return jsMethodInfo{}, false
+	}
+	ownerType, ok := l.typeInfo(fn.Signature.Params[0].Type)
+	if !ok || ownerType.Kind != air.TypeStruct {
+		return jsMethodInfo{}, false
+	}
+	prefix := ownerType.Name + "."
+	if !strings.HasPrefix(fn.Name, prefix) {
+		return jsMethodInfo{}, false
+	}
+	rest := strings.TrimPrefix(fn.Name, prefix)
+	parts := strings.Split(rest, ".")
+	if len(parts) == 0 {
+		return jsMethodInfo{}, false
+	}
+	method := parts[len(parts)-1]
+	if method == "" {
+		return jsMethodInfo{}, false
+	}
+	return jsMethodInfo{Owner: ownerType.ID, Method: method}, true
 }
 
 func (l *airJSLowerer) planModuleFiles() {
@@ -161,7 +292,7 @@ func (l *airJSLowerer) lowerModule(module air.Module, invokeRoot bool) (string, 
 	outputPath := l.moduleFiles[module.ID]
 	preludeImport := relativeJSImport(outputPath, "ard.prelude.mjs")
 	imports := []string{
-		jsNamedImportLine([]string{"Maybe", "Result", "ardEq", "ardToString", "makeArdError", "makeEnum", "isEnumOf"}, preludeImport),
+		jsNamedImportLine([]string{"Maybe", "Result", "ardEq", "ardToString", "makeArdError", "makeEnum", "isEnumOf", "isVoid"}, preludeImport),
 		jsNamespaceImportLine("prelude", preludeImport),
 	}
 	ffi := l.collectFFIArtifacts()
@@ -192,7 +323,7 @@ func (l *airJSLowerer) lowerModule(module air.Module, invokeRoot bool) (string, 
 	sort.Slice(functionIDs, func(i, j int) bool { return functionIDs[i] < functionIDs[j] })
 	for _, functionID := range functionIDs {
 		fn := l.program.Functions[functionID]
-		if fn.IsScript {
+		if fn.IsScript || l.closureFunctions[fn.ID] || l.isMethodFunction(fn.ID) {
 			continue
 		}
 		decl, err := l.lowerFunction(fn)
@@ -342,8 +473,15 @@ func (l *airJSLowerer) lowerTypeDecl(typeID air.TypeID) (string, error) {
 			name := jsName(field.Name)
 			lines = append(lines, "this."+name+" = "+name+";")
 		}
-		ctor := renderJSDoc(jsBlockDoc("constructor("+strings.Join(params, ", ")+")", strings.Join(lines, "\n")))
-		return renderJSDoc(jsClassDoc(jsName(t.Name), []string{ctor})), nil
+		members := []string{renderJSDoc(jsBlockDoc("constructor("+strings.Join(params, ", ")+")", strings.Join(lines, "\n")))}
+		for _, methodID := range l.methodsByType[typeID] {
+			method, err := l.lowerClassMethod(l.program.Functions[methodID])
+			if err != nil {
+				return "", err
+			}
+			members = append(members, method)
+		}
+		return renderJSDoc(jsClassDoc(jsName(t.Name), members)), nil
 	case air.TypeEnum:
 		fields := make([]jsObjectField, 0, len(t.Variants))
 		for _, variant := range t.Variants {
@@ -353,6 +491,34 @@ func (l *airJSLowerer) lowerTypeDecl(typeID air.TypeID) (string, error) {
 	default:
 		return "", nil
 	}
+}
+
+func (l *airJSLowerer) lowerClassMethod(fn air.Function) (string, error) {
+	info, ok := l.methodFunctions[fn.ID]
+	if !ok {
+		return "", fmt.Errorf("function %s is not a class method", fn.Name)
+	}
+	params := make([]string, 0, len(fn.Signature.Params)-1)
+	for _, param := range fn.Signature.Params[1:] {
+		params = append(params, jsName(param.Name))
+	}
+	overrides := map[air.LocalID]string{}
+	if len(fn.Locals) > 0 {
+		overrides[fn.Locals[0].ID] = "this"
+	}
+	previous := l.localOverrides[fn.ID]
+	l.localOverrides[fn.ID] = overrides
+	body, err := l.lowerBlock(fn, fn.Body, true)
+	if previous != nil {
+		l.localOverrides[fn.ID] = previous
+	} else {
+		delete(l.localOverrides, fn.ID)
+	}
+	if err != nil {
+		return "", err
+	}
+	_ = info
+	return renderJSDoc(jsBlockDoc(jsName(info.Method)+"("+strings.Join(params, ", ")+")", body)), nil
 }
 
 func (l *airJSLowerer) lowerFunction(fn air.Function) (string, error) {
@@ -394,17 +560,39 @@ func (l *airJSLowerer) lowerBlock(fn air.Function, block air.Block, returns bool
 			lines = append(lines, tryLines...)
 			return strings.Join(lines, "\n"), nil
 		}
+		if block.Result.Kind == air.ExprMaybeExpect {
+			expectLines, value, err := l.lowerMaybeExpectLines(fn, *block.Result)
+			if err != nil {
+				return "", err
+			}
+			lines = append(lines, expectLines...)
+			if returns {
+				if l.isVoidType(block.Result.Type) {
+					lines = append(lines, "return;")
+				} else {
+					lines = append(lines, "return "+value+";")
+				}
+			} else if !l.isVoidType(block.Result.Type) {
+				lines = append(lines, value+";")
+			}
+			return strings.Join(lines, "\n"), nil
+		}
 		expr, err := l.lowerExpr(fn, *block.Result)
 		if err != nil {
 			return "", err
 		}
 		if returns {
-			lines = append(lines, "return "+expr+";")
+			if l.isVoidType(block.Result.Type) {
+				lines = append(lines, expr+";")
+				lines = append(lines, "return;")
+			} else {
+				lines = append(lines, "return "+expr+";")
+			}
 		} else {
 			lines = append(lines, expr+";")
 		}
 	} else if returns {
-		lines = append(lines, "return undefined;")
+		lines = append(lines, "return;")
 	}
 	return strings.Join(lines, "\n"), nil
 }
@@ -414,6 +602,18 @@ func (l *airJSLowerer) lowerStmt(fn air.Function, stmt air.Stmt) (string, error)
 	case air.StmtLet:
 		if stmt.Value != nil && (stmt.Value.Kind == air.ExprTryResult || stmt.Value.Kind == air.ExprTryMaybe) {
 			return l.lowerTryLet(fn, stmt)
+		}
+		if stmt.Value != nil && stmt.Value.Kind == air.ExprMaybeExpect {
+			lines, value, err := l.lowerMaybeExpectLines(fn, *stmt.Value)
+			if err != nil {
+				return "", err
+			}
+			keyword := "const"
+			if stmt.Mutable {
+				keyword = "let"
+			}
+			lines = append(lines, keyword+" "+l.localName(fn, stmt.Local)+" = "+value+";")
+			return strings.Join(lines, "\n"), nil
 		}
 		value, err := l.lowerExpr(fn, *stmt.Value)
 		if err != nil {
@@ -425,6 +625,14 @@ func (l *airJSLowerer) lowerStmt(fn air.Function, stmt air.Stmt) (string, error)
 		}
 		return keyword + " " + l.localName(fn, stmt.Local) + " = " + value + ";", nil
 	case air.StmtAssign:
+		if stmt.Value != nil && stmt.Value.Kind == air.ExprMaybeExpect {
+			lines, value, err := l.lowerMaybeExpectLines(fn, *stmt.Value)
+			if err != nil {
+				return "", err
+			}
+			lines = append(lines, l.localName(fn, stmt.Local)+" = "+value+";")
+			return strings.Join(lines, "\n"), nil
+		}
 		value, err := l.lowerExpr(fn, *stmt.Value)
 		if err != nil {
 			return "", err
@@ -447,6 +655,16 @@ func (l *airJSLowerer) lowerStmt(fn air.Function, stmt air.Stmt) (string, error)
 	case air.StmtExpr:
 		if stmt.Expr != nil && stmt.Expr.Kind == air.ExprIf {
 			return l.lowerIfStmt(fn, *stmt.Expr)
+		}
+		if stmt.Expr != nil && stmt.Expr.Kind == air.ExprMaybeExpect {
+			lines, value, err := l.lowerMaybeExpectLines(fn, *stmt.Expr)
+			if err != nil {
+				return "", err
+			}
+			if !l.isVoidType(stmt.Expr.Type) {
+				lines = append(lines, value+";")
+			}
+			return strings.Join(lines, "\n"), nil
 		}
 		value, err := l.lowerExpr(fn, *stmt.Expr)
 		if err != nil {
@@ -489,7 +707,7 @@ func (l *airJSLowerer) lowerIfStmt(fn air.Function, expr air.Expr) (string, erro
 func (l *airJSLowerer) lowerExpr(fn air.Function, expr air.Expr) (string, error) {
 	switch expr.Kind {
 	case air.ExprConstVoid:
-		return "undefined", nil
+		return "null", nil
 	case air.ExprConstInt:
 		return strconv.Itoa(expr.Int), nil
 	case air.ExprConstFloat:
@@ -508,21 +726,30 @@ func (l *airJSLowerer) lowerExpr(fn air.Function, expr air.Expr) (string, error)
 	case air.ExprMatchUnion:
 		return l.lowerUnionMatch(fn, expr)
 	case air.ExprCall:
+		if info, ok := l.methodFunctions[expr.Function]; ok {
+			if len(expr.Args) == 0 {
+				return "", fmt.Errorf("method call %s missing receiver", info.Method)
+			}
+			receiver, err := l.lowerExpr(fn, expr.Args[0])
+			if err != nil {
+				return "", err
+			}
+			args, err := l.lowerArgs(fn, expr.Args[1:])
+			if err != nil {
+				return "", err
+			}
+			return renderJSExpr(jsCallExprIR{Callee: receiver + "." + jsName(info.Method), Args: args}), nil
+		}
 		args, err := l.lowerArgs(fn, expr.Args)
 		if err != nil {
 			return "", err
 		}
 		return renderJSExpr(jsCallExprIR{Callee: l.functionRef(fn.Module, expr.Function), Args: args}), nil
 	case air.ExprCallExtern:
-		args, err := l.lowerArgs(fn, expr.Args)
+		call, err := l.lowerExternCallRaw(fn, expr)
 		if err != nil {
 			return "", err
 		}
-		callee, err := l.externRef(expr.Extern)
-		if err != nil {
-			return "", err
-		}
-		call := renderJSExpr(jsCallExprIR{Callee: callee, Args: args})
 		return l.adaptExternReturn(call, expr.Type)
 	case air.ExprSpawnFiber:
 		return l.lowerSpawnFiber(fn, expr)
@@ -727,7 +954,7 @@ func (l *airJSLowerer) lowerFiberJoin(fn air.Function, expr air.Expr) (string, e
 	if _, err := l.lowerExpr(fn, *expr.Target); err != nil {
 		return "", err
 	}
-	return "undefined", nil
+	return "null", nil
 }
 
 func (l *airJSLowerer) lowerTraitCall(fn air.Function, expr air.Expr) (string, error) {
@@ -752,6 +979,18 @@ func (l *airJSLowerer) lowerTraitCall(fn air.Function, expr air.Expr) (string, e
 	return "", fmt.Errorf("unsupported AIR JS trait call %s.%s", trait.Name, method.Name)
 }
 
+func (l *airJSLowerer) lowerExternCallRaw(fn air.Function, expr air.Expr) (string, error) {
+	args, err := l.lowerArgs(fn, expr.Args)
+	if err != nil {
+		return "", err
+	}
+	callee, err := l.externRef(expr.Extern)
+	if err != nil {
+		return "", err
+	}
+	return renderJSExpr(jsCallExprIR{Callee: callee, Args: args}), nil
+}
+
 func (l *airJSLowerer) adaptExternReturn(call string, typeID air.TypeID) (string, error) {
 	t, ok := l.typeInfo(typeID)
 	if !ok {
@@ -763,7 +1002,7 @@ func (l *airJSLowerer) adaptExternReturn(call string, typeID air.TypeID) (string
 		if err != nil {
 			return "", err
 		}
-		body := "const __extern = " + call + ";\nreturn (__extern === undefined || __extern === null) ? Maybe.none() : Maybe.some(" + adapted + ");"
+		body := "const __extern = " + call + ";\nreturn !isVoid(__extern) ? Maybe.some(" + adapted + ") : Maybe.none();"
 		return renderJSDoc(jsIIFEDoc(body)), nil
 	case air.TypeResult:
 		adaptedOk, err := l.adaptExternValue("__extern.ok", t.Value)
@@ -823,7 +1062,7 @@ func (l *airJSLowerer) adaptExternValue(value string, typeID air.TypeID) (string
 		if err != nil {
 			return "", err
 		}
-		body := "const __maybe = " + value + ";\nreturn (__maybe === undefined || __maybe === null) ? Maybe.none() : Maybe.some(" + adapted + ");"
+		body := "const __maybe = " + value + ";\nreturn !isVoid(__maybe) ? Maybe.some(" + adapted + ") : Maybe.none();"
 		return renderJSDoc(jsIIFEDoc(body)), nil
 	default:
 		return value, nil
@@ -973,17 +1212,27 @@ func (l *airJSLowerer) lowerMakeClosure(fn air.Function, expr air.Expr) (string,
 	}
 	closureFn := l.program.Functions[expr.Function]
 	params := make([]string, 0, len(closureFn.Signature.Params))
-	callArgs := make([]string, 0, len(expr.CaptureLocals)+len(closureFn.Signature.Params))
-	for _, local := range expr.CaptureLocals {
-		callArgs = append(callArgs, l.localName(fn, local))
-	}
 	for _, param := range closureFn.Signature.Params {
-		name := jsName(param.Name)
-		params = append(params, name)
-		callArgs = append(callArgs, name)
+		params = append(params, jsName(param.Name))
 	}
-	call := renderJSExpr(jsCallExprIR{Callee: l.functionRef(fn.Module, expr.Function), Args: callArgs})
-	body := "return " + call + ";"
+	overrides := map[air.LocalID]string{}
+	for i, capture := range closureFn.Captures {
+		if i >= len(expr.CaptureLocals) {
+			return "", fmt.Errorf("closure %s capture mismatch", closureFn.Name)
+		}
+		overrides[capture.Local] = l.localName(fn, expr.CaptureLocals[i])
+	}
+	previous := l.localOverrides[closureFn.ID]
+	l.localOverrides[closureFn.ID] = overrides
+	body, err := l.lowerBlock(closureFn, closureFn.Body, true)
+	if previous != nil {
+		l.localOverrides[closureFn.ID] = previous
+	} else {
+		delete(l.localOverrides, closureFn.ID)
+	}
+	if err != nil {
+		return "", err
+	}
 	return renderJSDoc(jsBlockDoc("function("+strings.Join(params, ", ")+")", body)), nil
 }
 
@@ -1157,14 +1406,14 @@ func (l *airJSLowerer) lowerListOp(fn air.Function, expr air.Expr) (string, erro
 	case air.ExprListSet:
 		return renderJSDoc(jsIIFEDoc("const __value = " + target + ";\n__value[" + args[0] + "] = " + args[1] + ";\nreturn true;")), nil
 	case air.ExprListSwap:
-		body := "const __value = " + target + ";\nconst __tmp = __value[" + args[0] + "];\n__value[" + args[0] + "] = __value[" + args[1] + "];\n__value[" + args[1] + "] = __tmp;\nreturn undefined;"
+		body := "const __value = " + target + ";\nconst __tmp = __value[" + args[0] + "];\n__value[" + args[0] + "] = __value[" + args[1] + "];\n__value[" + args[1] + "] = __tmp;\nreturn null;"
 		return renderJSDoc(jsIIFEDoc(body)), nil
 	case air.ExprListSort:
 		if len(args) != 1 {
 			return "", fmt.Errorf("list sort expects comparator")
 		}
 		cmp := args[0]
-		return renderJSDoc(jsIIFEDoc("const __value = " + target + ";\n__value.sort((a, b) => " + cmp + "(a, b) ? -1 : (" + cmp + "(b, a) ? 1 : 0));\nreturn undefined;")), nil
+		return renderJSDoc(jsIIFEDoc("const __value = " + target + ";\n__value.sort((a, b) => " + cmp + "(a, b) ? -1 : (" + cmp + "(b, a) ? 1 : 0));\nreturn null;")), nil
 	default:
 		return "", fmt.Errorf("unsupported AIR JS list op %d", expr.Kind)
 	}
@@ -1189,7 +1438,7 @@ func (l *airJSLowerer) lowerMapOp(fn air.Function, expr air.Expr) (string, error
 	case air.ExprMapSet:
 		return renderJSDoc(jsIIFEDoc("const __value = " + target + ";\n__value.set(" + args[0] + ", " + args[1] + ");\nreturn true;")), nil
 	case air.ExprMapDrop:
-		return renderJSDoc(jsIIFEDoc("const __value = " + target + ";\n__value.delete(" + args[0] + ");\nreturn undefined;")), nil
+		return renderJSDoc(jsIIFEDoc("const __value = " + target + ";\n__value.delete(" + args[0] + ");\nreturn null;")), nil
 	case air.ExprMapHas:
 		return target + ".has(" + args[0] + ")", nil
 	case air.ExprMapKeyAt:
@@ -1199,6 +1448,48 @@ func (l *airJSLowerer) lowerMapOp(fn air.Function, expr air.Expr) (string, error
 	default:
 		return "", fmt.Errorf("unsupported AIR JS map op %d", expr.Kind)
 	}
+}
+
+func (l *airJSLowerer) lowerMaybeExpectLines(fn air.Function, expr air.Expr) ([]string, string, error) {
+	if expr.Target == nil {
+		return nil, "", fmt.Errorf("maybe expect missing target")
+	}
+	if len(expr.Args) != 1 {
+		return nil, "", fmt.Errorf("maybe expect expects one argument")
+	}
+	message, err := l.lowerExpr(fn, expr.Args[0])
+	if err != nil {
+		return nil, "", err
+	}
+	expectVar := l.temp("expect")
+	if expr.Target.Kind == air.ExprCallExtern {
+		call, err := l.lowerExternCallRaw(fn, *expr.Target)
+		if err != nil {
+			return nil, "", err
+		}
+		maybeType, ok := l.typeInfo(expr.Target.Type)
+		if !ok || maybeType.Kind != air.TypeMaybe {
+			return nil, "", fmt.Errorf("maybe expect lowered with non-Maybe extern target %d", expr.Target.Type)
+		}
+		adapted, err := l.adaptExternValue(expectVar, maybeType.Elem)
+		if err != nil {
+			return nil, "", err
+		}
+		lines := []string{
+			"const " + expectVar + " = " + call + ";",
+			"if (isVoid(" + expectVar + ")) throw makeArdError(\"panic\", \"ard/maybe\", \"expect\", 0, " + message + ");",
+		}
+		return lines, adapted, nil
+	}
+	target, err := l.lowerExpr(fn, *expr.Target)
+	if err != nil {
+		return nil, "", err
+	}
+	lines := []string{
+		"const " + expectVar + " = " + target + ";",
+		"if (" + expectVar + ".isNone()) throw makeArdError(\"panic\", \"ard/maybe\", \"expect\", 0, " + message + ");",
+	}
+	return lines, expectVar + ".value", nil
 }
 
 func (l *airJSLowerer) lowerMaybeOp(fn air.Function, expr air.Expr) (string, error) {
@@ -1352,6 +1643,11 @@ func (l *airJSLowerer) lowerBinaryCall(fn air.Function, expr air.Expr, build fun
 }
 
 func (l *airJSLowerer) localName(fn air.Function, local air.LocalID) string {
+	if overrides := l.localOverrides[fn.ID]; overrides != nil {
+		if name, ok := overrides[local]; ok {
+			return name
+		}
+	}
 	if int(local) < 0 || int(local) >= len(fn.Locals) {
 		return "__local" + strconv.Itoa(int(local))
 	}
@@ -1488,7 +1784,7 @@ func (l *airJSLowerer) moduleExports(module air.Module) []string {
 	}
 	for _, functionID := range module.Functions {
 		fn := l.program.Functions[functionID]
-		if fn.IsScript {
+		if fn.IsScript || l.closureFunctions[fn.ID] || l.isMethodFunction(fn.ID) {
 			continue
 		}
 		exports = append(exports, l.functionName(functionID))
@@ -1507,11 +1803,21 @@ func airBlockIsZero(block air.Block) bool {
 	return len(block.Stmts) == 0 && block.Result == nil
 }
 
+func (l *airJSLowerer) isMethodFunction(id air.FunctionID) bool {
+	_, ok := l.methodFunctions[id]
+	return ok
+}
+
 func (l *airJSLowerer) typeInfo(id air.TypeID) (air.TypeInfo, bool) {
 	if id <= 0 || int(id) > len(l.program.Types) {
 		return air.TypeInfo{}, false
 	}
 	return l.program.Types[id-1], true
+}
+
+func (l *airJSLowerer) isVoidType(id air.TypeID) bool {
+	info, ok := l.typeInfo(id)
+	return ok && info.Kind == air.TypeVoid
 }
 
 func (l *airJSLowerer) collectFFIArtifacts() FFIArtifacts {

--- a/compiler/javascript/air_backend.go
+++ b/compiler/javascript/air_backend.go
@@ -142,7 +142,7 @@ func generateSourcesFromAIR(program *air.Program, options Options) (map[string][
 
 func (l *airJSLowerer) planModuleFiles() {
 	rootModule := air.ModuleID(-1)
-	if rootID, ok := airJSRootFunction(l.program); ok {
+	if rootID, ok := airJSRootModuleFunction(l.program); ok {
 		rootModule = l.program.Functions[rootID].Module
 	} else if len(l.program.Modules) > 0 {
 		rootModule = l.program.Modules[len(l.program.Modules)-1].ID
@@ -210,7 +210,7 @@ func (l *airJSLowerer) lowerModule(module air.Module, invokeRoot bool) (string, 
 		b.WriteString(script)
 		b.WriteString("\n\n")
 	}
-	if invokeRoot {
+	if invokeRoot && l.program.Script == air.NoFunction {
 		if rootID, ok := airJSRootFunction(l.program); ok && l.program.Functions[rootID].Module == module.ID {
 			b.WriteString("await ")
 			b.WriteString(l.functionName(rootID))
@@ -371,11 +371,7 @@ func (l *airJSLowerer) lowerFunction(fn air.Function) (string, error) {
 }
 
 func (l *airJSLowerer) lowerScriptFunction(fn air.Function) (string, error) {
-	body, err := l.lowerBlock(fn, fn.Body, true)
-	if err != nil {
-		return "", err
-	}
-	return renderJSDoc(jsBlockDoc("function "+l.functionName(fn.ID)+"()", body)), nil
+	return l.lowerBlock(fn, fn.Body, false)
 }
 
 func (l *airJSLowerer) lowerBlock(fn air.Function, block air.Block, returns bool) (string, error) {
@@ -1466,7 +1462,8 @@ func (l *airJSLowerer) externRef(id air.ExternID) (string, error) {
 func isAIRJSPreludeExtern(binding string) bool {
 	switch binding {
 	case "JsonToDynamic", "DecodeString", "DecodeInt", "DecodeFloat", "DecodeBool", "IsNil",
-		"DynamicToList", "DynamicToMap", "ExtractField", "StrToDynamic", "IntToDynamic",
+		"DynamicToList", "DynamicToMap", "ExtractField", "IntFromStr", "FloatFromStr",
+		"FloatFromInt", "FloatFloor", "StrToDynamic", "IntToDynamic",
 		"FloatToDynamic", "BoolToDynamic", "VoidToDynamic", "ListToDynamic", "MapToDynamic",
 		"JsonEncode", "promiseResolve", "promiseReject", "promiseMap", "promiseThen",
 		"promiseRescue", "promiseInspect", "promiseInspectError", "promiseFinally",
@@ -1540,7 +1537,7 @@ func (l *airJSLowerer) collectFFIArtifacts() FFIArtifacts {
 	return ffi
 }
 
-func airJSRootFunction(program *air.Program) (air.FunctionID, bool) {
+func airJSRootModuleFunction(program *air.Program) (air.FunctionID, bool) {
 	if program == nil {
 		return air.NoFunction, false
 	}
@@ -1549,6 +1546,16 @@ func airJSRootFunction(program *air.Program) (air.FunctionID, bool) {
 	}
 	if program.Script != air.NoFunction {
 		return program.Script, true
+	}
+	return air.NoFunction, false
+}
+
+func airJSRootFunction(program *air.Program) (air.FunctionID, bool) {
+	if program == nil {
+		return air.NoFunction, false
+	}
+	if program.Entry != air.NoFunction {
+		return program.Entry, true
 	}
 	return air.NoFunction, false
 }

--- a/compiler/javascript/air_backend.go
+++ b/compiler/javascript/air_backend.go
@@ -63,13 +63,21 @@ func RunProgram(program *air.Program, target string, _ []string, projectInfo *ch
 }
 
 func BuildProgram(program *air.Program, outputPath string, target string, projectInfo *checker.ProjectInfo) (string, error) {
+	return buildProgram(program, outputPath, target, projectInfo, false)
+}
+
+func BuildExecutableProgram(program *air.Program, outputPath string, target string, projectInfo *checker.ProjectInfo) (string, error) {
+	return buildProgram(program, outputPath, target, projectInfo, true)
+}
+
+func buildProgram(program *air.Program, outputPath string, target string, projectInfo *checker.ProjectInfo, invokeRoot bool) (string, error) {
 	resolvedOutputPath, err := filepath.Abs(outputPath)
 	if err != nil {
 		return "", err
 	}
 	outputDir := filepath.Dir(resolvedOutputPath)
 	rootFileName := filepath.Base(resolvedOutputPath)
-	files, ffi, err := GenerateSources(program, Options{Target: target, RootFileName: rootFileName})
+	files, ffi, err := GenerateSources(program, Options{Target: target, RootFileName: rootFileName, InvokeMain: invokeRoot})
 	if err != nil {
 		return "", err
 	}

--- a/compiler/javascript/ard.prelude.mjs
+++ b/compiler/javascript/ard.prelude.mjs
@@ -34,6 +34,10 @@ export function isEnumOf(value, enumName) {
   return isArdEnum(value) && value.enum === enumName;
 }
 
+export function isVoid(value) {
+  return value === null || value === undefined;
+}
+
 export function ardEnumValue(value) {
   return isArdEnum(value) ? value.value : value;
 }

--- a/compiler/javascript/ard.prelude.mjs
+++ b/compiler/javascript/ard.prelude.mjs
@@ -299,6 +299,26 @@ export function ExtractField(data, name) {
   return { ok: hasOwn(data, name) ? data[name] : null };
 }
 
+export function IntFromStr(value) {
+  if (typeof value !== "string" || !/^[+-]?\d+$/.test(value.trim())) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+export function FloatFromStr(value) {
+  if (typeof value !== "string" || value.trim() === "") return null;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function FloatFromInt(value) {
+  return value;
+}
+
+export function FloatFloor(value) {
+  return Math.floor(value);
+}
+
 export function StrToDynamic(val) {
   return val;
 }

--- a/compiler/javascript/javascript_test.go
+++ b/compiler/javascript/javascript_test.go
@@ -762,6 +762,9 @@ let result = add(1, 2)
 	if !strings.Contains(source, "const result = add(1, 2);") {
 		t.Fatalf("expected script let in AIR JS output, got:\n%s", source)
 	}
+	if strings.Contains(source, "__ard_script") {
+		t.Fatalf("expected top-level script statements to emit directly, got:\n%s", source)
+	}
 	if !strings.Contains(source, "export { add };") {
 		t.Fatalf("expected function export in AIR JS output, got:\n%s", source)
 	}

--- a/compiler/javascript/javascript_test.go
+++ b/compiler/javascript/javascript_test.go
@@ -105,6 +105,53 @@ let result = get_age()
 	}
 }
 
+func TestBuildLowersStructMethodsAsClassMethods(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write ard.toml: %v", err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`
+struct Counter { value: Int }
+
+impl Counter {
+  fn mut increment() {
+    self.value =+ 1
+  }
+
+  fn to_str() Str {
+    self.value.to_str()
+  }
+}
+
+fn main() Str {
+  mut counter = Counter{value: 1}
+  counter.increment()
+  counter.to_str()
+}
+`), 0o644); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+
+	outputPath := filepath.Join(dir, "main.mjs")
+	if _, err := Build(mainPath, outputPath, backend.TargetJSBrowser); err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	out, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read generated module: %v", err)
+	}
+	source := string(out)
+	for _, expected := range []string{"increment() {", "to_str() {", "counter.increment();", "return counter.to_str();"} {
+		if !strings.Contains(source, expected) {
+			t.Fatalf("expected %q in generated module, got:\n%s", expected, source)
+		}
+	}
+	if strings.Contains(source, "function Counter_increment") || strings.Contains(source, "function Counter_to_str") || strings.Contains(source, "export { Counter_increment") {
+		t.Fatalf("expected struct methods to be emitted only as class methods, got:\n%s", source)
+	}
+}
+
 func TestRunExecutesCoreLoopProgram(t *testing.T) {
 	if _, err := exec.LookPath("node"); err != nil {
 		t.Skip("node not installed")
@@ -856,6 +903,57 @@ let ok_value = ok.or(0)
 	}
 }
 
+func TestGenerateSourcesFromAIRMaybeExpectUsesStatementGuards(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write ard.toml: %v", err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`
+use ard/maybe
+
+fn value() Int {
+  let count = maybe::some(1).expect("count")
+  count
+}
+
+fn tail() Int {
+  maybe::some(2).expect("tail")
+}
+
+maybe::some(()).expect("start")
+`), 0o644); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetJSServer)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower AIR: %v", err)
+	}
+	files, _, err := GenerateSources(program, Options{Target: backend.TargetJSServer, RootFileName: "main.mjs"})
+	if err != nil {
+		t.Fatalf("generate AIR JS sources: %v", err)
+	}
+	source := string(files["main.mjs"])
+	for _, expected := range []string{
+		`if (__expect`,
+		`.isNone()) throw makeArdError("panic", "ard/maybe", "expect", 0, "count");`,
+		`const count = __expect`,
+		`.value;`,
+		`return __expect`,
+	} {
+		if !strings.Contains(source, expected) {
+			t.Fatalf("expected %q in AIR JS output, got:\n%s", expected, source)
+		}
+	}
+	if strings.Contains(source, `.expect("count")`) || strings.Contains(source, `.expect("tail")`) || strings.Contains(source, `.expect("start")`) {
+		t.Fatalf("expected direct Maybe.expect calls to be lowered to statement guards, got:\n%s", source)
+	}
+}
+
 func TestGenerateSourcesFromAIRImportedModuleCalls(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
@@ -1072,8 +1170,11 @@ let result = add_two(40)
 	for _, content := range files {
 		source += string(content)
 	}
-	if !strings.Contains(source, "function(value) {") || !strings.Contains(source, "return add_two(40);") && !strings.Contains(source, "const result = add_two(40);") {
-		t.Fatalf("expected closure literal and call in AIR JS output, got:\n%s", source)
+	if !strings.Contains(source, "function(value) {") || !strings.Contains(source, "return (base + value);") || !strings.Contains(source, "const result = add_two(40);") {
+		t.Fatalf("expected inlined closure literal and call in AIR JS output, got:\n%s", source)
+	}
+	if strings.Contains(source, "anon_func") {
+		t.Fatalf("expected closure helper functions to be inlined, got:\n%s", source)
 	}
 }
 
@@ -1199,7 +1300,7 @@ let result = result_value()
 		t.Fatalf("expected project ffi artifact use")
 	}
 	source := string(files["main.mjs"])
-	for _, expected := range []string{"ardToString(42)", "Maybe.none()", "Maybe.some(__extern)", "Result.ok(__extern.ok)", "Result.err(__extern.error)"} {
+	for _, expected := range []string{"ardToString(42)", "!isVoid(__extern) ? Maybe.some(__extern) : Maybe.none()", "Result.ok(__extern.ok)", "Result.err(__extern.error)"} {
 		if !strings.Contains(source, expected) {
 			t.Fatalf("expected %q in AIR JS output, got:\n%s", expected, source)
 		}

--- a/compiler/main.go
+++ b/compiler/main.go
@@ -729,7 +729,7 @@ func resolveJSBuildOutputPath(inputPath string, outputPath string, target string
 			rootDir = "."
 		}
 	}
-	return filepath.Join(rootDir, "ard-out", "js", target, "build", defaultOutput+".mjs")
+	return filepath.Join(rootDir, "ard-out", target, defaultOutput+".mjs")
 }
 
 func buildGoBinary(inputPath string, outputPath string, target string) (string, error) {

--- a/compiler/main.go
+++ b/compiler/main.go
@@ -703,7 +703,7 @@ func buildJSProgram(inputPath string, outputPath string, target string) (string,
 	var builtPath string
 	if err := profile.Time("javascript.build", func() error {
 		var buildErr error
-		builtPath, buildErr = javascript.BuildProgram(program, outputPath, target, loaded.ProjectInfo)
+		builtPath, buildErr = javascript.BuildExecutableProgram(program, outputPath, target, loaded.ProjectInfo)
 		return buildErr
 	}); err != nil {
 		return "", err

--- a/compiler/main.go
+++ b/compiler/main.go
@@ -703,7 +703,7 @@ func buildJSProgram(inputPath string, outputPath string, target string) (string,
 	var builtPath string
 	if err := profile.Time("javascript.build", func() error {
 		var buildErr error
-		builtPath, buildErr = javascript.BuildExecutableProgram(program, outputPath, target, loaded.ProjectInfo)
+		builtPath, buildErr = javascript.BuildProgram(program, outputPath, target, loaded.ProjectInfo)
 		return buildErr
 	}); err != nil {
 		return "", err

--- a/compiler/main_test.go
+++ b/compiler/main_test.go
@@ -549,7 +549,7 @@ func TestBuildJSProgramDefaultWritesArdOut(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildJSProgram error = %v", err)
 	}
-	want := filepath.Join(dir, "ard-out", "js", backend.TargetJSBrowser, "build", "main.mjs")
+	want := filepath.Join(dir, "ard-out", backend.TargetJSBrowser, "main.mjs")
 	if builtPath != want {
 		t.Fatalf("built path = %q, want %q", builtPath, want)
 	}

--- a/compiler/main_test.go
+++ b/compiler/main_test.go
@@ -563,8 +563,8 @@ func TestBuildJSProgramDefaultWritesArdOut(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read generated root module: %v", err)
 	}
-	if !strings.Contains(string(out), "await main();") {
-		t.Fatalf("expected CLI build output to invoke root function, got:\n%s", string(out))
+	if strings.Contains(string(out), "await main();") || strings.Contains(string(out), "await __ard_script();") {
+		t.Fatalf("expected build output to be importable without auto-invoking root, got:\n%s", string(out))
 	}
 }
 

--- a/compiler/main_test.go
+++ b/compiler/main_test.go
@@ -559,6 +559,13 @@ func TestBuildJSProgramDefaultWritesArdOut(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(filepath.Dir(want), "ard.prelude.mjs")); err != nil {
 		t.Fatalf("expected generated prelude next to root module: %v", err)
 	}
+	out, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("read generated root module: %v", err)
+	}
+	if !strings.Contains(string(out), "await main();") {
+		t.Fatalf("expected CLI build output to invoke root function, got:\n%s", string(out))
+	}
 }
 
 func TestParseFormatArgs(t *testing.T) {

--- a/compiler/parse/functions_test.go
+++ b/compiler/parse/functions_test.go
@@ -51,9 +51,8 @@ func TestExternTypeDeclaration(t *testing.T) {
 				Imports: []Import{},
 				Statements: []Statement{
 					&ExternTypeDeclaration{
-						Name:             "Vaxis",
-						ExternalBinding:  "*vaxis.Vaxis",
-						ExternalBindings: map[string]string{"go": "*vaxis.Vaxis"},
+						Name:            "Vaxis",
+						ExternalBinding: "*vaxis.Vaxis",
 					},
 				},
 			},
@@ -78,9 +77,8 @@ func TestFunctionDeclaration(t *testing.T) {
 								Type: &GenericType{Name: "T"},
 							},
 						},
-						ReturnType:       &VoidType{},
-						ExternalBinding:  "runtime.go_print",
-						ExternalBindings: map[string]string{"go": "runtime.go_print"},
+						ReturnType:      &VoidType{},
+						ExternalBinding: "runtime.go_print",
 					},
 				},
 			},

--- a/compiler/parse/parser.go
+++ b/compiler/parse/parser.go
@@ -2181,7 +2181,6 @@ func (p *parser) functionDef(asMethod bool, isTest bool) (Statement, error) {
 			if p.check(string_) {
 				bindingToken := p.advance()
 				externalBinding = trimQuotedString(bindingToken.text)
-				externalBindings = map[string]string{"go": externalBinding}
 				endRow = bindingToken.line
 				endCol = bindingToken.column + len(bindingToken.text)
 			} else if p.match(left_brace) {
@@ -2351,11 +2350,10 @@ func (p *parser) functionDef(asMethod bool, isTest bool) (Statement, error) {
 			}
 
 			externalBinding := ""
-			externalBindings := map[string]string{}
+			var externalBindings map[string]string
 			if p.check(string_) {
 				bindingToken := p.advance()
 				externalBinding = trimQuotedString(bindingToken.text)
-				externalBindings["go"] = externalBinding
 			} else if p.match(left_brace) {
 				bindings, err := p.parseExternalBindingBlock()
 				if err != nil {


### PR DESCRIPTION
## Summary
- resolve shorthand extern bindings against the effective JS target
- simplify default JS build output paths and keep build artifacts importable
- transpile top-level Ard statements as top-level JavaScript statements
- improve generated JS readability with inline closures, class methods, natural void returns, and explicit nullable checks
- add missing JS prelude helpers used by stdlib primitives

## Validation
- `cd compiler && go test . ./javascript ./parse ./checker`
- `cd compiler && go install`
- `cd ../ard-js && npm test`