### PR TITLE
fix(go): import project FFI for extern type references

### DIFF
--- a/compiler/go/backend.go
+++ b/compiler/go/backend.go
@@ -5,6 +5,7 @@ package gotarget
 import (
 	"encoding/json"
 	"fmt"
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
@@ -450,7 +451,68 @@ func programUsesProjectFFI(program *air.Program, projectInfo *checker.ProjectInf
 		}
 		return true
 	}
+	for _, typ := range program.Types {
+		if typ.Kind != air.TypeExtern || strings.HasPrefix(typ.ModulePath, "ard/") {
+			continue
+		}
+		if _, ok := dependencyAliasForModulePath(typ.ModulePath, projectInfo); ok {
+			continue
+		}
+		if strings.Contains(typ.ExternBinding, "projectffi.") || externBindingUsesUnqualifiedProjectFFIType(typ.ExternBinding) {
+			return true
+		}
+	}
 	return false
+}
+
+func externBindingUsesUnqualifiedProjectFFIType(binding string) bool {
+	expr, err := parser.ParseExpr(binding)
+	if err != nil {
+		return false
+	}
+	return exprUsesUnqualifiedProjectFFIType(expr)
+}
+
+func exprUsesUnqualifiedProjectFFIType(expr ast.Expr) bool {
+	switch node := expr.(type) {
+	case *ast.Ident:
+		return ast.IsExported(node.Name) && !isPredeclaredGoTypeName(node.Name)
+	case *ast.StarExpr:
+		return exprUsesUnqualifiedProjectFFIType(node.X)
+	case *ast.ArrayType:
+		return exprUsesUnqualifiedProjectFFIType(node.Elt)
+	case *ast.MapType:
+		return exprUsesUnqualifiedProjectFFIType(node.Key) || exprUsesUnqualifiedProjectFFIType(node.Value)
+	case *ast.IndexExpr:
+		return exprUsesUnqualifiedProjectFFIType(node.X) || exprUsesUnqualifiedProjectFFIType(node.Index)
+	case *ast.IndexListExpr:
+		if exprUsesUnqualifiedProjectFFIType(node.X) {
+			return true
+		}
+		for _, index := range node.Indices {
+			if exprUsesUnqualifiedProjectFFIType(index) {
+				return true
+			}
+		}
+		return false
+	case *ast.ParenExpr:
+		return exprUsesUnqualifiedProjectFFIType(node.X)
+	case *ast.SelectorExpr:
+		return false
+	default:
+		return false
+	}
+}
+
+func projectHasFFICompanions(projectInfo *checker.ProjectInfo) bool {
+	if projectInfo == nil || strings.TrimSpace(projectInfo.RootPath) == "" {
+		return false
+	}
+	if fileExists(filepath.Join(projectInfo.RootPath, "ffi.go")) {
+		return true
+	}
+	matches, err := filepath.Glob(filepath.Join(projectInfo.RootPath, "ffi", "*.go"))
+	return err == nil && len(matches) > 0
 }
 
 func externModuleIsStdlib(program *air.Program, ext air.Extern) bool {

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -307,6 +307,87 @@ fn main() Str {
 	}
 }
 
