### PR TITLE
feat(json): add typed parse API and specialized codecs

### DIFF
--- a/compiler/benchmarks/programs/json_serde_roundtrip.ard
+++ b/compiler/benchmarks/programs/json_serde_roundtrip.ard
@@ -1,4 +1,3 @@
-use ard/decode
 use ard/dynamic
 use ard/io
 use ard/json
@@ -44,17 +43,13 @@ fn packet_to_dynamic(packet: Packet) Dynamic {
 }
 
 fn score_packet(payload: Str) Int {
-  let raw = decode::from_json(payload).expect("valid json")
-  let id = decode::run(raw, decode::field("id", decode::int)).expect("id")
-  let name = decode::run(raw, decode::field("name", decode::string)).expect("name")
-  let active = decode::run(raw, decode::field("active", decode::bool)).expect("active")
-  let values = decode::run(raw, decode::field("values", decode::list(decode::int))).expect("values")
+  let packet = json::parse<Packet>(payload).expect("valid json")
 
-  mut total = id + name.size()
-  if active {
+  mut total = packet.id + packet.name.size()
+  if packet.active {
     total =+ 19
   }
-  for value, idx in values {
+  for value, idx in packet.values {
     total =+ value * (idx + 1)
   }
   total

--- a/compiler/benchmarks/programs/json_serde_roundtrip.ard
+++ b/compiler/benchmarks/programs/json_serde_roundtrip.ard
@@ -1,4 +1,3 @@
-use ard/dynamic
 use ard/io
 use ard/json
 
@@ -26,22 +25,6 @@ fn make_packet(i: Int) Packet {
   }
 }
 
-fn packet_to_dynamic(packet: Packet) Dynamic {
-  dynamic::object(
-    [
-      "id": dynamic::from_int(packet.id),
-      "name": dynamic::from_str(packet.name),
-      "active": dynamic::from_bool(packet.active),
-      "values": dynamic::list(
-        packet.values,
-        fn(value: Int) Dynamic {
-          dynamic::from_int(value)
-        },
-      ),
-    ],
-  )
-}
-
 fn score_packet(payload: Str) Int {
   let packet = json::parse<Packet>(payload).expect("valid json")
 
@@ -58,7 +41,7 @@ fn score_packet(payload: Str) Int {
 fn main() {
   mut checksum = 0
   for i in 0..5000 {
-    let encoded = json::encode(packet_to_dynamic(make_packet(i))).expect("encoded")
+    let encoded = json::encode(make_packet(i)).expect("encoded")
     checksum =+ score_packet(encoded)
   }
   io::print(checksum)

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -3058,6 +3058,18 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 			if mod.Path() == "ard/async" && s.Function.Name == "eval" {
 				return c.validateAsyncEval(s.Function.Args[0].Value)
 			}
+			if mod.Path() == "ard/json" && s.Function.Name == "parse" {
+				if err := validateJSONShape("json::parse", call.Type()); err != nil {
+					c.addError(err.Error(), s.GetLocation())
+					return nil
+				}
+			}
+			if mod.Path() == "ard/json" && s.Function.Name == "encode" && len(args) > 0 {
+				if err := validateJSONShape("json::encode", args[0].Type()); err != nil {
+					c.addError(err.Error(), s.GetLocation())
+					return nil
+				}
+			}
 
 			return &ModuleFunctionCall{
 				Module: mod.Path(),
@@ -5409,4 +5421,46 @@ func (c *Checker) wrapAccessorInMatch(subject Expression, prop *InstanceProperty
 		None:      noneBlock,
 		InnerType: innerType,
 	}
+}
+
+func validateJSONShape(api string, typ Type) error {
+	if result, ok := derefType(typ).(*Result); ok && api == "json::parse" {
+		typ = result.Val()
+	}
+	return validateJSONShapeType(api, derefType(typ), map[string]bool{})
+}
+
+func validateJSONShapeType(api string, typ Type, seen map[string]bool) error {
+	typ = derefType(typ)
+	if typ == Str || typ == Int || typ == Float || typ == Bool || typ == Dynamic {
+		return nil
+	}
+	switch t := typ.(type) {
+	case *List:
+		return validateJSONShapeType(api, t.Of(), seen)
+	case *Map:
+		if derefType(t.Key()) != Str {
+			return fmt.Errorf("%s only supports Str map keys, got %s", api, t.Key().String())
+		}
+		return validateJSONShapeType(api, t.Value(), seen)
+	case *Maybe:
+		return validateJSONShapeType(api, t.Of(), seen)
+	case *StructDef:
+		name := t.String()
+		if seen[name] {
+			return nil
+		}
+		seen[name] = true
+		for fieldName, fieldType := range t.Fields {
+			if err := validateJSONShapeType(api, fieldType, seen); err != nil {
+				return fmt.Errorf("%s field %s: %w", api, fieldName, err)
+			}
+		}
+		return nil
+	case *TypeVar:
+		if t.Actual() != nil {
+			return validateJSONShapeType(api, t.Actual(), seen)
+		}
+	}
+	return fmt.Errorf("%s does not support %s", api, typ.String())
 }

--- a/compiler/checker/traits_test.go
+++ b/compiler/checker/traits_test.go
@@ -137,6 +137,28 @@ func TestTraitsAsTypes(t *testing.T) {
 				{Kind: checker.Error, Message: "Type mismatch: Expected implementation of Encodable, got [Int]"},
 			},
 		},
+		{
+			name: "json parse validates supported target type",
+			input: `
+			use ard/json
+
+			json::parse<fn() Void>("null")
+			`,
+			diagnostics: []checker.Diagnostic{
+				{Kind: checker.Error, Message: "json::parse does not support fn <function>() Void"},
+			},
+		},
+		{
+			name: "json parse validates map keys",
+			input: `
+			use ard/json
+
+			json::parse<[Int: Str]>("{}")
+			`,
+			diagnostics: []checker.Diagnostic{
+				{Kind: checker.Error, Message: "json::parse only supports Str map keys, got Int"},
+			},
+		},
 		// {
 		// 	name: "functions with Trait return",
 		// 	input: `

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -323,7 +323,10 @@ func (l *lowerer) runtimePreludeDecls() []ast.Decl {
 	}
 	if l.runtimeHelpers["json_parse"] {
 		l.currentImports["fmt"] = "fmt"
+		l.currentImports["json"] = "encoding/json/v2"
+		l.currentImports["jsontext"] = "encoding/json/jsontext"
 		l.currentImports["runtime"] = "github.com/akonwi/ard/runtime"
+		l.currentImports["strconv"] = "strconv"
 		parts = append(parts, l.jsonParsePreludeSource())
 	}
 	if l.runtimeHelpers["json_encode"] {
@@ -4026,7 +4029,11 @@ func (l *lowerer) lowerExternCall(fn air.Function, expr air.Expr) (loweredExpr, 
 			return loweredExpr{}, fmt.Errorf("JsonEncode expects 1 arg")
 		}
 		l.markRuntimeHelper("json_encode")
-		wrapped, err := l.wrapValueErrorCall(expr.Type, &ast.CallExpr{Fun: ast.NewIdent(l.jsonEncodeTopHelperName(expr.Args[0].Type)), Args: args})
+		helper := l.jsonEncodeTopHelperName(expr.Args[0].Type)
+		if l.jsonNativeCodecSafe(expr.Args[0].Type, map[air.TypeID]bool{}) {
+			helper = l.jsonEncodeMarshalTopHelperName(expr.Args[0].Type)
+		}
+		wrapped, err := l.wrapValueErrorCall(expr.Type, &ast.CallExpr{Fun: ast.NewIdent(helper), Args: args})
 		if err != nil {
 			return loweredExpr{}, err
 		}
@@ -4272,27 +4279,17 @@ func (l *lowerer) lowerJSONParseExtern(expr air.Expr, args []ast.Expr, stmts []a
 	if err != nil {
 		return loweredExpr{}, err
 	}
-	rawTemp := l.nextTemp()
 	errTemp := l.nextTemp()
 	hostErrTemp := l.nextTemp()
 	outTemp := l.nextTemp()
 
 	allStmts := append([]ast.Stmt{}, stmts...)
 	allStmts = append(allStmts,
-		&ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(rawTemp)}, Type: ast.NewIdent("any")}}}},
 		&ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(errTemp)}, Type: ast.NewIdent("string")}}}},
 		&ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(hostErrTemp)}, Type: ast.NewIdent("error")}}}},
 		&ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(outTemp)}, Type: valueType}}}},
-		&ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(rawTemp), ast.NewIdent(hostErrTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{&ast.CallExpr{Fun: l.qualified("stdlibffi", "github.com/akonwi/ard/std_lib/ffi", "JsonToDynamic"), Args: []ast.Expr{args[0]}}}},
+		&ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(hostErrTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{&ast.CallExpr{Fun: l.qualified("json", "encoding/json/v2", "Unmarshal"), Args: []ast.Expr{&ast.CallExpr{Fun: &ast.ArrayType{Elt: ast.NewIdent("byte")}, Args: []ast.Expr{args[0]}}, &ast.UnaryExpr{Op: token.AND, X: ast.NewIdent(outTemp)}}}}},
 		&ast.IfStmt{Cond: &ast.BinaryExpr{X: ast.NewIdent(hostErrTemp), Op: token.NEQ, Y: ast.NewIdent("nil")}, Body: &ast.BlockStmt{List: []ast.Stmt{&ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(errTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{&ast.CallExpr{Fun: &ast.SelectorExpr{X: ast.NewIdent(hostErrTemp), Sel: ast.NewIdent("Error")}}}}}}},
-		&ast.IfStmt{
-			Cond: &ast.BinaryExpr{X: ast.NewIdent(errTemp), Op: token.EQL, Y: &ast.BasicLit{Kind: token.STRING, Value: `""`}},
-			Body: &ast.BlockStmt{List: []ast.Stmt{&ast.AssignStmt{
-				Lhs: []ast.Expr{ast.NewIdent(outTemp), ast.NewIdent(errTemp)},
-				Tok: token.ASSIGN,
-				Rhs: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent(l.jsonParseHelperName(resultInfo.Value)), Args: []ast.Expr{ast.NewIdent(rawTemp), &ast.BasicLit{Kind: token.STRING, Value: `""`}}}},
-			}}},
-		},
 	)
 	resultExpr := &ast.CompositeLit{Type: mustTypeExpr(l, expr.Type), Elts: []ast.Expr{
 		&ast.KeyValueExpr{Key: ast.NewIdent("Value"), Value: ast.NewIdent(outTemp)},
@@ -4354,6 +4351,7 @@ func ardJSONMissing(path string, expected string) string {
 			continue
 		}
 		l.writeJSONParseHelper(&b, typ.ID)
+		l.writeJSONDecodeTextHelper(&b, typ.ID)
 	}
 	return b.String()
 }
