### PR TITLE
fix(go): dispatch cross-module trait objects

### DIFF
--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -2664,6 +2664,9 @@ func (fl *functionLowerer) lowerExpr(expr checker.Expression) (*Expr, error) {
 			return &Expr{Kind: ExprMakeList, Type: typeID}, nil
 		}
 		moduleID := fl.l.internModule(e.Module)
+		if err := fl.l.ensureModuleTraitImplsDeclared(e.Module); err != nil {
+			return nil, err
+		}
 		if e.Call.ExternalBinding != "" {
 			id, err := fl.l.declareConcreteExternCall(moduleID, e.Call.Name, e.Call)
 			if err != nil {
@@ -3783,6 +3786,9 @@ func (fl *functionLowerer) lowerModuleSymbol(typeID TypeID, symbol *checker.Modu
 	def, ok := fl.l.moduleFunctionDefinitionForSymbol(symbol)
 	if ok {
 		module := fl.l.internModule(symbol.Module)
+		if err := fl.l.ensureModuleTraitImplsDeclared(symbol.Module); err != nil {
+			return nil, err
+		}
 		id, err := fl.l.declareAndLowerFunction(module, def)
 		if err != nil {
 			return nil, err
@@ -4081,6 +4087,50 @@ func (l *lowerer) lookupExternInModule(modulePath, name string) (ExternID, bool)
 	}
 	id, ok := l.externs[functionKey(moduleID, name)]
 	return id, ok
+}
+
+func (l *lowerer) ensureModuleTraitImplsDeclared(modulePath string) error {
+	mod, ok := l.moduleByName[modulePath]
+	if !ok || mod.Program() == nil {
+		return nil
+	}
+	modID := l.internModule(modulePath)
+	prog := mod.Program()
+	for _, stmt := range prog.Statements {
+		switch node := stmt.Stmt.(type) {
+		case *checker.StructDef:
+			if typeHasUnresolvedTypeVar(node) {
+				continue
+			}
+			typeID, err := l.internType(node)
+			if err != nil {
+				return err
+			}
+			l.program.Modules[modID].Types = appendUniqueType(l.program.Modules[modID].Types, typeID)
+		case *checker.Enum:
+			typeID, err := l.internType(node)
+			if err != nil {
+				return err
+			}
+			l.program.Modules[modID].Types = appendUniqueType(l.program.Modules[modID].Types, typeID)
+		}
+	}
+	for _, stmt := range prog.Statements {
+		switch node := stmt.Stmt.(type) {
+		case *checker.StructDef:
+			if typeHasUnresolvedTypeVar(node) {
+				continue
+			}
+			if err := l.declareTraitImplsForType(modID, node); err != nil {
+				return err
+			}
+		case *checker.Enum:
+			if err := l.declareTraitImplsForType(modID, node); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (l *lowerer) resolveModuleFunction(modulePath, name string) (FunctionID, bool, error) {

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -997,6 +997,78 @@ func TestGenerateSourcesSupportsUserTraitObjectDispatch(t *testing.T) {
 	}
 }
 
+func TestGenerateSourcesSupportsCrossModuleTraitObjectDispatch(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"checkprobe\"\nard = \">= 0.13.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "widget.ard"), []byte(`
+struct Frame { size: Int }
+
+trait Widget {
+  fn render(frame: Frame)
+}
+
+struct Text { content: Str }
+
+impl Widget for Text {
+  fn render(frame: Frame) { () }
+}
+
+fn plain(content: Str) Widget {
+  Text{content: content}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	resolver, err := checker.NewModuleResolver(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := parse.Parse([]byte(`
+use checkprobe/widget
+
+fn main() {
+  let f = widget::Frame{size: 10}
+  let t = widget::plain("hi")
+  t.render(f)
+}
+`), filepath.Join(tempDir, "main.ard"))
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	c := checker.New(filepath.Join(tempDir, "main.ard"), result.Program, resolver)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+	program, err := air.Lower(c.Module())
+	if err != nil {
+		t.Fatalf("lower error: %v", err)
+	}
+	sources, err := GenerateSources(program, Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("GenerateSources error = %v", err)
+	}
+	source := ""
+	for _, data := range sources {
+		if strings.Contains(string(data), "switch typed := t_1.(type)") {
+			source = string(data)
+			break
+		}
+	}
+	if source == "" {
+		t.Fatalf("generated sources missing trait dispatch: %#v", mapsKeys(sources))
+	}
+	if !strings.Contains(source, "case checkprobe_widget__Text:") {
+		t.Fatalf("generated source missing cross-module trait dispatch case:\n%s", source)
+	}
+	if !strings.Contains(source, "checkprobe_widget__Text_Widget_render(typed, f_0)") {
+		t.Fatalf("generated source missing cross-module trait dispatch call:\n%s", source)
+	}
+}
+
 func TestGenerateSourcesSupportsVoidTraitObjectDispatch(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/io


### PR DESCRIPTION
## Summary
- declare imported module trait impls before lowering cross-module function references
- add a regression test for cross-module trait-object dispatch codegen

## Tests
- cd compiler && go test ./air ./go -run 'Trait|CrossModule' -count=1
- cd compiler && go test ./... -count=1