### PR TITLE
fix(traits): support mutable trait parameters

### DIFF
--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -715,7 +715,7 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 						c.addError(fmt.Sprintf("Unrecognized type: %s", param.Type.GetName()), param.Type.GetLocation())
 						continue
 					}
-					params[j] = Parameter{Name: param.Name, Type: paramType}
+					params[j] = Parameter{Name: param.Name, Type: paramType, Mutable: param.Mutable}
 				}
 
 				var returnType Type = Void
@@ -822,7 +822,11 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 							c.addError(typeMismatch(expectedType, paramType), param.GetLocation())
 						}
 
-						params[i] = Parameter{Name: param.Name, Type: paramType}
+						if param.Mutable != traitMethod.Parameters[i].Mutable {
+							c.addError(fmt.Sprintf("Trait method '%s' parameter '%s' mutability mismatch", method.Name, param.Name), param.GetLocation())
+						}
+
+						params[i] = Parameter{Name: param.Name, Type: paramType, Mutable: param.Mutable}
 					}
 
 					// Check return type
@@ -895,7 +899,11 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 							c.addError(typeMismatch(expectedType, paramType), param.GetLocation())
 						}
 
-						params[i] = Parameter{Name: param.Name, Type: paramType}
+						if param.Mutable != traitMethod.Parameters[i].Mutable {
+							c.addError(fmt.Sprintf("Trait method '%s' parameter '%s' mutability mismatch", method.Name, param.Name), param.GetLocation())
+						}
+
+						params[i] = Parameter{Name: param.Name, Type: paramType, Mutable: param.Mutable}
 					}
 
 					// Check return type

