### PR TITLE
ci: update homebrew formula on release

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -9,7 +9,7 @@ description: Cut a new Ard version release end-to-end. Creates and pushes a new 
 
 Cut a new version of the Ard compiler and publish release notes. This skill handles the full flow: tag → CI → release notes. For notes-only updates to an existing release, use the `release-notes` skill instead.
 
-In this repo, the release process is driven by pushing a `v*` git tag. That tag triggers the `Release Binaries` GitHub Actions workflow, and the workflow creates the GitHub release plus uploaded binaries.
+In this repo, the release process is driven by pushing a `v*` git tag. That tag triggers the `Release Binaries` GitHub Actions workflow, and the workflow creates the GitHub release plus uploaded binaries. The workflow also updates `akonwi/homebrew-tap` with the new `Formula/ard.rb` using the `HOMEBREW_TAP_TOKEN` repository secret.
 
 ## Prerequisites
 
@@ -56,7 +56,7 @@ git push origin v<major>.<minor>.<patch>
 
 ### 3. Wait for the release workflow
 
-Pushing a `v*` tag triggers `.github/workflows/build.yml` ("Release Binaries"). It runs tests, builds darwin/linux (amd64/arm64) binaries, and creates a GitHub release with the assets attached.
+Pushing a `v*` tag triggers `.github/workflows/build.yml` ("Release Binaries"). It runs tests, builds darwin/linux (amd64/arm64) binaries, creates a GitHub release with the assets attached, and commits the updated Homebrew formula to `akonwi/homebrew-tap`.
 
 Wait for it to finish before drafting notes (otherwise `gh release edit` may race with the workflow's `gh release create`):
 
@@ -70,7 +70,7 @@ Or poll manually:
 gh run list --workflow "Release Binaries" --limit 1
 ```
 
-All jobs (`test`, `build (darwin/linux × amd64/arm64)`, `release`) must be green. If the workflow fails, stop and investigate — do not proceed to notes.
+All jobs (`test`, `build (darwin/linux × amd64/arm64)`, `release`, `update-homebrew-tap`) must be green. If the workflow fails, stop and investigate — do not proceed to notes.
 
 ### 4. Draft release notes
 
@@ -107,6 +107,7 @@ gh release view v<new>
 ## Notes
 
 - This skill assumes the workflow creates the release. Do not call `gh release create` — it will conflict with the CI job.
+- The Homebrew tap update requires the `HOMEBREW_TAP_TOKEN` secret to have push access to `akonwi/homebrew-tap`.
 - If the workflow races ahead and you need to rewrite notes later, that's what the `release-notes` skill is for.
 - If the tag was pushed but the workflow hasn't started yet, give GitHub a few seconds and re-query `gh run list`.
 - Do not tag from a feature branch. Always tag from `main`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,3 +136,94 @@ jobs:
             Cross-compiled Ard binaries for version ${{ github.ref_name }}
 
             Commit: ${{ github.sha }}
+
+  update-homebrew-tap:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: ard_${{ github.ref_name }}_*
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          sha256sum dist/*.tar.gz > dist/checksums.txt
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: akonwi/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update Ard formula
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          SEMVER="${VERSION#v}"
+          DARWIN_AMD64_SHA="$(grep "ard_${VERSION}_darwin_amd64.tar.gz" dist/checksums.txt | awk '{print $1}')"
+          DARWIN_ARM64_SHA="$(grep "ard_${VERSION}_darwin_arm64.tar.gz" dist/checksums.txt | awk '{print $1}')"
+          LINUX_AMD64_SHA="$(grep "ard_${VERSION}_linux_amd64.tar.gz" dist/checksums.txt | awk '{print $1}')"
+          LINUX_ARM64_SHA="$(grep "ard_${VERSION}_linux_arm64.tar.gz" dist/checksums.txt | awk '{print $1}')"
+
+          cat > homebrew-tap/Formula/ard.rb <<FORMULA
+          class Ard < Formula
+            desc "Programming language and compiler"
+            homepage "https://github.com/akonwi/ard"
+            version "${SEMVER}"
+            license "MIT"
+
+            if OS.mac?
+              if Hardware::CPU.arm?
+                url "https://github.com/akonwi/ard/releases/download/${VERSION}/ard_${VERSION}_darwin_arm64.tar.gz"
+                sha256 "${DARWIN_ARM64_SHA}"
+              else
+                url "https://github.com/akonwi/ard/releases/download/${VERSION}/ard_${VERSION}_darwin_amd64.tar.gz"
+                sha256 "${DARWIN_AMD64_SHA}"
+              end
+            elsif OS.linux?
+              if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+                url "https://github.com/akonwi/ard/releases/download/${VERSION}/ard_${VERSION}_linux_arm64.tar.gz"
+                sha256 "${LINUX_ARM64_SHA}"
+              else
+                url "https://github.com/akonwi/ard/releases/download/${VERSION}/ard_${VERSION}_linux_amd64.tar.gz"
+                sha256 "${LINUX_AMD64_SHA}"
+              end
+            end
+
+            def install
+              bin.install "ard"
+            end
+
+            test do
+              assert_match "${VERSION}", shell_output("#{bin}/ard version")
+            end
+          end
+          FORMULA
+
+      - name: Commit and push formula update
+        working-directory: homebrew-tap
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet -- Formula/ard.rb; then
+            echo "Formula/ard.rb is already up to date"
+            exit 0
+          fi
+
+          git add Formula/ard.rb
+          git commit -m "ard ${VERSION}"
+          git push


### PR DESCRIPTION
## Summary
- add a release workflow job that updates akonwi/homebrew-tap Formula/ard.rb from release artifact checksums
- document the Homebrew tap update in the Ard release skill

## Notes
- requires a HOMEBREW_TAP_TOKEN repository secret with push access to akonwi/homebrew-tap

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml")'
- git diff --check