### PR TITLE
fix(entrypoint): require void argless main

### DIFF
--- a/compiler/air/entrypoint.go
+++ b/compiler/air/entrypoint.go
@@ -1,0 +1,24 @@
+package air
+
+import "fmt"
+
+func ValidateEntrypointSignature(program *Program) error {
+	if program == nil || program.Entry == NoFunction {
+		return nil
+	}
+	if int(program.Entry) < 0 || int(program.Entry) >= len(program.Functions) {
+		return fmt.Errorf("entrypoint function %d out of range", program.Entry)
+	}
+	entry := program.Functions[program.Entry]
+	if len(entry.Signature.Params) != 0 {
+		return fmt.Errorf("main entrypoint cannot have parameters")
+	}
+	if int(entry.Signature.Return) <= 0 || int(entry.Signature.Return) > len(program.Types) {
+		return fmt.Errorf("main entrypoint return type %d out of range", entry.Signature.Return)
+	}
+	returnType := program.Types[entry.Signature.Return-1]
+	if returnType.Kind != TypeVoid {
+		return fmt.Errorf("main entrypoint must return Void, got %s", returnType.Name)
+	}
+	return nil
+}

--- a/compiler/air/entrypoint_test.go
+++ b/compiler/air/entrypoint_test.go
@@ -1,0 +1,73 @@
+package air
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/akonwi/ard/checker"
+	"github.com/akonwi/ard/parse"
+)
+
+func TestValidateEntrypointSignature(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		wantErr string
+	}{
+		{
+			name: "allows argless Void main",
+			source: `fn main() Void {
+			}`,
+		},
+		{
+			name: "rejects main with args",
+			source: `fn main(name: Str) Void {
+			}`,
+			wantErr: "main entrypoint cannot have parameters",
+		},
+		{
+			name: "rejects main returning non-Void",
+			source: `fn main() Int {
+			  1
+			}`,
+			wantErr: "main entrypoint must return Void, got Int",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			program := lowerEntrypointValidationSource(t, tt.source)
+			err := ValidateEntrypointSignature(program)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func lowerEntrypointValidationSource(t *testing.T, input string) *Program {
+	t.Helper()
+	result := parse.Parse([]byte(input), "main.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	c := checker.New("main.ard", result.Program, nil)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+	program, err := Lower(c.Module())
+	if err != nil {
+		t.Fatalf("lower error: %v", err)
+	}
+	return program
+}

--- a/compiler/main.go
+++ b/compiler/main.go
@@ -85,6 +85,10 @@ func main() {
 					fmt.Println(err)
 					os.Exit(1)
 				}
+				if err := validateEntrypointSignature(profile, program); err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
 				if err := runVMProgramProfile(program, os.Args, profile); err != nil {
 					fmt.Println(err)
 					os.Exit(1)
@@ -106,6 +110,10 @@ func main() {
 					program, lowerErr = air.Lower(loaded.Module)
 					return lowerErr
 				}); err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
+				if err := validateEntrypointSignature(profile, program); err != nil {
 					fmt.Println(err)
 					os.Exit(1)
 				}
@@ -672,6 +680,9 @@ func runJSProgram(inputPath string, target string, args []string) error {
 	}); err != nil {
 		return err
 	}
+	if err := validateEntrypointSignature(profile, program); err != nil {
+		return err
+	}
 	if err := profile.Time("javascript.run", func() error {
 		return javascript.RunProgram(program, target, args, loaded.ProjectInfo)
 	}); err != nil {
@@ -697,6 +708,9 @@ func buildJSProgram(inputPath string, outputPath string, target string) (string,
 		program, lowerErr = air.Lower(loaded.Module)
 		return lowerErr
 	}); err != nil {
+		return "", err
+	}
+	if err := validateEntrypointSignature(profile, program); err != nil {
 		return "", err
 	}
 	outputPath = resolveJSBuildOutputPath(inputPath, outputPath, target, loaded.ProjectInfo)
@@ -756,6 +770,9 @@ func buildGoBinary(inputPath string, outputPath string, target string) (string, 
 	}); err != nil {
 		return "", err
 	}
+	if err := validateEntrypointSignature(profile, program); err != nil {
+		return "", err
+	}
 	if outputPath == "" {
 		outputPath = filepath.Base(strings.TrimSuffix(inputPath, filepath.Ext(inputPath)))
 		if outputPath == "" || outputPath == "." || outputPath == string(filepath.Separator) {
@@ -795,6 +812,9 @@ func buildVMBinary(inputPath string, outputPath string) (string, error) {
 	if err := profile.Time("air.validate", func() error {
 		return air.Validate(program)
 	}); err != nil {
+		return "", err
+	}
+	if err := validateEntrypointSignature(profile, program); err != nil {
 		return "", err
 	}
 	if program.Entry == air.NoFunction {
@@ -866,6 +886,12 @@ func maybeRunEmbedded() bool {
 
 func runVMProgram(program *air.Program, args []string) error {
 	return runVMProgramProfile(program, args, nil)
+}
+
+func validateEntrypointSignature(profile *pipelineProfile, program *air.Program) error {
+	return profile.Time("air.validate_entrypoint", func() error {
+		return air.ValidateEntrypointSignature(program)
+	})
 }
 
 func runVMProgramProfile(program *air.Program, args []string, profile *pipelineProfile) error {

--- a/compiler/main_test.go
+++ b/compiler/main_test.go
@@ -350,6 +350,45 @@ func TestRunGoTargetModulesSample(t *testing.T) {
 	}
 }
 
+func TestBuildRejectsInvalidMainEntrypointSignature(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		wantErr string
+	}{
+		{
+			name: "main with args",
+			source: `fn main(name: Str) Void {
+			}`,
+			wantErr: "main entrypoint cannot have parameters",
+		},
+		{
+			name: "main with non-Void return",
+			source: `fn main() Int {
+			  1
+			}`,
+			wantErr: "main entrypoint must return Void, got Int",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			sourcePath := filepath.Join(tempDir, "main.ard")
+			if err := os.WriteFile(sourcePath, []byte(tt.source), 0o644); err != nil {
+				t.Fatalf("write source: %v", err)
+			}
+			_, err := buildGoBinary(sourcePath, filepath.Join(tempDir, "main-bin"), backend.TargetGo)
+			if err == nil {
+				t.Fatalf("buildGoBinary succeeded, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestBuildGoBinary(t *testing.T) {
 	tempDir := t.TempDir()
 	sourcePath := filepath.Join(tempDir, "main.ard")
@@ -541,7 +580,7 @@ func TestBuildJSProgramDefaultWritesArdOut(t *testing.T) {
 		t.Fatal(err)
 	}
 	sourcePath := filepath.Join(dir, "main.ard")
-	if err := os.WriteFile(sourcePath, []byte(`fn main() { "ok" }`), 0o644); err != nil {
+	if err := os.WriteFile(sourcePath, []byte(`fn main() { () }`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary
- require executable `main` entrypoints to be argless
- require executable `main` entrypoints to return `Void`
- validate entrypoint signatures for VM, Go, and JS run/build paths
- add AIR/unit and build-path regression tests

Closes #133

## Tests
- `cd compiler && go generate ./std_lib/ffi && go test ./...`
