### PR TITLE
fix(go): use call-site imports for trait dispatch

### DIFF
--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -3888,6 +3888,9 @@ func (fl *functionLowerer) lowerInstanceMethod(typeID TypeID, method *checker.In
 		return nil, fmt.Errorf("unsupported AIR instance method %s on %s", method.Method.Name, method.Subject.Type().String())
 	}
 	if typeInfo.Kind == TypeTraitObject {
+		if err := fl.l.ensureModuleImportTraitImplsDeclared(fl.fn.Module); err != nil {
+			return nil, err
+		}
 		if !validTraitID(&fl.l.program, typeInfo.Trait) {
 			return nil, fmt.Errorf("trait object %s references invalid trait %d", typeInfo.Name, typeInfo.Trait)
 		}
@@ -4089,6 +4092,24 @@ func (l *lowerer) lookupExternInModule(modulePath, name string) (ExternID, bool)
 	return id, ok
 }
 
+func (l *lowerer) ensureModuleImportTraitImplsDeclared(moduleID ModuleID) error {
+	if moduleID < 0 || int(moduleID) >= len(l.program.Modules) {
+		return nil
+	}
+	mod, ok := l.moduleByName[l.program.Modules[moduleID].Path]
+	if !ok || mod.Program() == nil {
+		return nil
+	}
+	for _, imported := range mod.Program().Imports {
+		importedID := l.internModule(imported.Path())
+		l.program.Modules[moduleID].Imports = appendUniqueModule(l.program.Modules[moduleID].Imports, importedID)
+		if err := l.ensureModuleTraitImplsDeclared(imported.Path()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (l *lowerer) ensureModuleTraitImplsDeclared(modulePath string) error {
 	mod, ok := l.moduleByName[modulePath]
 	if !ok || mod.Program() == nil {
@@ -4096,6 +4117,11 @@ func (l *lowerer) ensureModuleTraitImplsDeclared(modulePath string) error {
 	}
 	modID := l.internModule(modulePath)
 	prog := mod.Program()
+	for _, imported := range prog.Imports {
+		l.moduleByName[imported.Path()] = imported
+		importedID := l.internModule(imported.Path())
+		l.program.Modules[modID].Imports = appendUniqueModule(l.program.Modules[modID].Imports, importedID)
+	}
 	for _, stmt := range prog.Statements {
 		switch node := stmt.Stmt.(type) {
 		case *checker.StructDef:
@@ -4332,6 +4358,15 @@ func appendUniqueType(items []TypeID, id TypeID) []TypeID {
 }
 
 func appendUniqueFunction(items []FunctionID, id FunctionID) []FunctionID {
+	for _, item := range items {
+		if item == id {
+			return items
+		}
+	}
+	return append(items, id)
+}
+
+func appendUniqueModule(items []ModuleID, id ModuleID) []ModuleID {
 	for _, item := range items {
 		if item == id {
 			return items

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -1069,6 +1069,115 @@ fn main() {
 	}
 }
 
+func TestGenerateSourcesUsesCallSiteImportsForCrossModuleTraitObjectDispatch(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"nestprobe\"\nard = \">= 0.13.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range []string{filepath.Join(tempDir, "commands"), filepath.Join(tempDir, "tui", "core")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files := map[string]string{
+		"tui/core/widget.ard": `
+struct Frame { size: Int }
+
+trait Widget {
+  fn render(frame: Frame)
+}
+`,
+		"tui/core/text.ard": `
+use nestprobe/tui/core/widget
+
+struct Text { content: Str }
+
+impl widget::Widget for Text {
+  fn render(frame: widget::Frame) { () }
+}
+
+fn plain(content: Str) widget::Widget {
+  Text{content: content}
+}
+`,
+		"tui/core/box.ard": `
+use nestprobe/tui/core/widget
+
+struct Box { child: widget::Widget }
+
+impl widget::Widget for Box {
+  fn render(frame: widget::Frame) {
+    self.child.render(frame)
+  }
+}
+
+fn wrap(child: widget::Widget) widget::Widget {
+  Box{child: child}
+}
+`,
+		"commands/demo.ard": `
+use nestprobe/tui/core/widget
+use nestprobe/tui/core/text as textw
+use nestprobe/tui/core/box as boxw
+
+fn run() {
+  let f = widget::Frame{size: 10}
+  let demo = boxw::wrap(textw::plain("hi"))
+  demo.render(f)
+}
+`,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(tempDir, filepath.FromSlash(name)), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	resolver, err := checker.NewModuleResolver(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := parse.Parse([]byte(`
+use nestprobe/commands/demo
+
+fn main() {
+  demo::run()
+}
+`), filepath.Join(tempDir, "main.ard"))
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	c := checker.New(filepath.Join(tempDir, "main.ard"), result.Program, resolver)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+	program, err := air.Lower(c.Module())
+	if err != nil {
+		t.Fatalf("lower error: %v", err)
+	}
+	sources, err := GenerateSources(program, Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("GenerateSources error = %v", err)
+	}
+	source := ""
+	for _, data := range sources {
+		if strings.Contains(string(data), "switch typed := demo_1.(type)") {
+			source = string(data)
+			break
+		}
+	}
+	if source == "" {
+		t.Fatalf("generated sources missing call-site trait dispatch: %#v", mapsKeys(sources))
+	}
+	if !strings.Contains(source, "case nestprobe_tui_core_box__Box:") {
+		t.Fatalf("generated source missing Box dispatch case from call-site imports:\n%s", source)
+	}
+	if !strings.Contains(source, "case nestprobe_tui_core_text__Text:") {
+		t.Fatalf("generated source missing Text dispatch case from call-site imports:\n%s", source)
+	}
+}
+
 func TestGenerateSourcesSupportsVoidTraitObjectDispatch(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/io


### PR DESCRIPTION
## Summary
- register trait impls from a lazily lowered function module's own imports before lowering its body
- preserve imported-module relationships while declaring trait impls lazily
- add a regression test for trait dispatch in a non-entry module whose impls are only imported at the call site

## Tests
- cd compiler && go test ./go -run CallSiteImports -count=1
- cd compiler && go test ./air ./go -run 'Trait|CrossModule|CallSiteImports' -count=1
- cd compiler && go test ./... -count=1 (printed package successes locally but terminal tool timed out after output)