### PR TITLE
fix(checker): coerce concrete types to trait types at all storage positions

### DIFF
--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -1029,7 +1029,7 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 
 			if s.Type != nil {
 				if expected := c.resolveType(s.Type); expected != nil {
-					if !expected.equal(val.Type()) {
+					if !areCompatible(expected, val.Type()) {
 						c.addError(typeMismatch(expected, val.Type()), s.Value.GetLocation())
 						return nil
 					}
@@ -1076,7 +1076,7 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 					return nil
 				}
 
-				if !target.Type.equal(value.Type()) {
+				if !areCompatible(target.Type, value.Type()) {
 					c.addError(typeMismatch(target.Type, value.Type()), s.Value.GetLocation())
 					return nil
 				}
@@ -1488,7 +1488,7 @@ func (c *Checker) checkList(declaredType Type, expr *parse.ListLiteral) *ListLit
 				hasError = true
 				continue
 			}
-			if !expectedElementType.equal(element.Type()) {
+			if !areCompatible(expectedElementType, element.Type()) {
 				c.addError(typeMismatch(expectedElementType, element.Type()), item.GetLocation())
 				hasError = true
 				continue
@@ -1839,7 +1839,7 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 				// Implicit Maybe wrapping: if field is Maybe<T> and value is T, wrap in maybe::some()
 				if maybeField, isMaybe := field.(*Maybe); isMaybe {
 					if valType := checkVal.Type(); !valType.equal(field) {
-						if maybeField.Of().equal(valType) {
+						if areCompatible(maybeField.Of(), valType) {
 							checkVal = c.synthesizeMaybeSome(checkVal, field)
 						}
 					}
@@ -1874,7 +1874,7 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 							c.diagnostics = c.diagnostics[:diagnosticCount]
 							val = c.checkExpr(property.Value)
 							if val != nil && !val.Type().equal(field) {
-								if maybeField.Of().equal(val.Type()) {
+								if areCompatible(maybeField.Of(), val.Type()) {
 									val = c.synthesizeMaybeSome(val, field)
 								} else {
 									c.addError(typeMismatch(field, val.Type()), property.GetLocation())
@@ -3230,7 +3230,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				Body:                    nil,
 			}
 
-			// Check body (anonymous functions use equal, not areCompatible)
+			// Check body
 			body := c.checkBlockWithExpected(s.Body, func() {
 				c.scope.expectReturn(returnType)
 				for _, param := range params {
@@ -3241,8 +3241,8 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 			// Add function to scope after body is checked (for generic resolution support)
 			c.scope.add(uniqueName, fn, false)
 
-			// Validate return type using equal (stricter than areCompatible)
-			if returnType != Void && !returnType.equal(body.Type()) {
+			// Validate return type
+			if returnType != Void && !areCompatible(returnType, body.Type()) {
 				c.addError(typeMismatch(returnType, body.Type()), s.GetLocation())
 				return nil
 			}
@@ -4461,7 +4461,7 @@ func (c *Checker) checkExprAs(expr parse.Expression, expectedType Type) Expressi
 			bindInferredTypeVars(returnType, body.Type())
 
 			// Validate return type
-			if returnType != Void && !returnType.equal(body.Type()) {
+			if returnType != Void && !areCompatible(returnType, body.Type()) {
 				c.addError(typeMismatch(returnType, body.Type()), s.GetLocation())
 				return nil
 			}
@@ -4561,7 +4561,7 @@ func (c *Checker) checkExprAs(expr parse.Expression, expectedType Type) Expressi
 		return checked
 	}
 
-	if !expectedType.equal(checked.Type()) {
+	if !areCompatible(expectedType, checked.Type()) {
 		c.addError(typeMismatch(expectedType, checked.Type()), expr.GetLocation())
 		return nil
 	}
@@ -4727,7 +4727,7 @@ func (c *Checker) checkFunctionBody(fn *FunctionDef, bodyStmts []parse.Statement
 	}, returnType, true)
 
 	// Check that the function's return type matches its body's type
-	if returnType != Void && !returnType.equal(body.Type()) {
+	if returnType != Void && !areCompatible(returnType, body.Type()) {
 		c.addError(typeMismatch(returnType, body.Type()), location)
 	}
 
@@ -4789,7 +4789,7 @@ func (c *Checker) checkFunction(def *parse.FunctionDeclaration, init func()) *Fu
 		}
 	}, returnType, true)
 
-	// Validate return type - named functions use areCompatible, anonymous use equal
+	// Validate return type
 	if returnType != Void && !areCompatible(returnType, body.Type()) {
 		c.addError(typeMismatch(returnType, body.Type()), def.GetLocation())
 	}
@@ -5046,7 +5046,7 @@ func (c *Checker) checkAndProcessArguments(fnDef *FunctionDef, resolvedArgs []pa
 		if maybeParam, isMaybe := paramType.(*Maybe); isMaybe {
 			if argType := checkedArg.Type(); !argType.equal(paramType) {
 				// Check if argument type matches the inner Maybe type
-				if maybeParam.Of().equal(argType) {
+				if areCompatible(maybeParam.Of(), argType) {
 					// Wrap non-Maybe value in maybe::some()
 					checkedArg = c.synthesizeMaybeSome(checkedArg, paramType)
 				}

--- a/compiler/checker/traits_test.go
+++ b/compiler/checker/traits_test.go
@@ -175,5 +175,81 @@ func TestTraitsAsTypes(t *testing.T) {
 		// 		{Kind: checker.Error, Message: "Type mismatch: Expected ToString, got Foo"},
 		// 	},
 		// },
+		{
+			name: "let binding with explicit trait type (success)",
+			input: `
+			trait Drawable {
+			  fn draw() Str
+			}
+
+			struct Box { w: Int }
+
+			impl Drawable for Box {
+			  fn draw() Str { "box" }
+			}
+
+			fn main() {
+			  let d: Drawable = Box{w: 5}
+			}
+			`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "let binding with explicit trait type (failure)",
+			input: `
+			trait Drawable {
+			  fn draw() Str
+			}
+
+			struct Circle {}
+
+			fn main() {
+			  let d: Drawable = Circle{}
+			}
+			`,
+			diagnostics: []checker.Diagnostic{
+				{Kind: checker.Error, Message: "Type mismatch: Expected implementation of Drawable, got Circle"},
+			},
+		},
+		{
+			name: "struct field with trait type",
+			input: `
+			trait Drawable {
+			  fn draw() Str
+			}
+
+			struct Box { w: Int }
+
+			impl Drawable for Box {
+			  fn draw() Str { "box" }
+			}
+
+			struct Container { child: Drawable }
+
+			fn main() {
+			  let c = Container{child: Box{w: 5}}
+			}
+			`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "list with trait element type",
+			input: `
+			trait Drawable {
+			  fn draw() Str
+			}
+
+			struct Box { w: Int }
+
+			impl Drawable for Box {
+			  fn draw() Str { "box" }
+			}
+
+			fn main() {
+			  let items: [Drawable] = [Box{w: 5}, Box{w: 10}]
+			}
+			`,
+			diagnostics: []checker.Diagnostic{},
+		},
 	})
 }

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -953,6 +953,115 @@ func TestGenerateSourcesSupportsUserTraitObjectDispatch(t *testing.T) {
 	}
 }
 
+func TestGenerateSourcesSupportsVoidTraitObjectDispatch(t *testing.T) {
+	program := lowerSource(t, `
+		use ard/io
+
+		trait Greet {
+			fn say()
+		}
+
+		struct Cat {
+			name: Str,
+		}
+
+		impl Greet for Cat {
+			fn say() {
+				io::print("meow from {self.name}")
+			}
+		}
+
+		fn invoke(g: Greet) {
+			g.say()
+		}
+
+		fn main() {
+			invoke(Cat{name: "milo"})
+		}
+	`)
+
+	sources, err := GenerateSources(program, Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("GenerateSources error = %v", err)
+	}
+	source := string(sources["test.go"])
+	if !strings.Contains(source, "switch typed := g.(type)") {
+		t.Fatalf("generated source missing void trait object dispatch lowering:\n%s", source)
+	}
+	if !strings.Contains(source, "Cat_Greet_say(typed)") {
+		t.Fatalf("generated source missing void trait dispatch call:\n%s", source)
+	}
+	if strings.Contains(source, "= test_ard__Cat_Greet_say(typed)") || strings.Contains(source, "= Cat_Greet_say(typed)") {
+		t.Fatalf("generated source assigns void trait dispatch result:\n%s", source)
+	}
+	if !strings.Contains(source, "invoke(any(") {
+		t.Fatalf("generated source missing trait upcast for call argument:\n%s", source)
+	}
+}
+
+func TestGenerateSourcesSupportsStoredTraitObjectDispatch(t *testing.T) {
+	program := lowerSource(t, `
+		use ard/io
+
+		trait Drawable {
+			fn draw() Str
+		}
+
+		struct Box {
+			w: Int,
+		}
+
+		impl Drawable for Box {
+			fn draw() Str {
+				"box[{self.w}]"
+			}
+		}
+
+		struct Container {
+			child: Drawable,
+		}
+
+		fn show(d: Drawable) {
+			io::print(d.draw())
+		}
+
+		fn main() {
+			let d: Drawable = Box{w: 1}
+			io::print(d.draw())
+
+			let c = Container{child: Box{w: 2}}
+			io::print(c.child.draw())
+
+			let items: [Drawable] = [Box{w: 3}]
+			show(items.at(0))
+		}
+	`)
+
+	sources, err := GenerateSources(program, Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("GenerateSources error = %v", err)
+	}
+	source := string(sources["test.go"])
+	if !strings.Contains(source, "d_0 := any(") {
+		t.Fatalf("generated source missing local trait-object upcast:\n%s", source)
+	}
+	if !strings.Contains(source, "child: any(") {
+		t.Fatalf("generated source missing struct field trait-object upcast:\n%s", source)
+	}
+	if !strings.Contains(source, "[]any{any(") {
+		t.Fatalf("generated source missing list element trait-object upcast:\n%s", source)
+	}
+	if !strings.Contains(source, "switch typed := d_0.(type)") {
+		t.Fatalf("generated source missing local trait-object dispatch:\n%s", source)
+	}
+	if !strings.Contains(source, "switch typed := c_1.child.(type)") {
+		t.Fatalf("generated source missing struct field trait-object dispatch:\n%s", source)
+	}
+	if !strings.Contains(source, "show(items_2[0])") {
+		t.Fatalf("generated source missing list element trait-object use:\n%s", source)
+	}
+}
+
 func TestGenerateSourcesSupportsTraitObjectDispatch(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/io

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -794,7 +794,13 @@ func (l *lowerer) lowerExpr(fn air.Function, expr air.Expr) (loweredExpr, error)
 		if expr.Target == nil {
 			return loweredExpr{}, fmt.Errorf("trait upcast missing target")
 		}
-		return l.lowerExpr(fn, *expr.Target)
+		target, err := l.lowerExpr(fn, *expr.Target)
+		if err != nil {
+			return loweredExpr{}, err
+		}
+		// Box the concrete value as a trait object (Go any) so that
+		// subsequent assignments and dispatches use the correct type.
+		return loweredExpr{stmts: target.stmts, expr: &ast.CallExpr{Fun: ast.NewIdent("any"), Args: []ast.Expr{target.expr}}}, nil
 	case air.ExprCallTrait:
 		return l.lowerTraitCall(fn, expr)
 	case air.ExprToStr:
@@ -3581,13 +3587,18 @@ func (l *lowerer) lowerTraitCall(fn air.Function, expr air.Expr) (loweredExpr, e
 }
 
 func (l *lowerer) lowerTraitObjectCall(fn air.Function, target loweredExpr, expr air.Expr) (loweredExpr, error) {
-	resultTemp := l.nextTemp()
+	isVoid := l.isVoidType(expr.Type)
 	stmts := append([]ast.Stmt{}, target.stmts...)
-	resultType, err := l.goType(expr.Type)
-	if err != nil {
-		return loweredExpr{}, err
+
+	var resultTemp string
+	if !isVoid {
+		resultTemp = l.nextTemp()
+		resultType, err := l.goType(expr.Type)
+		if err != nil {
+			return loweredExpr{}, err
+		}
+		stmts = append(stmts, &ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(resultTemp)}, Type: resultType}}}})
 	}
-	stmts = append(stmts, &ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(resultTemp)}, Type: resultType}}}})
 
 	args := []ast.Expr{ast.NewIdent("typed")}
 	for _, arg := range expr.Args {
@@ -3605,13 +3616,23 @@ func (l *lowerer) lowerTraitObjectCall(fn air.Function, target loweredExpr, expr
 			continue
 		}
 		methodFn := l.program.Functions[impl.Methods[expr.Method]]
+		call := &ast.CallExpr{Fun: ast.NewIdent(functionName(l.program, methodFn)), Args: args}
+		var body ast.Stmt
+		if isVoid {
+			body = &ast.ExprStmt{X: call}
+		} else {
+			body = &ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(resultTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{call}}
+		}
 		cases = append(cases, &ast.CaseClause{
 			List: []ast.Expr{mustTypeExpr(l, impl.ForType)},
-			Body: []ast.Stmt{&ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(resultTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent(functionName(l.program, methodFn)), Args: args}}}},
+			Body: []ast.Stmt{body},
 		})
 	}
 	cases = append(cases, &ast.CaseClause{Body: []ast.Stmt{&ast.ExprStmt{X: &ast.CallExpr{Fun: ast.NewIdent("panic"), Args: []ast.Expr{&ast.BasicLit{Kind: token.STRING, Value: "\"unsupported trait object dispatch\""}}}}}})
 	stmts = append(stmts, &ast.TypeSwitchStmt{Assign: &ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent("typed")}, Tok: token.DEFINE, Rhs: []ast.Expr{&ast.TypeAssertExpr{X: target.expr}}}, Body: &ast.BlockStmt{List: cases}})
