### PR TITLE
test(go): cover option match extern call lowering

### DIFF
--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -307,6 +307,41 @@ fn main() Str {
 	}
 }
 
+func TestBuildProgramLowersOptionMatchArmModuleExternCall(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`use ard/decode
+
+fn nested_name(obj: Dynamic, field: Str) Str {
+  let nested = decode::run(obj, decode::field(field, decode::nullable(decode::dynamic)))
+    .expect("Missing nested field")
+  match nested {
+    n => decode::run(n, decode::field("name", decode::string)).expect("Missing nested name"),
+    _ => "",
+  }
+}
+
+fn main() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetGo)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	if _, err := BuildProgram(program, filepath.Join(dir, "app"), loaded.ProjectInfo); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+}
+
 func TestBuildProgramImportsProjectFFIForExternTypesOnlyUsedAsTypes(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {


### PR DESCRIPTION
## Summary
- Add regression coverage for issue #155's Option/Maybe match shape
- Verifies checker → AIR → Go build for a match arm calling `decode::run(...).expect(...)`

Closes #155

## Tests
- `cd compiler && go test ./go -run TestBuildProgramLowersOptionMatchArmModuleExternCall`
- `cd compiler && go test ./go`