@@ -4404,6 +4402,9 @@ func (l *lowerer) writeJSONParseHelper(b *strings.Builder, typeID air.TypeID) {
 		fmt.Fprintf(b, "\treturn out, ardJSONErr(path, %q, raw)\n", info.Name)
 	}
 	fmt.Fprintf(b, "}\n")
+	if info.Kind == air.TypeStruct {
+		fmt.Fprintf(b, "\nfunc (out *%s) UnmarshalJSONFrom(dec *jsontext.Decoder) error {\n\tparsed, message := %s(dec, \"\")\n\tif message != \"\" { return fmt.Errorf(\"%%s\", message) }\n\t*out = parsed\n\treturn nil\n}\n", typeName, l.jsonDecodeTextHelperName(typeID))
+	}
 }
 
 func (l *lowerer) jsonParseHelperName(typeID air.TypeID) string {
@@ -4503,7 +4504,11 @@ func (l *lowerer) writeJSONEncodeHelper(b *strings.Builder, typeID air.TypeID) {
 		fmt.Fprintf(b, "\tdata, err := json.Marshal(value)\n\tif err != nil { return err }\n\treturn enc.WriteValue(jsontext.Value(data))\n")
 	}
 	fmt.Fprintf(b, "}\n")
+	if info.Kind == air.TypeStruct {
+		fmt.Fprintf(b, "\nfunc (value %s) MarshalJSONTo(enc *jsontext.Encoder) error {\n\treturn %s(enc, value)\n}\n", typeName, helper)
+	}
 	fmt.Fprintf(b, "\nfunc %s(value %s) (string, error) {\n\tvar buf bytes.Buffer\n\tenc := jsontext.NewEncoder(&buf)\n\tif err := %s(enc, value); err != nil { return \"\", err }\n\treturn string(bytes.TrimSuffix(buf.Bytes(), []byte(\"\\n\"))), nil\n}\n", l.jsonEncodeTopHelperName(typeID), typeName, helper)
+	fmt.Fprintf(b, "\nfunc %s(value %s) (string, error) {\n\tdata, err := json.Marshal(value)\n\tif err != nil { return \"\", err }\n\treturn string(data), nil\n}\n", l.jsonEncodeMarshalTopHelperName(typeID), typeName)
 }
 
 func (l *lowerer) jsonEncodeHelperName(typeID air.TypeID) string {
@@ -4512,4 +4517,87 @@ func (l *lowerer) jsonEncodeHelperName(typeID air.TypeID) string {
 
 func (l *lowerer) jsonEncodeTopHelperName(typeID air.TypeID) string {
 	return fmt.Sprintf("ardJSONEncodeTop_%d", typeID)
+}
+
+func (l *lowerer) jsonEncodeMarshalTopHelperName(typeID air.TypeID) string {
+	return fmt.Sprintf("ardJSONMarshalTop_%d", typeID)
+}
+
+func (l *lowerer) jsonNativeCodecSafe(typeID air.TypeID, seen map[air.TypeID]bool) bool {
+	if !validTypeID(l.program, typeID) {
+		return false
+	}
+	if seen[typeID] {
+		return true
+	}
+	seen[typeID] = true
+	info := l.program.Types[typeID-1]
+	switch info.Kind {
+	case air.TypeVoid, air.TypeInt, air.TypeFloat, air.TypeBool, air.TypeStr, air.TypeEnum:
+		return true
+	case air.TypeList:
+		return l.jsonNativeCodecSafe(info.Elem, seen)
+	case air.TypeMap:
+		keyInfo := l.program.Types[info.Key-1]
+		return keyInfo.Kind == air.TypeStr && l.jsonNativeCodecSafe(info.Value, seen)
+	case air.TypeStruct:
+		for _, field := range info.Fields {
+			if !l.jsonNativeCodecSafe(field.Type, seen) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func (l *lowerer) writeJSONDecodeTextHelper(b *strings.Builder, typeID air.TypeID) {
+	if !validTypeID(l.program, typeID) {
+		return
+	}
+	info := l.program.Types[typeID-1]
+	typeName := l.jsonParseGoTypeName(typeID)
+	helper := l.jsonDecodeTextHelperName(typeID)
+	fmt.Fprintf(b, "\nfunc %s(dec *jsontext.Decoder, path string) (%s, string) {\n", helper, typeName)
+	fmt.Fprintf(b, "\tvar out %s\n\t_ = out\n", typeName)
+	switch info.Kind {
+	case air.TypeInt:
+		fmt.Fprintf(b, "\ttok, err := dec.ReadToken()\n\tif err != nil { return out, err.Error() }\n\tif tok.Kind() != jsontext.KindNumber { return out, path + \": got \" + tok.Kind().String() + \", expected Int\" }\n\tparsed, err := strconv.ParseInt(tok.String(), 10, 0)\n\tif err != nil { return out, path + \": got Number, expected Int\" }\n\treturn int(parsed), \"\"\n")
+	case air.TypeFloat:
+		fmt.Fprintf(b, "\ttok, err := dec.ReadToken()\n\tif err != nil { return out, err.Error() }\n\tif tok.Kind() != jsontext.KindNumber { return out, path + \": got \" + tok.Kind().String() + \", expected Float\" }\n\tparsed, err := strconv.ParseFloat(tok.String(), 64)\n\tif err != nil { return out, path + \": got Number, expected Float\" }\n\treturn parsed, \"\"\n")
+	case air.TypeBool:
+		fmt.Fprintf(b, "\ttok, err := dec.ReadToken()\n\tif err != nil { return out, err.Error() }\n\tif tok.Kind() == jsontext.KindTrue { return true, \"\" }\n\tif tok.Kind() == jsontext.KindFalse { return false, \"\" }\n\treturn out, path + \": got \" + tok.Kind().String() + \", expected Bool\"\n")
+	case air.TypeStr:
+		fmt.Fprintf(b, "\ttok, err := dec.ReadToken()\n\tif err != nil { return out, err.Error() }\n\tif tok.Kind() != jsontext.KindString { return out, path + \": got \" + tok.Kind().String() + \", expected Str\" }\n\treturn tok.String(), \"\"\n")
+	case air.TypeDynamic:
+		fmt.Fprintf(b, "\tvalue, err := dec.ReadValue()\n\tif err != nil { return out, err.Error() }\n\tvar raw any\n\tif err := json.Unmarshal(value, &raw); err != nil { return out, err.Error() }\n\treturn raw, \"\"\n")
+	case air.TypeMaybe:
+		fmt.Fprintf(b, "\tif dec.PeekKind() == jsontext.KindNull { _, _ = dec.ReadToken(); return out, \"\" }\n\tvalue, message := %s(dec, path)\n\tif message != \"\" { return out, message }\n\tout.Value = value\n\tout.Some = true\n\treturn out, \"\"\n", l.jsonDecodeTextHelperName(info.Elem))
+	case air.TypeList:
+		fmt.Fprintf(b, "\ttok, err := dec.ReadToken()\n\tif err != nil { return out, err.Error() }\n\tif tok.Kind() != jsontext.KindBeginArray { return out, path + \": got \" + tok.Kind().String() + \", expected %s\" }\n\tfor i := 0; dec.PeekKind() != jsontext.KindEndArray; i++ {\n\t\tvalue, message := %s(dec, ardJSONPath(path, fmt.Sprintf(\"[%%d]\", i)))\n\t\tif message != \"\" { return out, message }\n\t\tout = append(out, value)\n\t}\n\t_, err = dec.ReadToken()\n\tif err != nil { return out, err.Error() }\n\treturn out, \"\"\n", info.Name, l.jsonDecodeTextHelperName(info.Elem))
+	case air.TypeMap:
+		fmt.Fprintf(b, "\ttok, err := dec.ReadToken()\n\tif err != nil { return out, err.Error() }\n\tif tok.Kind() != jsontext.KindBeginObject { return out, path + \": got \" + tok.Kind().String() + \", expected %s\" }\n\tout = make(%s)\n\tfor dec.PeekKind() != jsontext.KindEndObject {\n\t\tkeyTok, err := dec.ReadToken()\n\t\tif err != nil { return out, err.Error() }\n\t\tkey := keyTok.String()\n\t\tvalue, message := %s(dec, ardJSONPath(path, key))\n\t\tif message != \"\" { return out, message }\n\t\tout[key] = value\n\t}\n\t_, err = dec.ReadToken()\n\tif err != nil { return out, err.Error() }\n\treturn out, \"\"\n", info.Name, typeName, l.jsonDecodeTextHelperName(info.Value))
+	case air.TypeStruct:
+		fmt.Fprintf(b, "\ttok, err := dec.ReadToken()\n\tif err != nil { return out, err.Error() }\n\tif tok.Kind() != jsontext.KindBeginObject { return out, path + \": got \" + tok.Kind().String() + \", expected %s\" }\n", info.Name)
+		fmt.Fprintf(b, "\tseen := map[string]bool{}\n\tfor dec.PeekKind() != jsontext.KindEndObject {\n\t\tkeyTok, err := dec.ReadToken()\n\t\tif err != nil { return out, err.Error() }\n\t\tkey := keyTok.String()\n\t\tswitch key {\n")
+		for _, field := range info.Fields {
+			fmt.Fprintf(b, "\t\tcase %q:\n\t\t\tvalue, message := %s(dec, ardJSONPath(path, key))\n\t\t\tif message != \"\" { return out, message }\n\t\t\tout.%s = value\n\t\t\tseen[key] = true\n", field.Name, l.jsonDecodeTextHelperName(field.Type), field.Name)
+		}
+		fmt.Fprintf(b, "\t\tdefault:\n\t\t\tif err := dec.SkipValue(); err != nil { return out, err.Error() }\n\t\t}\n\t}\n\t_, err = dec.ReadToken()\n\tif err != nil { return out, err.Error() }\n")
+		for _, field := range info.Fields {
+			fieldInfo := l.program.Types[field.Type-1]
+			if fieldInfo.Kind != air.TypeMaybe {
+				fmt.Fprintf(b, "\tif !seen[%q] { return out, ardJSONMissing(ardJSONPath(path, %q), %q) }\n", field.Name, field.Name, fieldInfo.Name)
+			}
+		}
+		fmt.Fprintf(b, "\treturn out, \"\"\n")
+	default:
+		fmt.Fprintf(b, "\treturn out, ardJSONErr(path, %q, nil)\n", info.Name)
+	}
+	fmt.Fprintf(b, "}\n")
+}
+
+func (l *lowerer) jsonDecodeTextHelperName(typeID air.TypeID) string {
+	return fmt.Sprintf("ardJSONDecodeText_%d", typeID)
 }

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -321,6 +321,11 @@ func (l *lowerer) runtimePreludeDecls() []ast.Decl {
 	}
 `)
 	}
+	if l.runtimeHelpers["json_parse"] {
+		l.currentImports["fmt"] = "fmt"
+		l.currentImports["runtime"] = "github.com/akonwi/ard/runtime"
+		parts = append(parts, l.jsonParsePreludeSource())
+	}
 	src := strings.Join(parts, "\n")
 	file, err := parser.ParseFile(token.NewFileSet(), "prelude.go", src, 0)
 	if err != nil {
@@ -4016,6 +4021,12 @@ func (l *lowerer) lowerExternCall(fn air.Function, expr air.Expr) (loweredExpr, 
 		}
 		wrapped.stmts = append(stmts, wrapped.stmts...)
 		return wrapped, nil
+	case "JsonParse":
+		wrapped, err := l.lowerJSONParseExtern(expr, args, stmts)
+		if err != nil {
+			return loweredExpr{}, err
+		}
+		return wrapped, nil
 	case "VoidToDynamic":
 		return loweredExpr{stmts: stmts, expr: ast.NewIdent("nil")}, nil
 	case "JsonToDynamic":
@@ -4232,4 +4243,189 @@ func validFunctionID(program *air.Program, id air.FunctionID) bool {
 
 func validTypeID(program *air.Program, id air.TypeID) bool {
 	return id > 0 && int(id) <= len(program.Types)
+}
+
+func (l *lowerer) lowerJSONParseExtern(expr air.Expr, args []ast.Expr, stmts []ast.Stmt) (loweredExpr, error) {
+	if len(args) != 1 || len(expr.Args) != 1 {
+		return loweredExpr{}, fmt.Errorf("JsonParse expects 1 arg")
+	}
+	if !validTypeID(l.program, expr.Type) {
+		return loweredExpr{}, fmt.Errorf("invalid JsonParse result type %d", expr.Type)
+	}
+	resultInfo := l.program.Types[expr.Type-1]
+	if resultInfo.Kind != air.TypeResult {
+		return loweredExpr{}, fmt.Errorf("JsonParse expected result return, got %s", resultInfo.Name)
+	}
+	l.markRuntimeHelper("json_parse")
+	valueType, err := l.goType(resultInfo.Value)
+	if err != nil {
+		return loweredExpr{}, err
+	}
+	rawTemp := l.nextTemp()
+	errTemp := l.nextTemp()
+	hostErrTemp := l.nextTemp()
+	outTemp := l.nextTemp()
+
+	allStmts := append([]ast.Stmt{}, stmts...)
+	allStmts = append(allStmts,
+		&ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(rawTemp)}, Type: ast.NewIdent("any")}}}},
+		&ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(errTemp)}, Type: ast.NewIdent("string")}}}},
+		&ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(hostErrTemp)}, Type: ast.NewIdent("error")}}}},
+		&ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(outTemp)}, Type: valueType}}}},
+		&ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(rawTemp), ast.NewIdent(hostErrTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{&ast.CallExpr{Fun: l.qualified("stdlibffi", "github.com/akonwi/ard/std_lib/ffi", "JsonToDynamic"), Args: []ast.Expr{args[0]}}}},
+		&ast.IfStmt{Cond: &ast.BinaryExpr{X: ast.NewIdent(hostErrTemp), Op: token.NEQ, Y: ast.NewIdent("nil")}, Body: &ast.BlockStmt{List: []ast.Stmt{&ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(errTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{&ast.CallExpr{Fun: &ast.SelectorExpr{X: ast.NewIdent(hostErrTemp), Sel: ast.NewIdent("Error")}}}}}}},
+		&ast.IfStmt{
+			Cond: &ast.BinaryExpr{X: ast.NewIdent(errTemp), Op: token.EQL, Y: &ast.BasicLit{Kind: token.STRING, Value: `""`}},
+			Body: &ast.BlockStmt{List: []ast.Stmt{&ast.AssignStmt{
+				Lhs: []ast.Expr{ast.NewIdent(outTemp), ast.NewIdent(errTemp)},
+				Tok: token.ASSIGN,
+				Rhs: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent(l.jsonParseHelperName(resultInfo.Value)), Args: []ast.Expr{ast.NewIdent(rawTemp), &ast.BasicLit{Kind: token.STRING, Value: `""`}}}},
+			}}},
+		},
+	)
+	resultExpr := &ast.CompositeLit{Type: mustTypeExpr(l, expr.Type), Elts: []ast.Expr{
+		&ast.KeyValueExpr{Key: ast.NewIdent("Value"), Value: ast.NewIdent(outTemp)},
+		&ast.KeyValueExpr{Key: ast.NewIdent("Err"), Value: ast.NewIdent(errTemp)},
+		&ast.KeyValueExpr{Key: ast.NewIdent("Ok"), Value: &ast.BinaryExpr{X: ast.NewIdent(errTemp), Op: token.EQL, Y: &ast.BasicLit{Kind: token.STRING, Value: `""`}}},
+	}}
+	return loweredExpr{stmts: allStmts, expr: resultExpr}, nil
+}
+
+func (l *lowerer) jsonParsePreludeSource() string {
+	var b strings.Builder
+	b.WriteString(`
+func ardJSONPath(path string, segment string) string {
+	if path == "" {
+		return segment
+	}
+	if len(segment) > 0 && segment[0] == '[' {
+		return path + segment
+	}
+	return path + "." + segment
+}
+
+func ardJSONFound(raw any) string {
+	switch raw.(type) {
+	case nil:
+		return "null"
+	case string:
+		return "Str"
+	case bool:
+		return "Bool"
+	case float64, float32, int, int64, uint64:
+		return "Number"
+	case []any:
+		return "List"
+	case map[string]any:
+		return "Map"
+	default:
+		return fmt.Sprintf("%T", raw)
+	}
+}
+
+func ardJSONErr(path string, expected string, raw any) string {
+	message := "got " + ardJSONFound(raw) + ", expected " + expected
+	if path == "" {
+		return message
+	}
+	return path + ": " + message
+}
+
+func ardJSONMissing(path string, expected string) string {
+	if path == "" {
+		return "missing, expected " + expected
+	}
+	return path + ": missing, expected " + expected
+}
+`)
+	for _, typ := range l.program.Types {
+		if typ.ID == air.NoType {
+			continue
+		}
+		l.writeJSONParseHelper(&b, typ.ID)
+	}
+	return b.String()
+}
+
+func (l *lowerer) writeJSONParseHelper(b *strings.Builder, typeID air.TypeID) {
+	if !validTypeID(l.program, typeID) {
+		return
+	}
+	info := l.program.Types[typeID-1]
+	typeName := l.jsonParseGoTypeName(typeID)
+	helper := l.jsonParseHelperName(typeID)
+	fmt.Fprintf(b, "\nfunc %s(raw any, path string) (%s, string) {\n", helper, typeName)
+	fmt.Fprintf(b, "\tvar out %s\n\t_ = out\n", typeName)
+	switch info.Kind {
+	case air.TypeInt:
+		fmt.Fprintf(b, "\tswitch value := raw.(type) {\n\tcase float64:\n\t\tparsed := int(value)\n\t\tif value == float64(parsed) { return parsed, \"\" }\n\tcase int:\n\t\treturn value, \"\"\n\t}\n\treturn out, ardJSONErr(path, \"Int\", raw)\n")
+	case air.TypeFloat:
+		fmt.Fprintf(b, "\tswitch value := raw.(type) {\n\tcase float64:\n\t\treturn value, \"\"\n\tcase int:\n\t\treturn float64(value), \"\"\n\t}\n\treturn out, ardJSONErr(path, \"Float\", raw)\n")
+	case air.TypeBool:
+		fmt.Fprintf(b, "\tif value, ok := raw.(bool); ok { return value, \"\" }\n\treturn out, ardJSONErr(path, \"Bool\", raw)\n")
+	case air.TypeStr:
+		fmt.Fprintf(b, "\tif value, ok := raw.(string); ok { return value, \"\" }\n\treturn out, ardJSONErr(path, \"Str\", raw)\n")
+	case air.TypeDynamic:
+		fmt.Fprintf(b, "\treturn raw, \"\"\n")
+	case air.TypeMaybe:
+		elemHelper := l.jsonParseHelperName(info.Elem)
+		fmt.Fprintf(b, "\tif raw == nil { return out, \"\" }\n\tvalue, err := %s(raw, path)\n\tif err != \"\" { return out, err }\n\tout.Value = value\n\tout.Some = true\n\treturn out, \"\"\n", elemHelper)
+	case air.TypeList:
+		elemHelper := l.jsonParseHelperName(info.Elem)
+		fmt.Fprintf(b, "\titems, ok := raw.([]any)\n\tif !ok { return out, ardJSONErr(path, \"%s\", raw) }\n\tout = make(%s, len(items))\n\tfor i, item := range items {\n\t\tvalue, err := %s(item, ardJSONPath(path, fmt.Sprintf(\"[%%d]\", i)))\n\t\tif err != \"\" { return out, err }\n\t\tout[i] = value\n\t}\n\treturn out, \"\"\n", info.Name, typeName, elemHelper)
+	case air.TypeMap:
+		valueHelper := l.jsonParseHelperName(info.Value)
+		fmt.Fprintf(b, "\titems, ok := raw.(map[string]any)\n\tif !ok { return out, ardJSONErr(path, \"%s\", raw) }\n\tout = make(%s, len(items))\n\tfor key, item := range items {\n\t\tvalue, err := %s(item, ardJSONPath(path, key))\n\t\tif err != \"\" { return out, err }\n\t\tout[key] = value\n\t}\n\treturn out, \"\"\n", info.Name, typeName, valueHelper)
+	case air.TypeStruct:
+		fmt.Fprintf(b, "\titems, ok := raw.(map[string]any)\n\tif !ok { return out, ardJSONErr(path, \"%s\", raw) }\n", info.Name)
+		for _, field := range info.Fields {
+			fieldInfo := l.program.Types[field.Type-1]
+			fieldHelper := l.jsonParseHelperName(field.Type)
+			fieldAccess := field.Name
+			if fieldInfo.Kind == air.TypeMaybe {
+				fmt.Fprintf(b, "\tif rawField, ok := items[%q]; ok {\n\t\tvalue, err := %s(rawField, ardJSONPath(path, %q))\n\t\tif err != \"\" { return out, err }\n\t\tout.%s = value\n\t}\n", field.Name, fieldHelper, field.Name, fieldAccess)
+			} else {
+				fmt.Fprintf(b, "\traw%s, ok := items[%q]\n\tif !ok { return out, ardJSONMissing(ardJSONPath(path, %q), \"%s\") }\n\tvalue%s, err := %s(raw%s, ardJSONPath(path, %q))\n\tif err != \"\" { return out, err }\n\tout.%s = value%s\n", exportedFieldName(field.Name), field.Name, field.Name, fieldInfo.Name, exportedFieldName(field.Name), fieldHelper, exportedFieldName(field.Name), field.Name, fieldAccess, exportedFieldName(field.Name))
+			}
+		}
+		fmt.Fprintf(b, "\treturn out, \"\"\n")
+	default:
+		fmt.Fprintf(b, "\treturn out, ardJSONErr(path, %q, raw)\n", info.Name)
+	}
+	fmt.Fprintf(b, "}\n")
+}
+
+func (l *lowerer) jsonParseHelperName(typeID air.TypeID) string {
+	return fmt.Sprintf("ardJSONParse_%d", typeID)
+}
+
+func (l *lowerer) jsonParseGoTypeName(typeID air.TypeID) string {
+	if !validTypeID(l.program, typeID) {
+		return "any"
+	}
+	info := l.program.Types[typeID-1]
+	switch info.Kind {
+	case air.TypeVoid:
+		return "struct{}"
+	case air.TypeInt:
+		return "int"
+	case air.TypeFloat:
+		return "float64"
+	case air.TypeBool:
+		return "bool"
+	case air.TypeStr:
+		return "string"
+	case air.TypeDynamic, air.TypeExtern, air.TypeTraitObject:
+		return "any"
+	case air.TypeMaybe:
+		return "runtime.Maybe[" + l.jsonParseGoTypeName(info.Elem) + "]"
+	case air.TypeList:
+		return "[]" + l.jsonParseGoTypeName(info.Elem)
+	case air.TypeMap:
+		return "map[" + l.jsonParseGoTypeName(info.Key) + "]" + l.jsonParseGoTypeName(info.Value)
+	case air.TypeStruct, air.TypeEnum, air.TypeUnion:
+		return typeName(l.program, info)
+	default:
+		return "any"
+	}
 }

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -326,6 +326,13 @@ func (l *lowerer) runtimePreludeDecls() []ast.Decl {
 		l.currentImports["runtime"] = "github.com/akonwi/ard/runtime"
 		parts = append(parts, l.jsonParsePreludeSource())
 	}
+	if l.runtimeHelpers["json_encode"] {
+		l.currentImports["bytes"] = "bytes"
+		l.currentImports["fmt"] = "fmt"
+		l.currentImports["json"] = "encoding/json/v2"
+		l.currentImports["jsontext"] = "encoding/json/jsontext"
+		parts = append(parts, l.jsonEncodePreludeSource())
+	}
 	src := strings.Join(parts, "\n")
 	file, err := parser.ParseFile(token.NewFileSet(), "prelude.go", src, 0)
 	if err != nil {
@@ -4015,7 +4022,11 @@ func (l *lowerer) lowerExternCall(fn air.Function, expr air.Expr) (loweredExpr, 
 	case "MapToDynamic":
 		return loweredExpr{stmts: stmts, expr: &ast.CallExpr{Fun: l.qualified("stdlibffi", "github.com/akonwi/ard/std_lib/ffi", "MapToDynamic"), Args: args}}, nil
 	case "JsonEncode":
-		wrapped, err := l.wrapValueErrorCall(expr.Type, &ast.CallExpr{Fun: l.qualified("stdlibffi", "github.com/akonwi/ard/std_lib/ffi", "JsonEncode"), Args: args})
+		if len(args) != 1 || len(expr.Args) != 1 {
+			return loweredExpr{}, fmt.Errorf("JsonEncode expects 1 arg")
+		}
+		l.markRuntimeHelper("json_encode")
+		wrapped, err := l.wrapValueErrorCall(expr.Type, &ast.CallExpr{Fun: ast.NewIdent(l.jsonEncodeTopHelperName(expr.Args[0].Type)), Args: args})
 		if err != nil {
 			return loweredExpr{}, err
 		}
@@ -4428,4 +4439,77 @@ func (l *lowerer) jsonParseGoTypeName(typeID air.TypeID) string {
 	default:
 		return "any"
 	}
+}
+
+func (l *lowerer) jsonEncodePreludeSource() string {
+	var b strings.Builder
+	for _, typ := range l.program.Types {
+		if typ.ID == air.NoType {
+			continue
+		}
+		l.writeJSONEncodeHelper(&b, typ.ID)
+	}
+	return b.String()
+}
+
+func (l *lowerer) writeJSONEncodeHelper(b *strings.Builder, typeID air.TypeID) {
+	if !validTypeID(l.program, typeID) {
+		return
+	}
+	info := l.program.Types[typeID-1]
+	typeName := l.jsonParseGoTypeName(typeID)
+	helper := l.jsonEncodeHelperName(typeID)
+	fmt.Fprintf(b, "\nfunc %s(enc *jsontext.Encoder, value %s) error {\n", helper, typeName)
+	switch info.Kind {
+	case air.TypeVoid:
+		fmt.Fprintf(b, "\treturn enc.WriteToken(jsontext.Null)\n")
+	case air.TypeInt:
+		fmt.Fprintf(b, "\treturn enc.WriteToken(jsontext.Int(int64(value)))\n")
+	case air.TypeFloat:
+		fmt.Fprintf(b, "\treturn enc.WriteToken(jsontext.Float(value))\n")
+	case air.TypeBool:
+		fmt.Fprintf(b, "\tif value { return enc.WriteToken(jsontext.True) }\n\treturn enc.WriteToken(jsontext.False)\n")
+	case air.TypeStr:
+		fmt.Fprintf(b, "\treturn enc.WriteToken(jsontext.String(value))\n")
+	case air.TypeDynamic, air.TypeExtern, air.TypeTraitObject:
+		fmt.Fprintf(b, "\tdata, err := json.Marshal(value)\n\tif err != nil { return err }\n\treturn enc.WriteValue(jsontext.Value(data))\n")
+	case air.TypeMaybe:
+		fmt.Fprintf(b, "\tif !value.Some { return enc.WriteToken(jsontext.Null) }\n\treturn %s(enc, value.Value)\n", l.jsonEncodeHelperName(info.Elem))
+	case air.TypeResult:
+		fmt.Fprintf(b, "\tdata, err := json.Marshal(value)\n\tif err != nil { return err }\n\treturn enc.WriteValue(jsontext.Value(data))\n")
+	case air.TypeList:
+		fmt.Fprintf(b, "\tif err := enc.WriteToken(jsontext.BeginArray); err != nil { return err }\n\tfor _, item := range value {\n\t\tif err := %s(enc, item); err != nil { return err }\n\t}\n\treturn enc.WriteToken(jsontext.EndArray)\n", l.jsonEncodeHelperName(info.Elem))
+	case air.TypeMap:
+		fmt.Fprintf(b, "\tif err := enc.WriteToken(jsontext.BeginObject); err != nil { return err }\n\tfor key, item := range value {\n\t\tif err := enc.WriteToken(jsontext.String(fmt.Sprint(key))); err != nil { return err }\n\t\tif err := %s(enc, item); err != nil { return err }\n\t}\n\treturn enc.WriteToken(jsontext.EndObject)\n", l.jsonEncodeHelperName(info.Value))
+	case air.TypeStruct:
+		fmt.Fprintf(b, "\tif err := enc.WriteToken(jsontext.BeginObject); err != nil { return err }\n")
+		for _, field := range info.Fields {
+			fmt.Fprintf(b, "\tif err := enc.WriteToken(jsontext.String(%q)); err != nil { return err }\n", field.Name)
+			fmt.Fprintf(b, "\tif err := %s(enc, value.%s); err != nil { return err }\n", l.jsonEncodeHelperName(field.Type), field.Name)
+		}
+		fmt.Fprintf(b, "\treturn enc.WriteToken(jsontext.EndObject)\n")
+	case air.TypeEnum:
+		fmt.Fprintf(b, "\treturn enc.WriteToken(jsontext.Int(int64(value)))\n")
+	case air.TypeUnion:
+		fmt.Fprintf(b, "\tswitch value.tag {\n")
+		for _, member := range info.Members {
+			fieldName := unionMemberFieldName(member)
+			fmt.Fprintf(b, "\tcase %d:\n\t\treturn %s(enc, value.%s)\n", member.Tag, l.jsonEncodeHelperName(member.Type), fieldName)
+		}
+		fmt.Fprintf(b, "\t}\n\treturn enc.WriteToken(jsontext.Null)\n")
+	case air.TypeFunction, air.TypeFiber:
+		fmt.Fprintf(b, "\tdata, err := json.Marshal(value)\n\tif err != nil { return err }\n\treturn enc.WriteValue(jsontext.Value(data))\n")
+	default:
+		fmt.Fprintf(b, "\tdata, err := json.Marshal(value)\n\tif err != nil { return err }\n\treturn enc.WriteValue(jsontext.Value(data))\n")
+	}
+	fmt.Fprintf(b, "}\n")
+	fmt.Fprintf(b, "\nfunc %s(value %s) (string, error) {\n\tvar buf bytes.Buffer\n\tenc := jsontext.NewEncoder(&buf)\n\tif err := %s(enc, value); err != nil { return \"\", err }\n\treturn string(bytes.TrimSuffix(buf.Bytes(), []byte(\"\\n\"))), nil\n}\n", l.jsonEncodeTopHelperName(typeID), typeName, helper)
+}
+
+func (l *lowerer) jsonEncodeHelperName(typeID air.TypeID) string {
+	return fmt.Sprintf("ardJSONEncode_%d", typeID)
+}
+
+func (l *lowerer) jsonEncodeTopHelperName(typeID air.TypeID) string {
+	return fmt.Sprintf("ardJSONEncodeTop_%d", typeID)
 }

--- a/compiler/javascript/air_backend.go
+++ b/compiler/javascript/air_backend.go
@@ -1761,7 +1761,7 @@ func isAIRJSPreludeExtern(binding string) bool {
 		"DynamicToList", "DynamicToMap", "ExtractField", "IntFromStr", "FloatFromStr",
 		"FloatFromInt", "FloatFloor", "StrToDynamic", "IntToDynamic",
 		"FloatToDynamic", "BoolToDynamic", "VoidToDynamic", "ListToDynamic", "MapToDynamic",
-		"JsonEncode", "promiseResolve", "promiseReject", "promiseMap", "promiseThen",
+		"JsonEncode", "JsonParse", "promiseResolve", "promiseReject", "promiseMap", "promiseThen",
 		"promiseRescue", "promiseInspect", "promiseInspectError", "promiseFinally",
 		"promiseAll", "promiseRace", "promiseDelay", "fetchNative", "fetchResponseUrl",
 		"fetchResponseStatus", "fetchResponseHeaders", "fetchResponseBody", "fetchErrorMessage":

--- a/compiler/javascript/ard.prelude.mjs
+++ b/compiler/javascript/ard.prelude.mjs
@@ -255,6 +255,14 @@ export function JsonToDynamic(jsonString) {
   }
 }
 
+export function JsonParse(input) {
+  try {
+    return { ok: JSON.parse(input) };
+  } catch (error) {
+    return { err: messageFromError(error) };
+  }
+}
+
 export function DecodeString(data) {
   if (data === null || data === undefined) return { err: makeDecodeError("Str", "null") };
   if (typeof data === "string") return { ok: data };

--- a/compiler/std_lib/ffi/ard.gen.go
+++ b/compiler/std_lib/ffi/ard.gen.go
@@ -123,6 +123,12 @@ type Response struct {
 	Body    string
 }
 
+type TodoJSONTest struct {
+	Id    int
+	Title string
+	Note  Maybe[string]
+}
+
 type Transaction struct {
 	Tx Tx
 }
@@ -448,4 +454,5 @@ func (h Host) Functions() map[string]any {
 // Skipped extern AsyncEval: generic parameters are not generated yet.
 // Skipped extern GetResult: generic parameters are not generated yet.
 // Skipped extern JsonEncode: generic parameters are not generated yet.
+// Skipped extern JsonParse: generic returns are not generated yet.
 // Skipped extern NewList: generic returns are not generated yet.

--- a/compiler/std_lib/json.ard
+++ b/compiler/std_lib/json.ard
@@ -4,6 +4,13 @@ use ard/testing
 
 // Standard library JSON module implemented with FFI
 
+type Input = Str | Dynamic
+
+extern fn parse(input: Input) $T!Str = {
+  go = "JsonParse"
+  js = "JsonParse"
+}
+
 extern fn encode(value: $T) Str!Str = {
   go = "JsonEncode"
   js = "JsonEncode"
@@ -24,6 +31,32 @@ struct WinnerJSONTest {
 struct PredictionJSONTest {
   advice: Str?,
   winner: WinnerJSONTest?,
+}
+
+struct TodoJSONTest {
+  id: Int,
+  title: Str,
+  note: Str?,
+}
+
+test fn test_parse_struct() Void!Str {
+  let raw = "\{\"id\":1,\"title\":\"ship\"\}"
+  let todo = try parse<TodoJSONTest>(raw)
+  testing::assert(todo.id == 1 and todo.title == "ship", "Expected JSON to parse into struct")
+}
+
+test fn test_parse_nullable_missing_field() Void!Str {
+  let raw = "\{\"id\":1,\"title\":\"ship\"\}"
+  let todo = try parse<TodoJSONTest>(raw)
+  testing::assert(todo.note.is_none(), "Expected missing nullable field to parse as none")
+}
+
+test fn test_parse_error_message() Void!Str {
+  let raw = "\{\"id\":\"bad\",\"title\":\"ship\"\}"
+  match parse<TodoJSONTest>(raw) {
+    ok(_) => testing::assert(false, "Expected parse to fail"),
+    err(e) => testing::assert(e.contains("id"), "Expected parse error message to include path"),
+  }
 }
 
 test fn test_encode_int() Void!Str {

--- a/compiler/std_lib/json.ard
+++ b/compiler/std_lib/json.ard
@@ -4,9 +4,7 @@ use ard/testing
 
 // Standard library JSON module implemented with FFI
 
-type Input = Str | Dynamic
-
-extern fn parse(input: Input) $T!Str = {
+extern fn parse(input: Str) $T!Str = {
   go = "JsonParse"
   js = "JsonParse"
 }

--- a/compiler/vm/bytecode_json_parity_test.go
+++ b/compiler/vm/bytecode_json_parity_test.go
@@ -63,23 +63,6 @@ func TestVMBytecodeParityParseJSON(t *testing.T) {
 			want: 2,
 		},
 		{
-			name: "parse dynamic object",
-			input: `
-				use ard/decode
-				use ard/json
-
-				struct Todo {
-					id: Int,
-					title: Str,
-				}
-
-				let raw = decode::from_json("\{\"id\":1,\"title\":\"ship\"}").expect("dynamic")
-				let todo = json::parse<Todo>(raw).expect("parse")
-				todo.title
-			`,
-			want: "ship",
-		},
-		{
 			name: "parse error includes path in message",
 			input: `
 				use ard/json

--- a/compiler/vm/bytecode_json_parity_test.go
+++ b/compiler/vm/bytecode_json_parity_test.go
@@ -2,6 +2,103 @@ package vm
 
 import "testing"
 
+func TestVMBytecodeParityParseJSON(t *testing.T) {
+	runBytecodeParityCases(t, []bytecodeParityCase{
+		{
+			name: "parse struct",
+			input: `
+				use ard/json
+
+				struct Todo {
+					id: Int,
+					title: Str,
+				}
+
+				let todo = json::parse<Todo>("\{\"id\":1,\"title\":\"ship\"}").expect("parse")
+				"{todo.id}:{todo.title}"
+			`,
+			want: "1:ship",
+		},
+		{
+			name: "parse nested list",
+			input: `
+				use ard/json
+
+				struct Todo {
+					id: Int,
+					title: Str,
+				}
+				struct Payload {
+					items: [Todo],
+				}
+
+				let payload = json::parse<Payload>("\{\"items\":[\{\"id\":1,\"title\":\"ship\"}]}").expect("parse")
+				payload.items.at(0).title
+			`,
+			want: "ship",
+		},
+		{
+			name: "parse nullable missing field",
+			input: `
+				use ard/json
+
+				struct Todo {
+					id: Int,
+					title: Str?,
+				}
+
+				let todo = json::parse<Todo>("\{\"id\":1}").expect("parse")
+				todo.title.or("missing")
+			`,
+			want: "missing",
+		},
+		{
+			name: "parse map",
+			input: `
+				use ard/json
+
+				let counts = json::parse<[Str: Int]>("\{\"a\":1,\"b\":2}").expect("parse")
+				counts.get("b").or(0)
+			`,
+			want: 2,
+		},
+		{
+			name: "parse dynamic object",
+			input: `
+				use ard/decode
+				use ard/json
+
+				struct Todo {
+					id: Int,
+					title: Str,
+				}
+
+				let raw = decode::from_json("\{\"id\":1,\"title\":\"ship\"}").expect("dynamic")
+				let todo = json::parse<Todo>(raw).expect("parse")
+				todo.title
+			`,
+			want: "ship",
+		},
+		{
+			name: "parse error includes path in message",
+			input: `
+				use ard/json
+
+				struct Todo {
+					id: Int,
+					title: Str,
+				}
+
+				match json::parse<Todo>("\{\"id\":\"bad\",\"title\":\"ship\"}") {
+					ok(_) => "ok",
+					err(e) => e,
+				}
+			`,
+			want: "id: got Str, expected Int",
+		},
+	})
+}
+
 func TestVMBytecodeParityEncodeJSONPrimitives(t *testing.T) {
 	runBytecodeParityCases(t, []bytecodeParityCase{
 		{

--- a/compiler/vm/ffi.go
+++ b/compiler/vm/ffi.go
@@ -76,6 +76,9 @@ func (vm *VM) callExtern(id air.ExternID, args []Value) (value Value, err error)
 	if binding == "JsonParse" {
 		return vm.callJSONParse(extern, args)
 	}
+	if binding == "JsonEncode" {
+		return vm.callJSONEncode(extern, args)
+	}
 	adapter, ok := vm.externs[id]
 	if !ok {
 		return Value{}, fmt.Errorf("extern binding %q is not registered", binding)

--- a/compiler/vm/ffi.go
+++ b/compiler/vm/ffi.go
@@ -73,6 +73,9 @@ func (vm *VM) callExtern(id air.ExternID, args []Value) (value Value, err error)
 	}
 	extern := vm.program.Externs[id]
 	binding := goExternBinding(extern)
+	if binding == "JsonParse" {
+		return vm.callJSONParse(extern, args)
+	}
 	adapter, ok := vm.externs[id]
 	if !ok {
 		return Value{}, fmt.Errorf("extern binding %q is not registered", binding)

--- a/compiler/vm/json_encode.go
+++ b/compiler/vm/json_encode.go
@@ -1,0 +1,167 @@
+package vm
+
+import (
+	"bytes"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+	"fmt"
+	"strings"
+
+	"github.com/akonwi/ard/air"
+)
+
+func (vm *VM) callJSONEncode(extern air.Extern, args []Value) (Value, error) {
+	returnInfo, err := vm.typeInfo(extern.Signature.Return)
+	if err != nil {
+		return Value{}, err
+	}
+	if returnInfo.Kind != air.TypeResult {
+		return Value{}, fmt.Errorf("JsonEncode return type must be Result, got %s", returnInfo.Name)
+	}
+	if len(args) != 1 {
+		return Value{}, fmt.Errorf("JsonEncode expects 1 arg, got %d", len(args))
+	}
+
+	var buf bytes.Buffer
+	enc := jsontext.NewEncoder(&buf)
+	if err := vm.jsonEncodeValue(enc, args[0]); err != nil {
+		return Result(extern.Signature.Return, false, Str(returnInfo.Error, err.Error())), nil
+	}
+	out := strings.TrimSuffix(buf.String(), "\n")
+	return Result(extern.Signature.Return, true, Str(returnInfo.Value, out)), nil
+}
+
+func (vm *VM) jsonEncodeValue(enc *jsontext.Encoder, value Value) error {
+	switch value.Kind {
+	case ValueVoid:
+		return enc.WriteToken(jsontext.Null)
+	case ValueInt:
+		return enc.WriteToken(jsontext.Int(int64(value.Int)))
+	case ValueFloat:
+		return enc.WriteToken(jsontext.Float(value.Float))
+	case ValueBool:
+		if value.Bool {
+			return enc.WriteToken(jsontext.True)
+		}
+		return enc.WriteToken(jsontext.False)
+	case ValueStr:
+		return enc.WriteToken(jsontext.String(value.Str))
+	case ValueEnum:
+		return enc.WriteToken(jsontext.Int(int64(value.Int)))
+	}
+
+	typeInfo, err := vm.typeInfo(value.Type)
+	if err != nil {
+		return err
+	}
+	switch value.Kind {
+	case ValueDynamic:
+		bytes, err := json.Marshal(value.Ref)
+		if err != nil {
+			return err
+		}
+		return enc.WriteValue(jsontext.Value(bytes))
+	case ValueMaybe:
+		maybeValue, err := value.maybeValue()
+		if err != nil {
+			return err
+		}
+		if !maybeValue.Some {
+			return enc.WriteToken(jsontext.Null)
+		}
+		return vm.jsonEncodeValue(enc, maybeValue.Value)
+	case ValueResult, ValueResultInt, ValueResultStr, ValueResultBool, ValueResultFloat:
+		ok, resultValue, err := value.resultParts()
+		if err != nil {
+			return err
+		}
+		_ = ok
+		return vm.jsonEncodeValue(enc, resultValue)
+	case ValueList:
+		listValue, err := value.listValue()
+		if err != nil {
+			return err
+		}
+		if err := enc.WriteToken(jsontext.BeginArray); err != nil {
+			return err
+		}
+		for _, item := range listValue.Items {
+			if err := vm.jsonEncodeValue(enc, item); err != nil {
+				return err
+			}
+		}
+		return enc.WriteToken(jsontext.EndArray)
+	case ValueMap:
+		mapValue, err := value.mapValue()
+		if err != nil {
+			return err
+		}
+		if err := enc.WriteToken(jsontext.BeginObject); err != nil {
+			return err
+		}
+		for _, entry := range mapValue.Entries {
+			key, err := jsonEncodeMapKey(entry.Key)
+			if err != nil {
+				return err
+			}
+			if err := enc.WriteToken(jsontext.String(key)); err != nil {
+				return err
+			}
+			if err := vm.jsonEncodeValue(enc, entry.Value); err != nil {
+				return err
+			}
+		}
+		return enc.WriteToken(jsontext.EndObject)
+	case ValueStruct:
+		structValue, err := value.structValue()
+		if err != nil {
+			return err
+		}
+		if typeInfo.Kind != air.TypeStruct {
+			return fmt.Errorf("expected struct type, got %s", typeInfo.Name)
+		}
+		if err := enc.WriteToken(jsontext.BeginObject); err != nil {
+			return err
+		}
+		for _, field := range typeInfo.Fields {
+			if err := enc.WriteToken(jsontext.String(field.Name)); err != nil {
+				return err
+			}
+			if err := vm.jsonEncodeValue(enc, structValue.Fields[field.Index]); err != nil {
+				return err
+			}
+		}
+		return enc.WriteToken(jsontext.EndObject)
+	case ValueUnion:
+		unionValue, err := value.unionValue()
+		if err != nil {
+			return err
+		}
+		return vm.jsonEncodeValue(enc, unionValue.Value)
+	case ValueTraitObject:
+		traitObject, err := value.traitObjectValue()
+		if err != nil {
+			return err
+		}
+		return vm.jsonEncodeValue(enc, traitObject.Value)
+	case ValueExtern:
+		externValue, err := value.externValue()
+		if err != nil {
+			return err
+		}
+		bytes, err := json.Marshal(externValue.Handle)
+		if err != nil {
+			return err
+		}
+		return enc.WriteValue(jsontext.Value(bytes))
+	default:
+		return fmt.Errorf("cannot JSON encode %s", typeInfo.Name)
+	}
+}
+
+func jsonEncodeMapKey(value Value) (string, error) {
+	if value.Kind == ValueStr {
+		return value.Str, nil
+	}
+	return fmt.Sprint(value.GoValue()), nil
+}

--- a/compiler/vm/json_parse.go
+++ b/compiler/vm/json_parse.go
@@ -1,9 +1,11 @@
 package vm
 
 import (
+	"encoding/json/jsontext"
 	"encoding/json/v2"
 	"fmt"
-	"math"
+	"io"
+	"strconv"
 	"strings"
 
 	"github.com/akonwi/ard/air"
@@ -33,47 +35,31 @@ func (vm *VM) callJSONParse(extern air.Extern, args []Value) (Value, error) {
 	if len(args) != 1 {
 		return Value{}, fmt.Errorf("JsonParse expects 1 arg, got %d", len(args))
 	}
-
-	raw, err := vm.jsonParseInput(args[0])
-	if err != nil {
-		return vm.jsonParseErr(extern.Signature.Return, returnInfo.Error, jsonDecodeError{expected: "JSON", found: err.Error()}), nil
+	if args[0].Kind != ValueStr {
+		return vm.jsonParseErr(extern.Signature.Return, jsonDecodeError{expected: "Str", found: args[0].GoValueString()}), nil
 	}
 
-	value, decodeErr := vm.jsonValueToValue(raw, returnInfo.Value, nil)
+	dec := jsontext.NewDecoder(strings.NewReader(args[0].Str))
+	value, decodeErr := vm.jsonDecodeValue(dec, returnInfo.Value, nil)
 	if decodeErr != nil {
-		return vm.jsonParseErr(extern.Signature.Return, returnInfo.Error, *decodeErr), nil
+		return vm.jsonParseErr(extern.Signature.Return, *decodeErr), nil
+	}
+	if kind := dec.PeekKind(); kind != jsontext.KindInvalid {
+		return vm.jsonParseErr(extern.Signature.Return, jsonDecodeError{expected: "end of JSON", found: kind.String()}), nil
 	}
 	return Result(extern.Signature.Return, true, value), nil
 }
 
-func (vm *VM) jsonParseInput(value Value) (any, error) {
-	if value.Kind == ValueUnion {
-		unionValue, err := value.unionValue()
-		if err != nil {
-			return nil, err
-		}
-		value = unionValue.Value
-	}
-	if value.Kind == ValueStr {
-		var raw any
-		if err := json.Unmarshal([]byte(value.Str), &raw); err != nil {
-			return nil, err
-		}
-		return raw, nil
-	}
-	if value.Kind == ValueDynamic {
-		return value.Ref, nil
-	}
-	return nil, fmt.Errorf("%s", value.GoValueString())
-}
-
-func (vm *VM) jsonValueToValue(raw any, typeID air.TypeID, path []string) (Value, *jsonDecodeError) {
+func (vm *VM) jsonDecodeValue(dec *jsontext.Decoder, typeID air.TypeID, path []string) (Value, *jsonDecodeError) {
 	typeInfo, err := vm.typeInfo(typeID)
 	if err != nil {
 		return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: err.Error(), path: path}
 	}
 
-	if raw == nil {
+	if dec.PeekKind() == jsontext.KindNull {
+		if _, err := dec.ReadToken(); err != nil {
+			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: err.Error(), path: path}
+		}
 		if typeInfo.Kind == air.TypeMaybe {
 			vm.recordMaybeDetailAlloc(false)
 			return Maybe(typeID, false, vm.zeroValue(typeInfo.Elem)), nil
@@ -86,118 +72,194 @@ func (vm *VM) jsonValueToValue(raw any, typeID air.TypeID, path []string) (Value
 
 	switch typeInfo.Kind {
 	case air.TypeInt:
-		if n, ok := jsonNumber(raw); ok && math.Trunc(n) == n {
-			return Int(typeID, int(n)), nil
+		tok, err := dec.ReadToken()
+		if err != nil {
+			return Value{}, jsonTokenErr(typeInfo.Name, path, err)
 		}
+		if tok.Kind() != jsontext.KindNumber {
+			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonKindFound(tok.Kind()), path: path}
+		}
+		parsed, err := strconv.ParseInt(tok.String(), 10, 0)
+		if err != nil {
+			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: "Number", path: path}
+		}
+		return Int(typeID, int(parsed)), nil
 	case air.TypeFloat:
-		if n, ok := jsonNumber(raw); ok {
-			return Float(typeID, n), nil
+		tok, err := dec.ReadToken()
+		if err != nil {
+			return Value{}, jsonTokenErr(typeInfo.Name, path, err)
 		}
+		if tok.Kind() != jsontext.KindNumber {
+			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonKindFound(tok.Kind()), path: path}
+		}
+		parsed, err := strconv.ParseFloat(tok.String(), 64)
+		if err != nil {
+			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: "Number", path: path}
+		}
+		return Float(typeID, parsed), nil
 	case air.TypeBool:
-		if b, ok := raw.(bool); ok {
-			return Bool(typeID, b), nil
+		tok, err := dec.ReadToken()
+		if err != nil {
+			return Value{}, jsonTokenErr(typeInfo.Name, path, err)
+		}
+		switch tok.Kind() {
+		case jsontext.KindTrue:
+			return Bool(typeID, true), nil
+		case jsontext.KindFalse:
+			return Bool(typeID, false), nil
+		default:
+			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonKindFound(tok.Kind()), path: path}
 		}
 	case air.TypeStr:
-		if s, ok := raw.(string); ok {
-			return Str(typeID, s), nil
+		tok, err := dec.ReadToken()
+		if err != nil {
+			return Value{}, jsonTokenErr(typeInfo.Name, path, err)
 		}
+		if tok.Kind() != jsontext.KindString {
+			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonKindFound(tok.Kind()), path: path}
+		}
+		return Str(typeID, tok.String()), nil
 	case air.TypeDynamic:
+		raw, decodeErr := jsonDecodeDynamic(dec, path)
+		if decodeErr != nil {
+			return Value{}, decodeErr
+		}
 		return Dynamic(typeID, raw), nil
 	case air.TypeMaybe:
-		inner, decodeErr := vm.jsonValueToValue(raw, typeInfo.Elem, path)
+		inner, decodeErr := vm.jsonDecodeValue(dec, typeInfo.Elem, path)
 		if decodeErr != nil {
 			return Value{}, decodeErr
 		}
 		vm.recordMaybeDetailAlloc(true)
 		return Maybe(typeID, true, inner), nil
 	case air.TypeList:
-		items, ok := raw.([]any)
-		if !ok {
-			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonFound(raw), path: path}
+		if tok, err := dec.ReadToken(); err != nil {
+			return Value{}, jsonTokenErr(typeInfo.Name, path, err)
+		} else if tok.Kind() != jsontext.KindBeginArray {
+			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonKindFound(tok.Kind()), path: path}
 		}
-		out := make([]Value, len(items))
-		for i, item := range items {
-			converted, decodeErr := vm.jsonValueToValue(item, typeInfo.Elem, appendPath(path, fmt.Sprintf("[%d]", i)))
+		items := []Value{}
+		for dec.PeekKind() != jsontext.KindEndArray {
+			item, decodeErr := vm.jsonDecodeValue(dec, typeInfo.Elem, appendPath(path, fmt.Sprintf("[%d]", len(items))))
 			if decodeErr != nil {
 				return Value{}, decodeErr
 			}
-			out[i] = converted
+			items = append(items, item)
 		}
-		return List(typeID, out), nil
+		if _, err := dec.ReadToken(); err != nil {
+			return Value{}, jsonTokenErr(typeInfo.Name, path, err)
+		}
+		return List(typeID, items), nil
 	case air.TypeMap:
-		m, ok := raw.(map[string]any)
-		if !ok {
-			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonFound(raw), path: path}
-		}
 		keyInfo, err := vm.typeInfo(typeInfo.Key)
 		if err != nil || keyInfo.Kind != air.TypeStr {
 			return Value{}, &jsonDecodeError{expected: "Str map key", found: keyInfo.Name, path: path}
 		}
-		entries := make([]MapEntryValue, 0, len(m))
-		for k, item := range m {
-			converted, decodeErr := vm.jsonValueToValue(item, typeInfo.Value, appendPath(path, k))
+		if tok, err := dec.ReadToken(); err != nil {
+			return Value{}, jsonTokenErr(typeInfo.Name, path, err)
+		} else if tok.Kind() != jsontext.KindBeginObject {
+			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonKindFound(tok.Kind()), path: path}
+		}
+		entries := []MapEntryValue{}
+		for dec.PeekKind() != jsontext.KindEndObject {
+			keyTok, err := dec.ReadToken()
+			if err != nil {
+				return Value{}, jsonTokenErr("Str", path, err)
+			}
+			if keyTok.Kind() != jsontext.KindString {
+				return Value{}, &jsonDecodeError{expected: "Str", found: jsonKindFound(keyTok.Kind()), path: path}
+			}
+			key := keyTok.String()
+			item, decodeErr := vm.jsonDecodeValue(dec, typeInfo.Value, appendPath(path, key))
 			if decodeErr != nil {
 				return Value{}, decodeErr
 			}
-			entries = append(entries, MapEntryValue{Key: Str(typeInfo.Key, k), Value: converted})
+			entries = append(entries, MapEntryValue{Key: Str(typeInfo.Key, key), Value: item})
+		}
+		if _, err := dec.ReadToken(); err != nil {
+			return Value{}, jsonTokenErr(typeInfo.Name, path, err)
 		}
 		return Map(typeID, entries), nil
 	case air.TypeStruct:
-		m, ok := raw.(map[string]any)
-		if !ok {
-			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonFound(raw), path: path}
-		}
-		fields := make([]Value, len(typeInfo.Fields))
-		for _, field := range typeInfo.Fields {
-			fieldInfo, err := vm.typeInfo(field.Type)
-			if err != nil {
-				return Value{}, &jsonDecodeError{expected: field.Name, found: err.Error(), path: path}
-			}
-			item, exists := m[field.Name]
-			if !exists {
-				if fieldInfo.Kind == air.TypeMaybe {
-					vm.recordMaybeDetailAlloc(false)
-					fields[field.Index] = Maybe(field.Type, false, vm.zeroValue(fieldInfo.Elem))
-					continue
-				}
-				return Value{}, &jsonDecodeError{expected: fieldInfo.Name, found: "missing", path: appendPath(path, field.Name)}
-			}
-			converted, decodeErr := vm.jsonValueToValue(item, field.Type, appendPath(path, field.Name))
-			if decodeErr != nil {
-				return Value{}, decodeErr
-			}
-			fields[field.Index] = converted
-		}
-		return Struct(typeID, fields), nil
+		return vm.jsonDecodeStruct(dec, typeID, typeInfo, path)
 	}
 
-	return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonFound(raw), path: path}
+	return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonKindFound(dec.PeekKind()), path: path}
 }
 
-func (vm *VM) jsonParseErr(resultType, errorType air.TypeID, decodeErr jsonDecodeError) Value {
-	errorInfo, err := vm.typeInfo(errorType)
-	if err != nil || errorInfo.Kind != air.TypeStruct {
-		return Result(resultType, false, Str(errorType, decodeErr.Error()))
+func (vm *VM) jsonDecodeStruct(dec *jsontext.Decoder, typeID air.TypeID, typeInfo air.TypeInfo, path []string) (Value, *jsonDecodeError) {
+	if tok, err := dec.ReadToken(); err != nil {
+		return Value{}, jsonTokenErr(typeInfo.Name, path, err)
+	} else if tok.Kind() != jsontext.KindBeginObject {
+		return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonKindFound(tok.Kind()), path: path}
 	}
-	fields := make([]Value, len(errorInfo.Fields))
-	for _, field := range errorInfo.Fields {
-		switch field.Name {
-		case "expected":
-			fields[field.Index] = Str(field.Type, decodeErr.expected)
-		case "found":
-			fields[field.Index] = Str(field.Type, decodeErr.found)
-		case "path":
-			pathInfo, _ := vm.typeInfo(field.Type)
-			items := make([]Value, len(decodeErr.path))
-			for i, segment := range decodeErr.path {
-				items[i] = Str(pathInfo.Elem, segment)
-			}
-			fields[field.Index] = List(field.Type, items)
-		default:
-			fields[field.Index] = vm.zeroValue(field.Type)
+
+	fields := make([]Value, len(typeInfo.Fields))
+	seen := make([]bool, len(typeInfo.Fields))
+	fieldsByName := make(map[string]air.FieldInfo, len(typeInfo.Fields))
+	for _, field := range typeInfo.Fields {
+		fieldsByName[field.Name] = field
+	}
+
+	for dec.PeekKind() != jsontext.KindEndObject {
+		keyTok, err := dec.ReadToken()
+		if err != nil {
+			return Value{}, jsonTokenErr("Str", path, err)
 		}
+		if keyTok.Kind() != jsontext.KindString {
+			return Value{}, &jsonDecodeError{expected: "Str", found: jsonKindFound(keyTok.Kind()), path: path}
+		}
+		fieldName := keyTok.String()
+		field, ok := fieldsByName[fieldName]
+		if !ok {
+			if err := dec.SkipValue(); err != nil {
+				return Value{}, jsonTokenErr("Dynamic", appendPath(path, fieldName), err)
+			}
+			continue
+		}
+		converted, decodeErr := vm.jsonDecodeValue(dec, field.Type, appendPath(path, fieldName))
+		if decodeErr != nil {
+			return Value{}, decodeErr
+		}
+		fields[field.Index] = converted
+		seen[field.Index] = true
 	}
-	return Result(resultType, false, Struct(errorType, fields))
+	if _, err := dec.ReadToken(); err != nil {
+		return Value{}, jsonTokenErr(typeInfo.Name, path, err)
+	}
+
+	for _, field := range typeInfo.Fields {
+		if seen[field.Index] {
+			continue
+		}
+		fieldInfo, err := vm.typeInfo(field.Type)
+		if err != nil {
+			return Value{}, &jsonDecodeError{expected: field.Name, found: err.Error(), path: path}
+		}
+		if fieldInfo.Kind == air.TypeMaybe {
+			vm.recordMaybeDetailAlloc(false)
+			fields[field.Index] = Maybe(field.Type, false, vm.zeroValue(fieldInfo.Elem))
+			continue
+		}
+		return Value{}, &jsonDecodeError{expected: fieldInfo.Name, found: "missing", path: appendPath(path, field.Name)}
+	}
+	return Struct(typeID, fields), nil
+}
+
+func jsonDecodeDynamic(dec *jsontext.Decoder, path []string) (any, *jsonDecodeError) {
+	value, err := dec.ReadValue()
+	if err != nil {
+		return nil, jsonTokenErr("Dynamic", path, err)
+	}
+	var raw any
+	if err := json.Unmarshal(value, &raw); err != nil {
+		return nil, &jsonDecodeError{expected: "Dynamic", found: err.Error(), path: path}
+	}
+	return raw, nil
+}
+
+func (vm *VM) jsonParseErr(resultType air.TypeID, decodeErr jsonDecodeError) Value {
+	return Result(resultType, false, Str(vm.program.Types[resultType-1].Error, decodeErr.Error()))
 }
 
 func appendPath(path []string, segment string) []string {
@@ -207,38 +269,32 @@ func appendPath(path []string, segment string) []string {
 	return out
 }
 
-func jsonNumber(raw any) (float64, bool) {
-	switch n := raw.(type) {
-	case float64:
-		return n, true
-	case float32:
-		return float64(n), true
-	case int:
-		return float64(n), true
-	case int64:
-		return float64(n), true
-	case uint64:
-		return float64(n), true
-	default:
-		return 0, false
+func jsonTokenErr(expected string, path []string, err error) *jsonDecodeError {
+	if err == io.EOF {
+		return &jsonDecodeError{expected: expected, found: "end of JSON", path: path}
 	}
+	return &jsonDecodeError{expected: expected, found: err.Error(), path: path}
 }
 
-func jsonFound(raw any) string {
-	switch raw.(type) {
-	case nil:
+func jsonKindFound(kind jsontext.Kind) string {
+	switch kind {
+	case jsontext.KindNull:
 		return "null"
-	case string:
+	case jsontext.KindString:
 		return "Str"
-	case bool:
+	case jsontext.KindTrue, jsontext.KindFalse:
 		return "Bool"
-	case float64, float32, int, int64, uint64:
+	case jsontext.KindNumber:
 		return "Number"
-	case []any:
+	case jsontext.KindBeginArray:
 		return "List"
-	case map[string]any:
+	case jsontext.KindBeginObject:
 		return "Map"
+	case jsontext.KindEndArray:
+		return "]"
+	case jsontext.KindEndObject:
+		return "}"
 	default:
-		return fmt.Sprintf("%T", raw)
+		return kind.String()
 	}
 }

--- a/compiler/vm/json_parse.go
+++ b/compiler/vm/json_parse.go
@@ -1,0 +1,244 @@
+package vm
+
+import (
+	"encoding/json/v2"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/akonwi/ard/air"
+)
+
+type jsonDecodeError struct {
+	expected string
+	found    string
+	path     []string
+}
+
+func (e jsonDecodeError) Error() string {
+	if len(e.path) == 0 {
+		return fmt.Sprintf("got %s, expected %s", e.found, e.expected)
+	}
+	return fmt.Sprintf("%s: got %s, expected %s", strings.Join(e.path, "."), e.found, e.expected)
+}
+
+func (vm *VM) callJSONParse(extern air.Extern, args []Value) (Value, error) {
+	returnInfo, err := vm.typeInfo(extern.Signature.Return)
+	if err != nil {
+		return Value{}, err
+	}
+	if returnInfo.Kind != air.TypeResult {
+		return Value{}, fmt.Errorf("JsonParse return type must be Result, got %s", returnInfo.Name)
+	}
+	if len(args) != 1 {
+		return Value{}, fmt.Errorf("JsonParse expects 1 arg, got %d", len(args))
+	}
+
+	raw, err := vm.jsonParseInput(args[0])
+	if err != nil {
+		return vm.jsonParseErr(extern.Signature.Return, returnInfo.Error, jsonDecodeError{expected: "JSON", found: err.Error()}), nil
+	}
+
+	value, decodeErr := vm.jsonValueToValue(raw, returnInfo.Value, nil)
+	if decodeErr != nil {
+		return vm.jsonParseErr(extern.Signature.Return, returnInfo.Error, *decodeErr), nil
+	}
+	return Result(extern.Signature.Return, true, value), nil
+}
+
+func (vm *VM) jsonParseInput(value Value) (any, error) {
+	if value.Kind == ValueUnion {
+		unionValue, err := value.unionValue()
+		if err != nil {
+			return nil, err
+		}
+		value = unionValue.Value
+	}
+	if value.Kind == ValueStr {
+		var raw any
+		if err := json.Unmarshal([]byte(value.Str), &raw); err != nil {
+			return nil, err
+		}
+		return raw, nil
+	}
+	if value.Kind == ValueDynamic {
+		return value.Ref, nil
+	}
+	return nil, fmt.Errorf("%s", value.GoValueString())
+}
+
+func (vm *VM) jsonValueToValue(raw any, typeID air.TypeID, path []string) (Value, *jsonDecodeError) {
+	typeInfo, err := vm.typeInfo(typeID)
+	if err != nil {
+		return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: err.Error(), path: path}
+	}
+
+	if raw == nil {
+		if typeInfo.Kind == air.TypeMaybe {
+			vm.recordMaybeDetailAlloc(false)
+			return Maybe(typeID, false, vm.zeroValue(typeInfo.Elem)), nil
+		}
+		if typeInfo.Kind == air.TypeDynamic {
+			return Dynamic(typeID, nil), nil
+		}
+		return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: "null", path: path}
+	}
+
+	switch typeInfo.Kind {
+	case air.TypeInt:
+		if n, ok := jsonNumber(raw); ok && math.Trunc(n) == n {
+			return Int(typeID, int(n)), nil
+		}
+	case air.TypeFloat:
+		if n, ok := jsonNumber(raw); ok {
+			return Float(typeID, n), nil
+		}
+	case air.TypeBool:
+		if b, ok := raw.(bool); ok {
+			return Bool(typeID, b), nil
+		}
+	case air.TypeStr:
+		if s, ok := raw.(string); ok {
+			return Str(typeID, s), nil
+		}
+	case air.TypeDynamic:
+		return Dynamic(typeID, raw), nil
+	case air.TypeMaybe:
+		inner, decodeErr := vm.jsonValueToValue(raw, typeInfo.Elem, path)
+		if decodeErr != nil {
+			return Value{}, decodeErr
+		}
+		vm.recordMaybeDetailAlloc(true)
+		return Maybe(typeID, true, inner), nil
+	case air.TypeList:
+		items, ok := raw.([]any)
+		if !ok {
+			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonFound(raw), path: path}
+		}
+		out := make([]Value, len(items))
+		for i, item := range items {
+			converted, decodeErr := vm.jsonValueToValue(item, typeInfo.Elem, appendPath(path, fmt.Sprintf("[%d]", i)))
+			if decodeErr != nil {
+				return Value{}, decodeErr
+			}
+			out[i] = converted
+		}
+		return List(typeID, out), nil
+	case air.TypeMap:
+		m, ok := raw.(map[string]any)
+		if !ok {
+			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonFound(raw), path: path}
+		}
+		keyInfo, err := vm.typeInfo(typeInfo.Key)
+		if err != nil || keyInfo.Kind != air.TypeStr {
+			return Value{}, &jsonDecodeError{expected: "Str map key", found: keyInfo.Name, path: path}
+		}
+		entries := make([]MapEntryValue, 0, len(m))
+		for k, item := range m {
+			converted, decodeErr := vm.jsonValueToValue(item, typeInfo.Value, appendPath(path, k))
+			if decodeErr != nil {
+				return Value{}, decodeErr
+			}
+			entries = append(entries, MapEntryValue{Key: Str(typeInfo.Key, k), Value: converted})
+		}
+		return Map(typeID, entries), nil
+	case air.TypeStruct:
+		m, ok := raw.(map[string]any)
+		if !ok {
+			return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonFound(raw), path: path}
+		}
+		fields := make([]Value, len(typeInfo.Fields))
+		for _, field := range typeInfo.Fields {
+			fieldInfo, err := vm.typeInfo(field.Type)
+			if err != nil {
+				return Value{}, &jsonDecodeError{expected: field.Name, found: err.Error(), path: path}
+			}
+			item, exists := m[field.Name]
+			if !exists {
+				if fieldInfo.Kind == air.TypeMaybe {
+					vm.recordMaybeDetailAlloc(false)
+					fields[field.Index] = Maybe(field.Type, false, vm.zeroValue(fieldInfo.Elem))
+					continue
+				}
+				return Value{}, &jsonDecodeError{expected: fieldInfo.Name, found: "missing", path: appendPath(path, field.Name)}
+			}
+			converted, decodeErr := vm.jsonValueToValue(item, field.Type, appendPath(path, field.Name))
+			if decodeErr != nil {
+				return Value{}, decodeErr
+			}
+			fields[field.Index] = converted
+		}
+		return Struct(typeID, fields), nil
+	}
+
+	return Value{}, &jsonDecodeError{expected: typeInfo.Name, found: jsonFound(raw), path: path}
+}
+
+func (vm *VM) jsonParseErr(resultType, errorType air.TypeID, decodeErr jsonDecodeError) Value {
+	errorInfo, err := vm.typeInfo(errorType)
+	if err != nil || errorInfo.Kind != air.TypeStruct {
+		return Result(resultType, false, Str(errorType, decodeErr.Error()))
+	}
+	fields := make([]Value, len(errorInfo.Fields))
+	for _, field := range errorInfo.Fields {
+		switch field.Name {
+		case "expected":
+			fields[field.Index] = Str(field.Type, decodeErr.expected)
+		case "found":
+			fields[field.Index] = Str(field.Type, decodeErr.found)
+		case "path":
+			pathInfo, _ := vm.typeInfo(field.Type)
+			items := make([]Value, len(decodeErr.path))
+			for i, segment := range decodeErr.path {
+				items[i] = Str(pathInfo.Elem, segment)
+			}
+			fields[field.Index] = List(field.Type, items)
+		default:
+			fields[field.Index] = vm.zeroValue(field.Type)
+		}
+	}
+	return Result(resultType, false, Struct(errorType, fields))
+}
+
+func appendPath(path []string, segment string) []string {
+	out := make([]string, len(path), len(path)+1)
+	copy(out, path)
+	out = append(out, segment)
+	return out
+}
+
+func jsonNumber(raw any) (float64, bool) {
+	switch n := raw.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+func jsonFound(raw any) string {
+	switch raw.(type) {
+	case nil:
+		return "null"
+	case string:
+		return "Str"
+	case bool:
+		return "Bool"
+	case float64, float32, int, int64, uint64:
+		return "Number"
+	case []any:
+		return "List"
+	case map[string]any:
+		return "Map"
+	default:
+		return fmt.Sprintf("%T", raw)
+	}
+}


### PR DESCRIPTION
## Summary
- add `json::parse<T>(Str) -> T!Str` with compile-time JSON shape validation
- implement VM-native typed parse/encode paths using `jsontext`
- add Go target specialization, including generated `MarshalJSONTo`/`UnmarshalJSONFrom` implementations for JSON-safe shapes
- add JS `JsonParse` support and update the JSON serde benchmark to use the new API

## Benchmarks
`cd compiler && ./benchmarks/run.sh json_serde_roundtrip`

Original decode/dynamic baseline:
- VM: 68.0 ms ± 0.3 ms
- Go target: 17.7 ms ± 3.4 ms
- native Go: 6.3 ms ± 0.1 ms
- JS: 44.4 ms ± 0.6 ms

Current:
- VM: 23.4 ms ± 0.3 ms
- Go target: 10.4 ms ± 0.3 ms
- native Go: 6.3 ms ± 0.2 ms
- JS: 32.9 ms ± 0.4 ms

## Test plan
- `cd compiler && go run main.go test std_lib/json.ard`
- `cd compiler && go test ./...`