+func TestBuildProgramImportsProjectFFIForExternTypesOnlyUsedAsTypes(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module demo\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ffiDir := filepath.Join(dir, "ffi")
+	if err := os.MkdirAll(ffiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ffiDir, "host.go"), []byte(`package ffi
+
+type Handle struct {
+	Name string
+}
+
+func MakeHandle(name string) (*Handle, error) {
+	return &Handle{Name: name}, nil
+}
+
+func HandleName(h *Handle) string {
+	return h.Name
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "lib.ard"), []byte(`extern type Handle = "*Handle"
+
+extern fn make_handle_raw(name: Str) Handle!Str = "MakeHandle"
+extern fn handle_name(h: Handle) Str = "HandleName"
+
+struct KeyEvent { name: Str }
+struct QuitEvent {}
+
+type Event = KeyEvent | QuitEvent
+
+fn next_event(name: Str) Event!Str {
+  let h = try make_handle_raw(name)
+  let ev: Event = KeyEvent{name: handle_name(h)}
+  Result::ok(ev)
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`use ard/io
+use ard/json
+use demo/lib
+
+fn main() {
+  match lib::next_event("hello").expect("ev") {
+    KeyEvent(k) => {
+      let s = json::encode(k).expect("enc")
+      io::print(s)
+    },
+    QuitEvent(_) => io::print("quit"),
+  }
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetGo)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	builtPath, err := BuildProgram(program, filepath.Join(dir, "app"), loaded.ProjectInfo)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if err := exec.Command(builtPath).Run(); err != nil {
+		t.Fatalf("run built binary: %v", err)
+	}
+}
+
 func TestBuildProgramSupportsProjectGoFFIWithTypedExternType(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -80,6 +80,9 @@ func collectFFIGoImports(projectInfo *checker.ProjectInfo) map[string]string {
 	for alias, path := range collectGoImportsFromPaths(stdlibFFIGoPaths()) {
 		imports[alias] = path
 	}
+	if projectHasFFICompanions(projectInfo) {
+		imports["projectffi"] = "generated/projectffi"
+	}
 	for alias, path := range collectGoImportsFromPaths(projectFFIGoPaths(projectInfo)) {
 		imports[alias] = path
 	}
@@ -299,6 +302,60 @@ func (l *lowerer) registerImportsForGoType(expr ast.Expr, imports map[string]str
 		}
 		return true
 	})
+}
+
+func (l *lowerer) qualifyProjectFFIExternType(expr ast.Expr) ast.Expr {
+	if !projectHasFFICompanions(l.projectInfo) {
+		return expr
+	}
+	return l.qualifyProjectFFIExternTypeExpr(expr)
+}
+
+func (l *lowerer) qualifyProjectFFIExternTypeExpr(expr ast.Expr) ast.Expr {
+	switch node := expr.(type) {
+	case *ast.Ident:
+		if ast.IsExported(node.Name) && !isPredeclaredGoTypeName(node.Name) {
+			l.currentImports["projectffi"] = "generated/projectffi"
+			return &ast.SelectorExpr{X: ast.NewIdent("projectffi"), Sel: ast.NewIdent(node.Name)}
+		}
+		return node
+	case *ast.StarExpr:
+		node.X = l.qualifyProjectFFIExternTypeExpr(node.X)
+		return node
+	case *ast.ArrayType:
+		node.Elt = l.qualifyProjectFFIExternTypeExpr(node.Elt)
+		return node
+	case *ast.MapType:
+		node.Key = l.qualifyProjectFFIExternTypeExpr(node.Key)
+		node.Value = l.qualifyProjectFFIExternTypeExpr(node.Value)
+		return node
+	case *ast.IndexExpr:
+		node.X = l.qualifyProjectFFIExternTypeExpr(node.X)
+		node.Index = l.qualifyProjectFFIExternTypeExpr(node.Index)
+		return node
+	case *ast.IndexListExpr:
+		node.X = l.qualifyProjectFFIExternTypeExpr(node.X)
+		for i := range node.Indices {
+			node.Indices[i] = l.qualifyProjectFFIExternTypeExpr(node.Indices[i])
+		}
+		return node
+	case *ast.ParenExpr:
+		node.X = l.qualifyProjectFFIExternTypeExpr(node.X)
+		return node
+	case *ast.SelectorExpr:
+		return node
+	default:
+		return node
+	}
+}
+
+func isPredeclaredGoTypeName(name string) bool {
+	switch name {
+	case "any", "bool", "byte", "comparable", "complex64", "complex128", "error", "float32", "float64", "int", "int8", "int16", "int32", "int64", "rune", "string", "uint", "uint8", "uint16", "uint32", "uint64", "uintptr":
+		return true
+	default:
+		return false
+	}
 }
 
 func (l *lowerer) runtimePreludeDecls() []ast.Decl {
@@ -1631,6 +1688,7 @@ func (l *lowerer) goType(typeID air.TypeID) (ast.Expr, error) {
 			if err != nil {
 				return nil, fmt.Errorf("invalid go extern type binding %q for %s: %w", info.ExternBinding, info.Name, err)
 			}
+			typ = l.qualifyProjectFFIExternType(typ)
 			l.registerFFIImportsForGoType(typ)
 			return typ, nil
 		}


### PR DESCRIPTION
## Summary
- Reproduce #153 with a project FFI extern type used through generated JSON helpers
- Allow project FFI extern type bindings to use unqualified exported Go type names like `*Handle`
- Qualify those bindings as `projectffi.Handle` during Go lowering and emit the required import
- Treat project FFI extern type references as project FFI usage so companions are copied even for type-only references

Fixes #153

## Tests
- `cd compiler && go test ./go`
- `cd compiler && go generate ./std_lib/ffi && go test ./...`