### PR TITLE
fix: support multiline type unions

### DIFF
--- a/compiler/formatter/formatter_test.go
+++ b/compiler/formatter/formatter_test.go
@@ -160,6 +160,16 @@ func TestFormat(t *testing.T) {
 			output: "type Value = Str | Int\n\nfn main() {}\n",
 		},
 		{
+			name:   "formats short multiline type union inline",
+			input:  "type Value =\n  | Str\n  | Int\n",
+			output: "type Value = Str | Int\n",
+		},
+		{
+			name:   "formats long type union with leading pipes",
+			input:  "type Event = KeyEvent | MouseEvent | ResizeEvent | FocusEvent | PasteEvent | RedrawEvent | QuitEvent | WindowMoveEvent\n",
+			output: "type Event =\n  | KeyEvent\n  | MouseEvent\n  | ResizeEvent\n  | FocusEvent\n  | PasteEvent\n  | RedrawEvent\n  | QuitEvent\n  | WindowMoveEvent\n",
+		},
+		{
 			name:   "preserves blank line between enum and impl",
 			input:  "enum Method {\n  Get\n}\n\nimpl Str::ToString for Method {\n  fn to_str() Str {\n    \"GET\"\n  }\n}\n",
 			output: "enum Method {\n  Get,\n}\n\nimpl Str::ToString for Method {\n  fn to_str() Str {\n    \"GET\"\n  }\n}\n",

--- a/compiler/formatter/printer.go
+++ b/compiler/formatter/printer.go
@@ -588,7 +588,29 @@ func (p printer) renderTypeDeclaration(node *parse.TypeDeclaration) string {
 }
 
 func (p printer) renderTypeDeclarationDoc(node *parse.TypeDeclaration) doc {
-	return dText(p.renderTypeDeclaration(node))
+	prefix := ""
+	if node.Private {
+		prefix = "private "
+	}
+	header := fmt.Sprintf("%stype %s", prefix, node.Name.Name)
+	if len(node.Type) == 0 {
+		return dText(header + " =")
+	}
+
+	parts := make([]string, 0, len(node.Type))
+	brokenParts := make([]doc, 0, len(node.Type))
+	for _, item := range node.Type {
+		rendered := p.renderType(item)
+		parts = append(parts, rendered)
+		brokenParts = append(brokenParts, dText("| "+rendered))
+	}
+
+	flat := dText(" = " + strings.Join(parts, " | "))
+	broken := dConcat(
+		dText(" ="),
+		dIndent(dConcat(dLine(), dJoin(dLine(), brokenParts))),
+	)
+	return dGroup(dConcat(dText(header), dIfBreak(broken, flat)))
 }
 
 func (p printer) renderWhileLoopDoc(node *parse.WhileLoop) doc {

--- a/compiler/parse/parser.go
+++ b/compiler/parse/parser.go
@@ -722,7 +722,7 @@ func (p *parser) typeUnion(private bool) (Statement, error) {
 	for hasMore {
 		declType := p.parseType()
 		decl.Type = append(decl.Type, declType)
-		hasMore = p.match(pipe)
+		hasMore = p.matchTypeUnionSeparator()
 	}
 
 	if len(decl.Type) > 0 {
@@ -732,6 +732,30 @@ func (p *parser) typeUnion(private bool) (Statement, error) {
 	}
 
 	return decl, nil
+}
+
+func (p *parser) matchTypeUnionSeparator() bool {
+	if p.match(pipe) {
+		p.skipNewlines()
+		return true
+	}
+
+	if !p.check(new_line) {
+		return false
+	}
+
+	index := p.index
+	for index < len(p.tokens) && p.tokens[index].kind == new_line {
+		index++
+	}
+	if index >= len(p.tokens) || p.tokens[index].kind != pipe {
+		return false
+	}
+
+	p.skipNewlines()
+	p.advance() // consume '|'
+	p.skipNewlines()
+	return true
 }
 
 func (p *parser) enumDef(private bool) Statement {

--- a/compiler/parse/parser.go
+++ b/compiler/parse/parser.go
@@ -715,7 +715,9 @@ func (p *parser) typeUnion(private bool) (Statement, error) {
 	p.advance()
 
 	if p.check(new_line) {
-		return nil, p.makeError(p.peek(), "Expected type definition after '='")
+		if !p.matchTypeUnionSeparator() {
+			return nil, p.makeError(p.peek(), "Expected type definition after '='")
+		}
 	}
 
 	hasMore := true

--- a/compiler/parse/parser_test.go
+++ b/compiler/parse/parser_test.go
@@ -490,6 +490,21 @@ func TestTypeUnion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Type union with leading pipe after equals new line",
+			input: `type X =
+  | A
+  | B`,
+			output: Program{
+				Imports: []Import{},
+				Statements: []Statement{
+					&TypeDeclaration{
+						Name: Identifier{Name: "X"},
+						Type: []DeclaredType{&CustomType{Name: "A"}, &CustomType{Name: "B"}},
+					},
+				},
+			},
+		},
 	})
 }
 

--- a/compiler/parse/parser_test.go
+++ b/compiler/parse/parser_test.go
@@ -462,6 +462,34 @@ func TestTypeUnion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Type union with leading pipe on new line",
+			input: `type X = A
+  | B`,
+			output: Program{
+				Imports: []Import{},
+				Statements: []Statement{
+					&TypeDeclaration{
+						Name: Identifier{Name: "X"},
+						Type: []DeclaredType{&CustomType{Name: "A"}, &CustomType{Name: "B"}},
+					},
+				},
+			},
+		},
+		{
+			name: "Type union with trailing pipe before new line",
+			input: `type X = A |
+  B`,
+			output: Program{
+				Imports: []Import{},
+				Statements: []Statement{
+					&TypeDeclaration{
+						Name: Identifier{Name: "X"},
+						Type: []DeclaredType{&CustomType{Name: "A"}, &CustomType{Name: "B"}},
+					},
+				},
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
## Summary
- Allow type union declarations to span lines with leading or trailing pipe separators
- Format long type unions using Prettier-style leading pipes
- Add parser and formatter regression tests

Fixes #150

## Tests
- `cd compiler && go test ./parse ./formatter`