### PR TITLE
fix(parser): stop not from consuming if blocks

### DIFF
--- a/compiler/parse/parser.go
+++ b/compiler/parse/parser.go
@@ -26,10 +26,11 @@ func (pr ParseResult) PrintErrors() {
 }
 
 type parser struct {
-	tokens   []token
-	index    int
-	fileName string
-	errors   []ParseError
+	tokens                 []token
+	index                  int
+	fileName               string
+	errors                 []ParseError
+	disallowStructInstance bool
 }
 
 func Parse(source []byte, fileName string) ParseResult {
@@ -2465,6 +2466,9 @@ func (p *parser) functionDef(asMethod bool, isTest bool) (Statement, error) {
 }
 
 func (p *parser) structInstance() (Expression, error) {
+	if p.disallowStructInstance {
+		return p.iterRange()
+	}
 	index := p.index
 	static := p.parseStaticPath()
 	if static != nil {
@@ -2826,7 +2830,10 @@ func (p *parser) unary() (Expression, error) {
 	if p.match(minus, not) {
 		opToken := p.previous()
 		if opToken.kind == not {
+			previousDisallowStructInstance := p.disallowStructInstance
+			p.disallowStructInstance = true
 			operand, err := p.parseExpression()
+			p.disallowStructInstance = previousDisallowStructInstance
 			if err != nil {
 				return nil, err
 			}

--- a/compiler/parse/parser_test.go
+++ b/compiler/parse/parser_test.go
@@ -245,6 +245,27 @@ func TestIfAndElse(t *testing.T) {
 			},
 		},
 		{
+			name: "Not condition with identifier and non-empty body",
+			input: `if not flag {
+				print("hi")
+			}`,
+			output: Program{
+				Imports: []Import{},
+				Statements: []Statement{
+					&IfStatement{
+						Condition: &UnaryExpression{
+							Operator: Not,
+							Operand:  &Identifier{Name: "flag"},
+						},
+						Body: []Statement{
+							&FunctionCall{Name: "print", Args: []Argument{{Value: &StrLiteral{Value: "hi"}}}, Comments: []Comment{}},
+						},
+						Else: nil,
+					},
+				},
+			},
+		},
+		{
 			name: "Valid if-else",
 			input: `
 					if true {}


### PR DESCRIPTION
## Summary
- reproduce parsing failure for `if not flag { ... }`
- prevent unary `not` operands from interpreting the following block brace as a struct literal
- preserve existing `not` parsing coverage for member access and comparisons

## Tests
- `cd compiler && go run main.go check /tmp/notflag.ard`
- `cd compiler && go test ./parse -run 'Test.*not|TestIfAndElse|TestNestedStructInstantiation' -count=1`
