### PR TITLE
fix(go): discover stdlib FFI imports in release builds

### DIFF
--- a/.github/workflows/test-compiler.yml
+++ b/.github/workflows/test-compiler.yml
@@ -53,47 +53,6 @@ jobs:
         working-directory: compiler
         run: go test -tags=goexperiment.jsonv2 ./go -count=1
 
-  test-release-mode-binary:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.26"
-          cache: true
-
-      - name: Build release-mode Ard CLI
-        working-directory: compiler
-        run: |
-          go build \
-            -tags=goexperiment.jsonv2 \
-            -ldflags="-X github.com/akonwi/ard/version.Version=v99.0.0" \
-            -o "$RUNNER_TEMP/ard-release-mode" \
-            .
-
-      - name: Run SQL stdlib smoke test with release-mode CLI
-        run: |
-          mkdir -p "$RUNNER_TEMP/ard-sql-smoke"
-          cat > "$RUNNER_TEMP/ard-sql-smoke/main.ard" <<'EOF'
-          use ard/sql
-
-          fn main() Void {
-            sql::extract_params("select * from chores where id = @id").size()
-          }
-          EOF
-          cd "$RUNNER_TEMP/ard-sql-smoke"
-          "$RUNNER_TEMP/ard-release-mode" run main.ard
-
-      - name: Run server smoke test with release-mode CLI
-        working-directory: examples/server
-        env:
-          ARD: ${{ runner.temp }}/ard-release-mode
-        run: ./test_server.py
-
   test-examples:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-compiler.yml
+++ b/.github/workflows/test-compiler.yml
@@ -53,6 +53,47 @@ jobs:
         working-directory: compiler
         run: go test -tags=goexperiment.jsonv2 ./go -count=1
 
+  test-release-mode-binary:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Build release-mode Ard CLI
+        working-directory: compiler
+        run: |
+          go build \
+            -tags=goexperiment.jsonv2 \
+            -ldflags="-X github.com/akonwi/ard/version.Version=v99.0.0" \
+            -o "$RUNNER_TEMP/ard-release-mode" \
+            .
+
+      - name: Run SQL stdlib smoke test with release-mode CLI
+        run: |
+          mkdir -p "$RUNNER_TEMP/ard-sql-smoke"
+          cat > "$RUNNER_TEMP/ard-sql-smoke/main.ard" <<'EOF'
+          use ard/sql
+
+          fn main() Void {
+            sql::extract_params("select * from chores where id = @id").size()
+          }
+          EOF
+          cd "$RUNNER_TEMP/ard-sql-smoke"
+          "$RUNNER_TEMP/ard-release-mode" run main.ard
+
+      - name: Run server smoke test with release-mode CLI
+        working-directory: examples/server
+        env:
+          ARD: ${{ runner.temp }}/ard-release-mode
+        run: ./test_server.py
+
   test-examples:
     runs-on: ubuntu-latest
 

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -825,6 +825,16 @@ func TestGenerateSourcesSupportsIfAndWhile(t *testing.T) {
 	}
 }
 
+func TestCollectFFIGoImportsIncludesStdlibImportsWithoutSourceCheckout(t *testing.T) {
+	imports := collectGoImportsFromEmbeddedArdModule()
+	if imports["sql"] != "database/sql" {
+		t.Fatalf("embedded stdlib FFI imports missing sql: %#v", imports)
+	}
+	if imports["http"] != "net/http" {
+		t.Fatalf("embedded stdlib FFI imports missing http: %#v", imports)
+	}
+}
+
 func TestWriteProgramUsesEmbeddedArdModuleForReleaseVersion(t *testing.T) {
 	original := version.Version
 	version.Version = "v0.19.1"

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -7,6 +7,7 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
+	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -74,7 +75,10 @@ func lowerProgram(program *air.Program, options Options) (map[string]*ast.File, 
 }
 
 func collectFFIGoImports(projectInfo *checker.ProjectInfo) map[string]string {
-	imports := collectGoImportsFromPaths(stdlibFFIGoPaths())
+	imports := collectGoImportsFromEmbeddedArdModule()
+	for alias, path := range collectGoImportsFromPaths(stdlibFFIGoPaths()) {
+		imports[alias] = path
+	}
 	for alias, path := range collectGoImportsFromPaths(projectFFIGoPaths(projectInfo)) {
 		imports[alias] = path
 	}
@@ -109,34 +113,58 @@ func projectFFIGoPaths(projectInfo *checker.ProjectInfo) []string {
 func collectGoImportsFromPaths(paths []string) map[string]string {
 	imports := map[string]string{}
 	for _, path := range paths {
-		if strings.HasSuffix(path, ".gen.go") || strings.HasSuffix(path, "_test.go") || filepath.Base(path) == "generate.go" {
+		if skipFFIImportSource(path) {
 			continue
 		}
-		file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			continue
 		}
-		for _, spec := range file.Imports {
-			if spec.Path == nil {
-				continue
-			}
-			importPath := strings.Trim(spec.Path.Value, "\"")
-			if importPath == "" || importPath == "C" {
-				continue
-			}
-			alias := ""
-			if spec.Name != nil {
-				if spec.Name.Name == "." || spec.Name.Name == "_" {
-					continue
-				}
-				alias = spec.Name.Name
-			} else {
-				alias = filepath.Base(importPath)
-			}
-			imports[alias] = importPath
-		}
+		collectGoImportsFromSource(imports, path, data)
 	}
 	return imports
+}
+
+func collectGoImportsFromEmbeddedArdModule() map[string]string {
+	imports := map[string]string{}
+	for rel, content := range embeddedArdModuleFiles {
+		if !strings.HasPrefix(rel, "std_lib/ffi/") || skipFFIImportSource(rel) {
+			continue
+		}
+		collectGoImportsFromSource(imports, rel, []byte(content))
+	}
+	return imports
+}
+
+func skipFFIImportSource(path string) bool {
+	base := filepath.Base(path)
+	return strings.HasSuffix(base, ".gen.go") || strings.HasSuffix(base, "_test.go") || base == "generate.go"
+}
+
+func collectGoImportsFromSource(imports map[string]string, name string, data []byte) {
+	file, err := parser.ParseFile(token.NewFileSet(), name, data, parser.ImportsOnly)
+	if err != nil {
+		return
+	}
+	for _, spec := range file.Imports {
+		if spec.Path == nil {
+			continue
+		}
+		importPath := strings.Trim(spec.Path.Value, "\"")
+		if importPath == "" || importPath == "C" {
+			continue
+		}
+		alias := ""
+		if spec.Name != nil {
+			if spec.Name.Name == "." || spec.Name.Name == "_" {
+				continue
+			}
+			alias = spec.Name.Name
+		} else {
+			alias = filepath.Base(importPath)
+		}
+		imports[alias] = importPath
+	}
 }
 
 func (l *lowerer) lowerModule(module air.Module) (*ast.File, error) {


### PR DESCRIPTION
## Summary
- collect stdlib FFI imports from the embedded Ard support module so release binaries do not depend on source checkout paths
- keep source checkout import discovery for dev builds and project FFI imports
- add regression coverage for embedded stdlib FFI imports

## Validation
- cd compiler && go test ./go
- cd compiler && go test . -run TestRunServerExampleRoutes
- cd compiler && go test ./...
- built a local release-style binary and verified Ranger now compiles past missing sql/http imports (reaches DATABASE_URL app panic)