### PR TITLE
fix(vm): clarify Go FFI binding support

### DIFF
--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -926,6 +926,10 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 			if len(bindings) == 0 && s.ExternalBinding != "" {
 				bindings = map[string]string{shorthandExternalBindingTarget(c.options.Target): s.ExternalBinding}
 			}
+			if target, ok := validateExternalBindingTargets(bindings); !ok {
+				c.addError(fmt.Sprintf("Unsupported extern binding target %q; use go for VM host FFI", target), s.GetLocation())
+				return nil
+			}
 			resolvedTarget, resolvedBinding := resolveExternalBindingForTarget(c.options.Target, bindings)
 			externType := &ExternType{Name_: s.Name, GenericParams: append([]string(nil), s.TypeParams...), TypeArgs: typeArgs, ExternalBinding: resolvedBinding, ExternalBindingTarget: resolvedTarget, ExternalBindings: bindings, private: s.Private}
 			c.scope.add(s.Name, externType, false)
@@ -4436,9 +4440,24 @@ func shorthandExternalBindingTarget(target string) string {
 	}
 }
 
+func validateExternalBindingTargets(bindings map[string]string) (string, bool) {
+	for target := range bindings {
+		switch target {
+		case backend.TargetGo, "js", backend.TargetJSServer, backend.TargetJSBrowser:
+			continue
+		default:
+			return target, false
+		}
+	}
+	return "", true
+}
+
 func resolveExternalBindingForTarget(target string, bindings map[string]string) (string, string) {
 	if len(bindings) == 0 {
 		return "", ""
+	}
+	if target == backend.TargetVM {
+		target = backend.TargetGo
 	}
 	if target != "" {
 		if binding := bindings[target]; binding != "" {
@@ -4494,6 +4513,10 @@ func (c *Checker) checkExternalFunction(def *parse.ExternalFunction) *ExternalFu
 	}
 	if len(bindings) == 0 {
 		c.addError("External binding cannot be empty", def.GetLocation())
+		return nil
+	}
+	if target, ok := validateExternalBindingTargets(bindings); !ok {
+		c.addError(fmt.Sprintf("Unsupported extern binding target %q; use go for VM host FFI", target), def.GetLocation())
 		return nil
 	}
 

--- a/compiler/checker/functions_test.go
+++ b/compiler/checker/functions_test.go
@@ -359,6 +359,79 @@ func TestExternalFunctionShorthandResolvesToEffectiveJSTarget(t *testing.T) {
 	}
 }
 
+func TestExternalFunctionBindingsResolveGoForVM(t *testing.T) {
+	source := `extern fn read_line() Str!Str = {
+  go = "ReadLine"
+  js-server = "readLine"
+}`
+
+	result := parse.Parse([]byte(source), "main.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected parse errors: %v", result.Errors)
+	}
+
+	vmChecker := checker.New("main.ard", result.Program, nil, checker.CheckOptions{Target: backend.TargetVM})
+	vmChecker.Check()
+	if vmChecker.HasErrors() {
+		t.Fatalf("unexpected vm diagnostics: %v", vmChecker.Diagnostics())
+	}
+	vmFn := vmChecker.Module().Program().Statements[0].Expr.(*checker.ExternalFunctionDef)
+	if vmFn.ExternalBinding != "ReadLine" || vmFn.ExternalBindingTarget != backend.TargetGo {
+		t.Fatalf("expected vm to use go binding, got %#v", vmFn)
+	}
+}
+
+func TestExternalFunctionRejectsVMAndBytecodeBindingTargets(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name: "vm function binding",
+			source: `extern fn value() Str = {
+  vm = "Value"
+}`,
+			want: `Unsupported extern binding target "vm"`,
+		},
+		{
+			name: "bytecode function binding",
+			source: `extern fn value() Str = {
+  bytecode = "Value"
+}`,
+			want: `Unsupported extern binding target "bytecode"`,
+		},
+		{
+			name: "vm extern type binding",
+			source: `extern type Handle = {
+  vm = "Handle"
+}`,
+			want: `Unsupported extern binding target "vm"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := parse.Parse([]byte(tc.source), "main.ard")
+			if len(result.Errors) > 0 {
+				t.Fatalf("unexpected parse errors: %v", result.Errors)
+			}
+			c := checker.New("main.ard", result.Program, nil, checker.CheckOptions{Target: backend.TargetVM})
+			c.Check()
+			if !c.HasErrors() {
+				t.Fatal("expected checker diagnostics")
+			}
+			joined := ""
+			for _, diagnostic := range c.Diagnostics() {
+				joined += diagnostic.String() + "\n"
+			}
+			if !strings.Contains(joined, tc.want) {
+				t.Fatalf("diagnostics = %s, want %q", joined, tc.want)
+			}
+		})
+	}
+}
+
 func TestExternalFunctionBindingsResolveSharedJSFallback(t *testing.T) {
 	source := `extern fn delay(ms: Int) Void = {
   go = "Delay"

--- a/compiler/docs/ffi.md
+++ b/compiler/docs/ffi.md
@@ -5,7 +5,7 @@
 Ard's extern/FFI system lets functions declared in Ard call target-specific implementations.
 
 Today that includes:
-- Go implementations inside `compiler/ffi/` for the bytecode VM and Go-oriented runtime paths
+- Go implementations for the VM host FFI and Go-oriented runtime paths
 - JavaScript companion modules for `js-server` and `js-browser`
 
 The system is intentionally narrow:
@@ -42,10 +42,11 @@ Binding blocks let one Ard declaration resolve differently per target.
 
 Current binding keys include:
 - `go`
-- `bytecode`
 - `js`
 - `js-server`
 - `js-browser`
+
+The VM does not have its own binding key. VM host FFI uses the `go` binding because VM externs are normal Go host functions invoked through generated Ard↔Go adapters. `vm` and `bytecode` are intentionally not valid binding targets.
 
 ### Resolution precedence
 
@@ -54,12 +55,12 @@ The checker resolves the active extern binding using this precedence:
 1. exact target binding, if present
 2. shared `js` binding for `js-server` and `js-browser`
 3. `go`
-4. `bytecode` for `go`, `bytecode`, or target-unspecified checking
 
 Examples:
 - `js-server` prefers `js-server`, then `js`, then `go`
 - `js-browser` prefers `js-browser`, then `js`, then `go`
-- `go` prefers `go`, then `bytecode`
+- `go` prefers `go`
+- `vm` uses `go` bindings for host FFI
 
 ## Go project companions
 
@@ -99,6 +100,28 @@ Project Go FFI currently uses idiomatic direct-call adaptation:
 - `T?` expects `*T` (`nil` becomes `None`, non-`nil` becomes `Some`)
 - `Void!Str` expects `error`
 - `T!Str` expects `(T, error)`
+
+## VM host FFI policy
+
+Decision record: the VM target intentionally uses `go` extern bindings rather than a separate `vm` or `bytecode` binding target.
+
+Rationale:
+- VM externs are Go host functions with generated adapters, not a distinct language-level FFI surface.
+- A separate VM binding key would duplicate the Go FFI path without a clear use case.
+- Shorthand externs should continue to work for VM by resolving to `go` bindings.
+- Unsupported binding keys such as `vm` and `bytecode` should be rejected instead of silently ignored.
+
+For the VM, every active extern should have explicit host support before execution:
+- the host function must be registered in the VM's host function registry
+- a generated adapter must exist for that binding/signature
+- missing functions or adapters should be reported early when targeting/constructing the VM, not discovered only at the call site
+
+Project Go FFI has different execution models:
+- `--target go` compiles project companion files (`ffi.go`, `ffi/*.go`) into the generated Go application and calls them directly
+- embedded VM hosts can provide project functions through the host function registry, but those functions still need generated adapters
+- plain VM execution should reject project Go FFI unless adapter generation/build support is available
+
+The Go target's current handwritten stdlib extern switch is separate technical debt. It can be refactored or generated from the same FFI contract later, but that is not required for the VM binding policy above.
 
 ## JavaScript companion modules
 

--- a/compiler/main.go
+++ b/compiler/main.go
@@ -820,6 +820,15 @@ func buildVMBinary(inputPath string, outputPath string) (string, error) {
 	if program.Entry == air.NoFunction {
 		return "", fmt.Errorf("vm builds require fn main()")
 	}
+	if err := validatePlainVMExternsProfile(profile, program); err != nil {
+		return "", err
+	}
+	if err := profile.Time("vm.validate_host_support", func() error {
+		_, err := vm.NewWithOptions(program, vm.Options{})
+		return err
+	}); err != nil {
+		return "", err
+	}
 	var data []byte
 	if err := profile.Time("air.serialize", func() error {
 		var serializeErr error
@@ -888,6 +897,85 @@ func runVMProgram(program *air.Program, args []string) error {
 	return runVMProgramProfile(program, args, nil)
 }
 
+func validatePlainVMExternsProfile(profile *pipelineProfile, program *air.Program) error {
+	return profile.Time("vm.validate_externs", func() error {
+		return validatePlainVMExterns(program)
+	})
+}
+
+func validatePlainVMExterns(program *air.Program) error {
+	if program == nil {
+		return nil
+	}
+	usedExterns := reachableVMExterns(program)
+	for _, ext := range program.Externs {
+		if !usedExterns[ext.ID] || vmExternModuleIsStdlib(program, ext) {
+			continue
+		}
+		binding := ext.Name
+		if goBinding := ext.Bindings[backend.TargetGo]; goBinding != "" {
+			binding = goBinding
+		}
+		return fmt.Errorf("plain vm execution does not support project extern %s with Go binding %q; use --target go or an embedded VM host with generated adapters", ext.Name, binding)
+	}
+	return nil
+}
+
+func vmExternModuleIsStdlib(program *air.Program, ext air.Extern) bool {
+	return int(ext.Module) >= 0 && int(ext.Module) < len(program.Modules) && strings.HasPrefix(program.Modules[ext.Module].Path, "ard/")
+}
+
+func reachableVMExterns(program *air.Program) map[air.ExternID]bool {
+	used := map[air.ExternID]bool{}
+	seenFunctions := map[air.FunctionID]bool{}
+	var visitFunction func(air.FunctionID)
+	visitFunction = func(id air.FunctionID) {
+		if id < 0 || int(id) >= len(program.Functions) || seenFunctions[id] {
+			return
+		}
+		seenFunctions[id] = true
+		collectVMBlockExterns(program.Functions[id].Body, used, visitFunction)
+	}
+	visitFunction(program.Entry)
+	visitFunction(program.Script)
+	for _, test := range program.Tests {
+		visitFunction(test.Function)
+	}
+	return used
+}
+
+func collectVMBlockExterns(block air.Block, used map[air.ExternID]bool, visitFunction func(air.FunctionID)) {
+	for _, stmt := range block.Stmts {
+		collectVMExprExterns(stmt.Value, used, visitFunction)
+		collectVMExprExterns(stmt.Expr, used, visitFunction)
+		collectVMExprExterns(stmt.Target, used, visitFunction)
+		collectVMBlockExterns(stmt.Body, used, visitFunction)
+	}
+	collectVMExprExterns(block.Result, used, visitFunction)
+}
+
+func collectVMExprExterns(expr *air.Expr, used map[air.ExternID]bool, visitFunction func(air.FunctionID)) {
+	if expr == nil {
+		return
+	}
+	switch expr.Kind {
+	case air.ExprCallExtern:
+		used[expr.Extern] = true
+	case air.ExprCall, air.ExprMakeClosure, air.ExprSpawnFiber:
+		visitFunction(expr.Function)
+	}
+	for i := range expr.Args {
+		collectVMExprExterns(&expr.Args[i], used, visitFunction)
+	}
+	for i := range expr.Entries {
+		collectVMExprExterns(&expr.Entries[i].Key, used, visitFunction)
+		collectVMExprExterns(&expr.Entries[i].Value, used, visitFunction)
+	}
+	for i := range expr.Fields {
+		collectVMExprExterns(&expr.Fields[i].Value, used, visitFunction)
+	}
+}
+
 func validateEntrypointSignature(profile *pipelineProfile, program *air.Program) error {
 	return profile.Time("air.validate_entrypoint", func() error {
 		return air.ValidateEntrypointSignature(program)
@@ -895,6 +983,9 @@ func validateEntrypointSignature(profile *pipelineProfile, program *air.Program)
 }
 
 func runVMProgramProfile(program *air.Program, args []string, profile *pipelineProfile) error {
+	if err := validatePlainVMExternsProfile(profile, program); err != nil {
+		return err
+	}
 	var machine *vm.VM
 	if err := profile.Time("vm.init", func() error {
 		var initErr error

--- a/compiler/main_test.go
+++ b/compiler/main_test.go
@@ -137,6 +137,37 @@ func TestRunVMProgram(t *testing.T) {
 	}
 }
 
+func TestRunVMProgramRejectsProjectGoFFI(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "main.ard")
+	source := `
+		extern fn custom() Str = "Custom"
+
+		fn main() Str {
+			custom()
+		}
+	`
+	if err := os.WriteFile(sourcePath, []byte(source), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	module, err := loadModule(sourcePath, backend.TargetVM)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(module)
+	if err != nil {
+		t.Fatalf("lower AIR: %v", err)
+	}
+	err = runVMProgram(program, []string{"ard", "run", "--target", "vm", sourcePath})
+	if err == nil {
+		t.Fatal("runVMProgram succeeded, want project FFI rejection")
+	}
+	if !strings.Contains(err.Error(), "plain vm execution does not support project extern custom") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestRunGoProgram(t *testing.T) {
 	tempDir := t.TempDir()
 	sourcePath := filepath.Join(tempDir, "main.ard")
@@ -923,6 +954,28 @@ func TestReadEmbeddedPayloadFromPath(t *testing.T) {
 	}
 	if string(got) != string(payload) {
 		t.Fatalf("payload = %q, want %q", got, payload)
+	}
+}
+
+func TestBuildVMBinaryRejectsProjectGoFFI(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "main.ard")
+	source := `
+		extern fn custom() Void = "Custom"
+
+		fn main() {
+			custom()
+		}
+	`
+	if err := os.WriteFile(sourcePath, []byte(source), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	_, err := buildVMBinary(sourcePath, filepath.Join(t.TempDir(), "app"))
+	if err == nil {
+		t.Fatal("buildVMBinary succeeded, want project FFI rejection")
+	}
+	if !strings.Contains(err.Error(), "plain vm execution does not support project extern custom") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/compiler/vm/ffi.go
+++ b/compiler/vm/ffi.go
@@ -72,7 +72,7 @@ func (vm *VM) callExtern(id air.ExternID, args []Value) (value Value, err error)
 		return Value{}, fmt.Errorf("invalid extern id %d", id)
 	}
 	extern := vm.program.Externs[id]
-	binding := goExternBinding(extern)
+	binding := hostExternBinding(extern)
 	if binding == "JsonParse" {
 		return vm.callJSONParse(extern, args)
 	}
@@ -106,11 +106,18 @@ func (vm *VM) callExtern(id air.ExternID, args []Value) (value Value, err error)
 
 func (vm *VM) buildHostExternAdapters(registry HostFunctionRegistry) (hostExternAdapters, error) {
 	adapters := hostExternAdapters{}
+	usedExterns := vm.reachableExterns()
 	for _, extern := range vm.program.Externs {
-		binding := goExternBinding(extern)
+		if !usedExterns[extern.ID] {
+			continue
+		}
+		binding := hostExternBinding(extern)
+		if isVMNativeExtern(binding) {
+			continue
+		}
 		fn, ok := registry[binding]
 		if !ok {
-			continue
+			return nil, fmt.Errorf("extern binding %q is not registered", binding)
 		}
 		adapter, err := vm.newHostExternAdapter(extern, binding, fn)
 		if err != nil {
@@ -177,11 +184,99 @@ func (adapter hostExternAdapter) callDirect(bridge generatedHostBridge, args []V
 	return value, nil
 }
 
-func goExternBinding(extern air.Extern) string {
+func hostExternBinding(extern air.Extern) string {
 	if binding := extern.Bindings["go"]; binding != "" {
 		return binding
 	}
 	return extern.Name
+}
+
+func isVMNativeExtern(binding string) bool {
+	switch binding {
+	case "JsonParse", "JsonEncode":
+		return true
+	default:
+		return false
+	}
+}
+
+func (vm *VM) reachableExterns() map[air.ExternID]bool {
+	used := map[air.ExternID]bool{}
+	seenFunctions := map[air.FunctionID]bool{}
+	var visitFunction func(air.FunctionID)
+	visitFunction = func(id air.FunctionID) {
+		if id < 0 || int(id) >= len(vm.program.Functions) || seenFunctions[id] {
+			return
+		}
+		seenFunctions[id] = true
+		vm.collectBlockExterns(vm.program.Functions[id].Body, used, visitFunction)
+	}
+	visitFunction(vm.program.Entry)
+	visitFunction(vm.program.Script)
+	for _, test := range vm.program.Tests {
+		visitFunction(test.Function)
+	}
+	return used
+}
+
+func (vm *VM) collectBlockExterns(block air.Block, used map[air.ExternID]bool, visitFunction func(air.FunctionID)) {
+	for _, stmt := range block.Stmts {
+		vm.collectExprExterns(stmt.Value, used, visitFunction)
+		vm.collectExprExterns(stmt.Expr, used, visitFunction)
+		vm.collectExprExterns(stmt.Target, used, visitFunction)
+		vm.collectBlockExterns(stmt.Body, used, visitFunction)
+	}
+	vm.collectExprExterns(block.Result, used, visitFunction)
+}
+
+func (vm *VM) collectExprExterns(expr *air.Expr, used map[air.ExternID]bool, visitFunction func(air.FunctionID)) {
+	if expr == nil {
+		return
+	}
+	switch expr.Kind {
+	case air.ExprCallExtern:
+		used[expr.Extern] = true
+	case air.ExprCall, air.ExprMakeClosure, air.ExprSpawnFiber:
+		visitFunction(expr.Function)
+	}
+	for i := range expr.Args {
+		vm.collectExprExterns(&expr.Args[i], used, visitFunction)
+	}
+	for i := range expr.Entries {
+		vm.collectExprExterns(&expr.Entries[i].Key, used, visitFunction)
+		vm.collectExprExterns(&expr.Entries[i].Value, used, visitFunction)
+	}
+	for i := range expr.Fields {
+		vm.collectExprExterns(&expr.Fields[i].Value, used, visitFunction)
+	}
+	vm.collectExprExterns(expr.Target, used, visitFunction)
+	vm.collectExprExterns(expr.Left, used, visitFunction)
+	vm.collectExprExterns(expr.Right, used, visitFunction)
+	vm.collectExprExterns(expr.Condition, used, visitFunction)
+	vm.collectBlockExterns(expr.Body, used, visitFunction)
+	vm.collectBlockExterns(expr.Then, used, visitFunction)
+	vm.collectBlockExterns(expr.Else, used, visitFunction)
+	for i := range expr.EnumCases {
+		vm.collectBlockExterns(expr.EnumCases[i].Body, used, visitFunction)
+	}
+	for i := range expr.IntCases {
+		vm.collectBlockExterns(expr.IntCases[i].Body, used, visitFunction)
+	}
+	for i := range expr.StrCases {
+		vm.collectBlockExterns(expr.StrCases[i].Body, used, visitFunction)
+	}
+	for i := range expr.RangeCases {
+		vm.collectBlockExterns(expr.RangeCases[i].Body, used, visitFunction)
+	}
+	for i := range expr.UnionCases {
+		vm.collectBlockExterns(expr.UnionCases[i].Body, used, visitFunction)
+	}
+	vm.collectBlockExterns(expr.CatchAll, used, visitFunction)
+	vm.collectBlockExterns(expr.Some, used, visitFunction)
+	vm.collectBlockExterns(expr.None, used, visitFunction)
+	vm.collectBlockExterns(expr.Ok, used, visitFunction)
+	vm.collectBlockExterns(expr.Err, used, visitFunction)
+	vm.collectBlockExterns(expr.Catch, used, visitFunction)
 }
 
 func (vm *VM) validateHostParamType(typeID air.TypeID, target reflect.Type) error {

--- a/compiler/vm/vm_test.go
+++ b/compiler/vm/vm_test.go
@@ -289,6 +289,34 @@ func TestRunEntryEvaluatesResultExtern(t *testing.T) {
 	}
 }
 
+func TestNewWithExternsFailsEarlyForMissingHostFunction(t *testing.T) {
+	program := lowerSourceForVMTest(t, `
+		extern fn missing() Str = "Missing"
+
+		missing()
+	`)
+
+	_, err := NewWithExterns(program, nil)
+	if err == nil || !strings.Contains(err.Error(), `extern binding "Missing" is not registered`) {
+		t.Fatalf("NewWithExterns error = %v, want missing extern registration", err)
+	}
+}
+
+func TestNewWithExternsFailsEarlyForMissingGeneratedAdapter(t *testing.T) {
+	program := lowerSourceForVMTest(t, `
+		extern fn custom() Str = "Custom"
+
+		custom()
+	`)
+
+	_, err := NewWithExterns(program, HostFunctionRegistry{
+		"Custom": func() string { return "ok" },
+	})
+	if err == nil || !strings.Contains(err.Error(), `extern Custom has no generated vm adapter`) {
+		t.Fatalf("NewWithExterns error = %v, want missing generated adapter", err)
+	}
+}
+
 func TestRunEntryEvaluatesClosureCallWithCapture(t *testing.T) {
 	got := runSource(t, `
 		let offset = 2
@@ -1110,7 +1138,7 @@ func newVMFromSource(t *testing.T, input string) *VM {
 	return newVMFromSourceWithExterns(t, input, nil)
 }
 
-func newVMFromSourceWithExterns(t *testing.T, input string, externs HostFunctionRegistry) *VM {
+func lowerSourceForVMTest(t *testing.T, input string) *air.Program {
 	t.Helper()
 	result := parse.Parse([]byte(input), "test.ard")
 	if len(result.Errors) > 0 {
@@ -1125,6 +1153,12 @@ func newVMFromSourceWithExterns(t *testing.T, input string, externs HostFunction
 	if err != nil {
 		t.Fatalf("lower error: %v", err)
 	}
+	return program
+}
+
+func newVMFromSourceWithExterns(t *testing.T, input string, externs HostFunctionRegistry) *VM {
+	t.Helper()
+	program := lowerSourceForVMTest(t, input)
 	vm, err := NewWithExterns(program, externs)
 	if err != nil {
 		t.Fatalf("new vm: %v", err)


### PR DESCRIPTION
## Summary
- clarify that VM externs use Go binding semantics and reject unsupported vm/bytecode extern binding keys
- validate reachable VM extern host functions and generated adapters during VM construction
- reject project Go FFI for plain VM run/build targets before VM initialization or serialization

## Tests
- cd compiler && go test ./...
