### PR TITLE
fix(go): resolve transitive async extern calls

### DIFF
--- a/compiler/checker/std_lib.go
+++ b/compiler/checker/std_lib.go
@@ -56,10 +56,13 @@ func (pkg AsyncPkg) Get(name string) Symbol {
 	case "sleep":
 		return Symbol{
 			Name: name,
-			Type: &FunctionDef{
-				Name:       name,
-				Parameters: []Parameter{{Name: "ms", Type: Int}},
-				ReturnType: Void,
+			Type: &ExternalFunctionDef{
+				Name:                  name,
+				Parameters:            []Parameter{{Name: "ms", Type: Int}},
+				ReturnType:            Void,
+				ExternalBinding:       "Sleep",
+				ExternalBindingTarget: backend.TargetGo,
+				ExternalBindings:      map[string]string{backend.TargetGo: "Sleep"},
 			},
 		}
 	case "start":

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -307,6 +307,42 @@ fn main() Str {
 	}
 }
 
+func TestBuildProgramLowersTransitiveStdlibExternFromSubmodule(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"sleep-repro\"\nard = \">= 0.13.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "lib.ard"), []byte(`use ard/async
+
+fn tick() Void {
+  async::sleep(1000000)
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`use sleep-repro/lib
+
+fn main() Void {
+  lib::tick()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetGo)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	if _, err := BuildProgram(program, filepath.Join(dir, "app"), loaded.ProjectInfo); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+}
+
 func TestBuildProgramLowersOptionMatchArmModuleExternCall(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {


### PR DESCRIPTION
## Summary
- expose hardcoded async::sleep as an external function with its Go binding
- add a Go backend regression for async::sleep called from a submodule when the entry module does not import ard/async

Fixes #163

## Tests
- cd compiler && go test ./checker ./go