### PR TITLE
fix(go): deref mut params for value calls

### DIFF
--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -16,6 +16,41 @@ import (
 	"github.com/akonwi/ard/version"
 )
 
+func TestGenerateSourcesDereferencesMutParamForNonMutMethodCall(t *testing.T) {
+	program := lowerSource(t, `
+		struct Box {
+			value: Int,
+		}
+
+		impl Box {
+			fn mut bump() {
+				self.value = self.value + 1
+			}
+
+			fn peek() Int {
+				self.value
+			}
+		}
+
+		fn process(mut b: Box) Int {
+			b.bump()
+			b.peek()
+		}
+	`)
+
+	sources, err := GenerateSources(program, Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("GenerateSources error = %v", err)
+	}
+	source := string(sources["test.go"])
+	if !strings.Contains(source, "Box_bump(b)") {
+		t.Fatalf("generated source missing mut method pointer call:\n%s", source)
+	}
+	if !strings.Contains(source, "Box_peek(*b)") {
+		t.Fatalf("generated source missing deref for non-mut method call on mut param:\n%s", source)
+	}
+}
+
 func TestGenerateSourcesFormatsSimpleProgram(t *testing.T) {
 	program := lowerSource(t, `
 		fn add(a: Int, b: Int) Int {

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -1272,10 +1272,17 @@ func (l *lowerer) lowerExpr(fn air.Function, expr air.Expr) (loweredExpr, error)
 			}
 			stmts = append(stmts, loweredArg.stmts...)
 			argExpr := loweredArg.expr
-			if i < len(target.Signature.Params) && target.Signature.Params[i].Mutable && validTypeID(l.program, target.Signature.Params[i].Type) {
-				paramType := l.program.Types[target.Signature.Params[i].Type-1]
-				if paramType.Kind == air.TypeStruct && !l.localIsPointerParam(fn, arg) {
-					argExpr = &ast.UnaryExpr{Op: token.AND, X: argExpr}
+			if i < len(target.Signature.Params) && validTypeID(l.program, target.Signature.Params[i].Type) {
+				param := target.Signature.Params[i]
+				paramType := l.program.Types[param.Type-1]
+				if paramType.Kind == air.TypeStruct {
+					argIsPointer := l.localIsPointerParam(fn, arg)
+					switch {
+					case param.Mutable && !argIsPointer:
+						argExpr = &ast.UnaryExpr{Op: token.AND, X: argExpr}
+					case !param.Mutable && argIsPointer:
+						argExpr = &ast.StarExpr{X: argExpr}
+					}
 				}
 			}
 			args = append(args, argExpr)


### PR DESCRIPTION
## Summary
- reproduce #183 with a mut struct parameter calling both mut and non-mut methods
- dereference pointer-backed mut parameters when calling value-receiver functions
- preserve existing value-to-pointer adaptation for mut receiver calls

## Tests
- cd compiler && go test ./go -run DereferencesMutParam -count=1
- cd compiler && go test ./go -run 'DereferencesMutParam|Mut' -count=1

Fixes #183