### PR TITLE
fix(formatter): preserve extern type bindings

### DIFF
--- a/backlog/userland-ffi-codegen.md
+++ b/backlog/userland-ffi-codegen.md
@@ -18,7 +18,10 @@ similar signature-driven contract generated from Ard `extern` declarations.
 Current project Go FFI support copies user-authored companion files from
 `PROJECT_ROOT/ffi.go` and `PROJECT_ROOT/ffi/*.go`. These files must use
 `package ffi`; the generated Go target imports them as a project FFI package.
-The `examples/tic-tac-toe` project is the current real-world reference example.
+Project extern types can bind to concrete Go host types, e.g.
+`extern type Terminal = "*vaxis.Vaxis"`, so companion functions can use typed
+host values instead of `any` casts. The `examples/tic-tac-toe` project is the
+current real-world reference example.
 
 The intended project shape is:
 

--- a/compiler/formatter/formatter_test.go
+++ b/compiler/formatter/formatter_test.go
@@ -80,6 +80,11 @@ func TestFormat(t *testing.T) {
 			output: "extern type ConnectionPtr\n",
 		},
 		{
+			name:   "preserves extern type Go binding",
+			input:  "extern type Terminal = \"*vaxis.Vaxis\"\n",
+			output: "extern type Terminal = \"*vaxis.Vaxis\"\n",
+		},
+		{
 			name:   "formats generic extern type declaration",
 			input:  "extern type Promise<$T>\n",
 			output: "extern type Promise<$T>\n",

--- a/compiler/formatter/printer.go
+++ b/compiler/formatter/printer.go
@@ -283,6 +283,9 @@ func (p printer) renderExternTypeDeclaration(node *parse.ExternTypeDeclaration) 
 	}
 	header := prefix + "extern type " + node.Name + p.renderTypeParams(node.TypeParams)
 	if len(node.ExternalBindings) == 0 {
+		if node.ExternalBinding != "" {
+			return header + " = " + strconv.Quote(node.ExternalBinding)
+		}
 		return header
 	}
 	if len(node.ExternalBindings) == 1 && node.ExternalBindings["go"] != "" {

--- a/docs/adrs/0008-use-target-aware-extern-companions-for-ffi.md
+++ b/docs/adrs/0008-use-target-aware-extern-companions-for-ffi.md
@@ -14,10 +14,16 @@ Embedding target behavior directly into Ard declarations or compiler special cas
 
 Use target-aware extern bindings and companion modules/files for Ard FFI.
 
-Extern declarations may use a Go-oriented string shorthand:
+Extern function declarations may use a Go-oriented string shorthand:
 
 ```ard
 extern fn read_line() Str!Str = "ReadLine"
+```
+
+Extern type declarations may also bind directly to a Go type when project or stdlib FFI should use a concrete host type instead of the default opaque representation:
+
+```ard
+extern type Terminal = "*vaxis.Vaxis"
 ```
 
 or an explicit target binding block:
@@ -52,6 +58,7 @@ Companion files must use `package ffi`. The Go target copies project companion f
 
 Project Go companion adaptation should use idiomatic generated Go values rather than a universal dynamic object layer. At the project FFI boundary, the current direct-call convention is:
 
+- `extern type Name = "GoType"` values pass as the bound Go type
 - scalar/list/map/function arguments pass as generated Go values
 - `T?` arguments pass as `*T`, with `nil` for none
 - `T` returns directly as `T`

--- a/examples/tic-tac-toe/README.md
+++ b/examples/tic-tac-toe/README.md
@@ -40,7 +40,7 @@ The smoke test builds the Ard Go target, runs the TUI under a PTY, sends keys, a
 Ard sees only this narrow API:
 
 ```ard
-extern type Terminal
+extern type Terminal = "*vaxis.Vaxis"
 extern fn tui_open() Terminal!Str = "TuiOpen"
 extern fn tui_close(term: Terminal) Void!Str = "TuiClose"
 extern fn tui_clear(term: Terminal) Void = "TuiClear"

--- a/examples/tic-tac-toe/ffi.go
+++ b/examples/tic-tac-toe/ffi.go
@@ -7,10 +7,6 @@ import (
 	"git.sr.ht/~rockorager/vaxis"
 )
 
-func mustVaxis(term any) *vaxis.Vaxis {
-	return term.(*vaxis.Vaxis)
-}
-
 func TuiOpen() (*vaxis.Vaxis, error) {
 	vx, err := vaxis.New(vaxis.Options{DisableKittyKeyboard: true})
 	if err != nil {
@@ -22,17 +18,17 @@ func TuiOpen() (*vaxis.Vaxis, error) {
 	return vx, nil
 }
 
-func TuiClose(term any) error {
-	mustVaxis(term).Close()
+func TuiClose(term *vaxis.Vaxis) error {
+	term.Close()
 	return nil
 }
 
-func TuiClear(term any) {
-	mustVaxis(term).Window().Clear()
+func TuiClear(term *vaxis.Vaxis) {
+	term.Window().Clear()
 }
 
-func TuiDrawText(term any, x int, y int, text string) {
-	root := mustVaxis(term).Window()
+func TuiDrawText(term *vaxis.Vaxis, x int, y int, text string) {
+	root := term.Window()
 	width, _ := root.Size()
 	if x < 0 || y < 0 || x >= width {
 		return
@@ -40,8 +36,8 @@ func TuiDrawText(term any, x int, y int, text string) {
 	root.New(x, y, width-x, 1).Print(vaxis.Segment{Text: text})
 }
 
-func TuiFlush(term any) error {
-	mustVaxis(term).Render()
+func TuiFlush(term *vaxis.Vaxis) error {
+	term.Render()
 	return nil
 }
 
@@ -61,8 +57,8 @@ func drainStartupEvents(vx *vaxis.Vaxis) {
 	}
 }
 
-func TuiReadKey(term any) (string, error) {
-	for ev := range mustVaxis(term).Events() {
+func TuiReadKey(term *vaxis.Vaxis) (string, error) {
+	for ev := range term.Events() {
 		switch ev := ev.(type) {
 		case vaxis.Key:
 			if ev.EventType != vaxis.EventPress {

--- a/examples/tic-tac-toe/main.ard
+++ b/examples/tic-tac-toe/main.ard
@@ -1,6 +1,6 @@
 use ard/maybe
 
-extern type Terminal
+extern type Terminal = "*vaxis.Vaxis"
 
 extern fn tui_open() Terminal!Str = "TuiOpen"
 


### PR DESCRIPTION
- **fix(formatter): preserve extern type bindings**
- **docs: document typed extern type bindings**