+	if isVoid {
+		return loweredExpr{stmts: stmts, expr: ast.NewIdent("nil")}, nil
+	}
 	return loweredExpr{stmts: stmts, expr: ast.NewIdent(resultTemp)}, nil
 }
 


### PR DESCRIPTION
## Summary

Fixes #175 — trait coercion (concrete → trait) now works at all assignment-compatible positions, not just function-call arguments. Additionally fixes the Go backend trait object lowering that was broken for void-returning trait methods and storage positions.

## Checker changes (`compiler/checker/checker.go`)

Changed `equal()` → `areCompatible()` in 10 locations where type compatibility should allow trait coercion:

| Position | Line |
|---|---|
| Let bindings | 1032 |
| Variable reassignment | 1079 |
| List elements | 1491 |
| Generic struct Maybe::some() wrapping | 1842 |
| Non-generic struct Maybe::some() wrapping | 1877 |
| `checkExprAs` final validation | 4564 |
| Anonymous function return (standalone) | 3245 |
| Anonymous function return (context-inferred) | 4464 |
| `checkFunctionBody` return validation | 4730 |
| Generic call Maybe param wrapping | 5049 |

## Go backend changes (`compiler/go/lower.go`)

### `lowerTraitObjectCall` (void dispatch fix)
The type-switch dispatch unconditionally created a `_tmp` variable and assigned call results, even for void-returning methods. This produced invalid Go:



Fixed by guarding the temp/assignment on non-void returns, using `ExprStmt` for void cases.

### `ExprTraitUpcast` (storage boxing fix)
When a concrete value is stored in a trait-typed position (let, struct field, list element), the AIR layer inserts `ExprTraitUpcast`. The Go backend was just passing through the concrete value — now it wraps it in `any(...)` so Go treats the variable/field as the trait interface type.

## Tests

Added 4 checker-level test cases covering let binding, struct field, and list with trait element types (both success and failure cases).