--- a/compiler/checker/traits_test.go
+++ b/compiler/checker/traits_test.go
@@ -40,6 +40,39 @@ func TestTraitDefinitions(t *testing.T) {
 			diagnostics: []checker.Diagnostic{},
 		},
 		{
+			name: "Trait methods can declare mutable parameters",
+			input: `
+			struct Counter { value: Int }
+			trait Bumpable {
+				fn poke(mut c: Counter)
+			}
+			struct Doubler {}
+			impl Bumpable for Doubler {
+				fn poke(mut c: Counter) { () }
+			}
+			`,
+			output: &checker.Program{
+				Statements: []checker.Statement{},
+			},
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "Trait impl parameter mutability must match",
+			input: `
+			struct Counter { value: Int }
+			trait Bumpable {
+				fn poke(mut c: Counter)
+			}
+			struct Doubler {}
+			impl Bumpable for Doubler {
+				fn poke(c: Counter) { () }
+			}
+			`,
+			diagnostics: []checker.Diagnostic{
+				{Kind: checker.Error, Message: "Trait method 'poke' parameter 'c' mutability mismatch"},
+			},
+		},
+		{
 			name: "An invalid implementation",
 			input: `
 					use ard/io

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -16,6 +16,45 @@ import (
 	"github.com/akonwi/ard/version"
 )
 
+func TestGenerateSourcesPassesMutTraitArgsByPointer(t *testing.T) {
+	program := lowerSource(t, `
+		struct Counter { value: Int }
+
+		impl Counter {
+			fn mut bump() { self.value = self.value + 1 }
+		}
+
+		trait Bumpable {
+			fn poke(mut c: Counter)
+		}
+
+		struct Doubler {}
+
+		impl Bumpable for Doubler {
+			fn poke(mut c: Counter) {
+				c.bump()
+				c.bump()
+			}
+		}
+
+		fn invoke(b: Bumpable, mut c: Counter) {
+			b.poke(c)
+		}
+	`)
+
+	sources, err := GenerateSources(program, Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("GenerateSources error = %v", err)
+	}
+	source := string(sources["test.go"])
+	if !strings.Contains(source, "Doubler_Bumpable_poke(typed, c)") {
+		t.Fatalf("generated source missing pointer trait dispatch arg:\n%s", source)
+	}
+	if strings.Contains(source, "Doubler_Bumpable_poke(typed, *c)") {
+		t.Fatalf("generated source dereferences mutable trait dispatch arg:\n%s", source)
+	}
+}
+
 func TestGenerateSourcesDereferencesMutParamForNonMutMethodCall(t *testing.T) {
 	program := lowerSource(t, `
 		struct Box {

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -16,6 +16,44 @@ import (
 	"github.com/akonwi/ard/version"
 )
 
+func TestGenerateSourcesTakesAddressOfLocalMutTraitArgs(t *testing.T) {
+	program := lowerSource(t, `
+		struct Counter { value: Int }
+
+		impl Counter {
+			fn mut bump() { self.value = self.value + 1 }
+		}
+
+		trait Bumpable {
+			fn poke(mut c: Counter)
+		}
+
+		struct Doubler {}
+
+		impl Bumpable for Doubler {
+			fn poke(mut c: Counter) {
+				c.bump()
+				c.bump()
+			}
+		}
+
+		fn main() {
+			mut c = Counter{value: 0}
+			let d: Bumpable = Doubler{}
+			d.poke(c)
+		}
+	`)
+
+	sources, err := GenerateSources(program, Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("GenerateSources error = %v", err)
+	}
+	source := string(sources["test.go"])
+	if !strings.Contains(source, "Doubler_Bumpable_poke(typed, &c_0)") {
+		t.Fatalf("generated source missing address-of for local mutable trait dispatch arg:\n%s", source)
+	}
+}
+
 func TestGenerateSourcesPassesMutTraitArgsByPointer(t *testing.T) {
 	program := lowerSource(t, `
 		struct Counter { value: Int }

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -1272,18 +1272,8 @@ func (l *lowerer) lowerExpr(fn air.Function, expr air.Expr) (loweredExpr, error)
 			}
 			stmts = append(stmts, loweredArg.stmts...)
 			argExpr := loweredArg.expr
-			if i < len(target.Signature.Params) && validTypeID(l.program, target.Signature.Params[i].Type) {
-				param := target.Signature.Params[i]
-				paramType := l.program.Types[param.Type-1]
-				if paramType.Kind == air.TypeStruct {
-					argIsPointer := l.localIsPointerParam(fn, arg)
-					switch {
-					case param.Mutable && !argIsPointer:
-						argExpr = &ast.UnaryExpr{Op: token.AND, X: argExpr}
-					case !param.Mutable && argIsPointer:
-						argExpr = &ast.StarExpr{X: argExpr}
-					}
-				}
+			if i < len(target.Signature.Params) {
+				argExpr = l.adaptCallArg(fn, arg, argExpr, target.Signature.Params[i])
 			}
 			args = append(args, argExpr)
 		}
@@ -2056,6 +2046,25 @@ func (l *lowerer) resolvedExprType(fn air.Function, expr air.Expr) air.TypeID {
 		return inferred
 	}
 	return expr.Type
+}
+
+func (l *lowerer) adaptCallArg(fn air.Function, arg air.Expr, argExpr ast.Expr, param air.Param) ast.Expr {
+	if !validTypeID(l.program, param.Type) {
+		return argExpr
+	}
+	paramType := l.program.Types[param.Type-1]
+	if paramType.Kind != air.TypeStruct {
+		return argExpr
+	}
+	argIsPointer := l.localIsPointerParam(fn, arg)
+	switch {
+	case param.Mutable && !argIsPointer:
+		return &ast.UnaryExpr{Op: token.AND, X: argExpr}
+	case !param.Mutable && argIsPointer:
+		return &ast.StarExpr{X: argExpr}
+	default:
+		return argExpr
+	}
 }
 
 func (l *lowerer) localIsPointerParam(fn air.Function, expr air.Expr) bool {
@@ -3622,14 +3631,14 @@ func (l *lowerer) lowerTraitObjectCall(fn air.Function, target loweredExpr, expr
 		stmts = append(stmts, &ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(resultTemp)}, Type: resultType}}}})
 	}
 
-	args := []ast.Expr{ast.NewIdent("typed")}
-	for _, arg := range expr.Args {
+	loweredArgs := make([]loweredExpr, len(expr.Args))
+	for i, arg := range expr.Args {
 		loweredArg, err := l.lowerExpr(fn, arg)
 		if err != nil {
 			return loweredExpr{}, err
 		}
 		stmts = append(stmts, loweredArg.stmts...)
-		args = append(args, loweredArg.expr)
+		loweredArgs[i] = loweredArg
 	}
 
 	cases := []ast.Stmt{}
@@ -3638,6 +3647,15 @@ func (l *lowerer) lowerTraitObjectCall(fn air.Function, target loweredExpr, expr
 			continue
 		}
 		methodFn := l.program.Functions[impl.Methods[expr.Method]]
+		args := []ast.Expr{ast.NewIdent("typed")}
+		for i, loweredArg := range loweredArgs {
+			argExpr := loweredArg.expr
+			paramIndex := i + 1 // skip receiver
+			if paramIndex < len(methodFn.Signature.Params) {
+				argExpr = l.adaptCallArg(fn, expr.Args[i], argExpr, methodFn.Signature.Params[paramIndex])
+			}
+			args = append(args, argExpr)
+		}
 		call := &ast.CallExpr{Fun: ast.NewIdent(functionName(l.program, methodFn)), Args: args}
 		var body ast.Stmt
 		if isVoid {

--- a/compiler/parse/parser.go
+++ b/compiler/parse/parser.go
@@ -1106,6 +1106,8 @@ func (p *parser) traitDef(private bool) *TraitDefinition {
 				p.advance()
 			}
 
+			isMutable := p.match(mut)
+
 			// Use same logic as struct fields for parameter name parsing
 			current := p.peek()
 			if !(current.kind == identifier || p.isAllowedIdentifierKeyword(current.kind)) {
@@ -1126,6 +1128,7 @@ func (p *parser) traitDef(private bool) *TraitDefinition {
 			paramType := p.parseType()
 			params = append(params, Parameter{
 				Location: paramName.getLocation(),
+				Mutable:  isMutable,
 				Name:     paramName.text,
 				Type:     paramType,
 			})

--- a/compiler/parse/traits_test.go
+++ b/compiler/parse/traits_test.go
@@ -48,6 +48,11 @@ func TestTraitDefinitions(t *testing.T) {
 			wantErrs: []string{},
 		},
 		{
+			name:     "Valid trait method with mutable parameter",
+			input:    "trait MyTrait {\n    fn test(mut value: Counter)\n}",
+			wantErrs: []string{},
+		},
+		{
 			name:     "Empty trait works",
 			input:    "trait MyTrait {\n}",
 			wantErrs: []string{},


### PR DESCRIPTION
## Summary
- allow  in trait method parameter declarations
- preserve and enforce trait/impl parameter mutability matching
- add Go backend regression coverage for mutable trait dispatch args

## Tests
- cd compiler && go test ./parse ./checker ./go -run 'Trait|PassesMutTraitArgs' -count=1

Fixes #185