### PR TITLE
fix(checker): only type final match against return

### DIFF
--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -1547,10 +1547,14 @@ func (c *Checker) checkBlockWithExpected(stmts []parse.Statement, setup func(), 
 
 	lastExprIndex := -1
 	if expectedFinal != nil && expectedFinal != Void {
-		for i := range stmts {
+		for i := len(stmts) - 1; i >= 0; i-- {
+			if _, ok := stmts[i].(*parse.Comment); ok {
+				continue
+			}
 			if canCheckStatementAsExpectedExpression(stmts[i], onlyMatchFinal) {
 				lastExprIndex = i
 			}
+			break
 		}
 	}
 

--- a/compiler/checker/functions_test.go
+++ b/compiler/checker/functions_test.go
@@ -254,6 +254,20 @@ func TestTestFunctions(t *testing.T) {
 func TestCallingPackageFunctions(t *testing.T) {
 	run(t, []test{
 		{
+			name: "Non-final side-effect match is not checked against function return type",
+			input: strings.Join([]string{
+				`use ard/io`,
+				`fn run_up(applied_count: Int) Void!Str {`,
+				`  match applied_count {`,
+				`    0 => io::print("No pending migrations"),`,
+				`    _ => io::print("{applied_count} migration(s) applied"),`,
+				`  }`,
+				`  Result::ok(())`,
+				`}`,
+			}, "\n"),
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
 			name: "Calling io::print",
 			input: strings.Join([]string{
 				`use ard/io`,


### PR DESCRIPTION
## Summary
- Apply expected return type checking only to the actual final expression in a block
- Prevent non-final side-effect match expressions from being checked against function return types
- Add regression coverage for a Void!Str function with an io::print match before Result::ok(())

## Tests
- `cd compiler && go test ./checker`
- `cd compiler && go generate ./std_lib/ffi && go test ./...`