### PR TITLE
feat(lsp): improve navigation and editing

### DIFF
--- a/compiler/checker/module_resolver.go
+++ b/compiler/checker/module_resolver.go
@@ -37,6 +37,7 @@ type ModuleResolver struct {
 	project      *ProjectInfo
 	moduleCache  map[string]Module         // cache loaded modules by file path
 	astCache     map[string]*parse.Program // cache parsed ASTs by file path
+	overlays     map[string]string         // unsaved source text by resolved file path
 	loadingChain []string                  // track import paths currently being loaded for circular dependency detection
 }
 
@@ -213,8 +214,24 @@ func NewModuleResolver(workingDir string) (*ModuleResolver, error) {
 		project:      project,
 		moduleCache:  make(map[string]Module),
 		astCache:     make(map[string]*parse.Program),
+		overlays:     make(map[string]string),
 		loadingChain: make([]string, 0),
 	}, nil
+}
+
+// SetOverlay provides unsaved source text for a resolved module file path.
+// The LSP uses this so imported open documents are checked from the editor
+// buffer instead of stale on-disk contents.
+func (mr *ModuleResolver) SetOverlay(filePath string, source string) {
+	if mr == nil || strings.TrimSpace(filePath) == "" {
+		return
+	}
+	if mr.overlays == nil {
+		mr.overlays = make(map[string]string)
+	}
+	clean := filepath.Clean(filePath)
+	mr.overlays[clean] = source
+	delete(mr.astCache, clean)
 }
 
 func FetchDependency(startPath string, alias string) (DependencyInfo, error) {
@@ -374,15 +391,23 @@ func (mr *ModuleResolver) LoadModule(importPath string) (*parse.Program, error) 
 		return nil, err
 	}
 
+	filePath = filepath.Clean(filePath)
+
 	// Check cache first
 	if cachedAST, exists := mr.astCache[filePath]; exists {
 		return cachedAST, nil
 	}
 
-	// Read the module file
-	sourceCode, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read module file %s: %w", filePath, err)
+	var sourceCode []byte
+	if overlay, ok := mr.overlays[filePath]; ok {
+		sourceCode = []byte(overlay)
+	} else {
+		var err error
+		// Read the module file
+		sourceCode, err = os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read module file %s: %w", filePath, err)
+		}
 	}
 
 	// Parse the module

--- a/compiler/formatter/formatter.go
+++ b/compiler/formatter/formatter.go
@@ -23,6 +23,8 @@ func Format(input []byte, fileName string) ([]byte, error) {
 		return nil, fmt.Errorf("cannot format invalid Ard source:\n%s", strings.Join(lines, "\n"))
 	}
 
+	removeUnusedImports(result.Program)
+
 	printer := newPrinter(100)
 	formatted := printer.program(result.Program)
 	return []byte(normalizeWhitespace(formatted)), nil

--- a/compiler/formatter/formatter_test.go
+++ b/compiler/formatter/formatter_test.go
@@ -36,8 +36,13 @@ func TestFormat(t *testing.T) {
 		},
 		{
 			name:   "sorts imports into groups",
-			input:  "use github.com/zeta/lib\nuse ard/io\nuse github.com/alpha/lib\n",
-			output: "use ard/io\n\nuse github.com/alpha/lib\nuse github.com/zeta/lib\n",
+			input:  "use github.com/zeta/lib\nuse ard/io\nuse github.com/alpha/lib\nlet _ = io::println(\"hi\")\nlet _ = lib::new()\n",
+			output: "use ard/io\n\nuse github.com/alpha/lib\nuse github.com/zeta/lib\n\nlet _ = io::println(\"hi\")\nlet _ = lib::new()\n",
+		},
+		{
+			name:   "removes unused imports",
+			input:  "use ard/io\nuse app/unused\nuse app/text\n\nlet label = text::new(\"hi\")\n",
+			output: "use app/text\n\nlet label = text::new(\"hi\")\n",
 		},
 		{
 			name:   "wraps long function parameters one per line with trailing comma",

--- a/compiler/formatter/imports.go
+++ b/compiler/formatter/imports.go
@@ -1,0 +1,262 @@
+package formatter
+
+import (
+	"strings"
+
+	"github.com/akonwi/ard/parse"
+)
+
+func removeUnusedImports(program *parse.Program) {
+	if program == nil || len(program.Imports) == 0 {
+		return
+	}
+	used := map[string]bool{}
+	for _, stmt := range program.Statements {
+		collectImportUsesInStatement(stmt, used)
+	}
+	imports := program.Imports[:0]
+	for _, imp := range program.Imports {
+		name := imp.Name
+		if name == "" {
+			name = defaultImportName(imp.Path)
+		}
+		if used[name] {
+			imports = append(imports, imp)
+		}
+	}
+	program.Imports = imports
+}
+
+func collectImportUsesInType(t parse.DeclaredType, used map[string]bool) {
+	switch v := t.(type) {
+	case parse.CustomType:
+		if v.Type.Target != nil {
+			if name := simpleImportUseName(v.Type.Target); name != "" {
+				used[name] = true
+			}
+		}
+		for _, arg := range v.TypeArgs {
+			collectImportUsesInType(arg, used)
+		}
+	case parse.List:
+		collectImportUsesInType(v.Element, used)
+	case parse.Map:
+		collectImportUsesInType(v.Key, used)
+		collectImportUsesInType(v.Value, used)
+	case parse.ResultType:
+		collectImportUsesInType(v.Val, used)
+		collectImportUsesInType(v.Err, used)
+	case parse.FunctionType:
+		for _, p := range v.Params {
+			collectImportUsesInType(p, used)
+		}
+		collectImportUsesInType(v.Return, used)
+	}
+}
+
+func collectImportUsesInStatement(stmt parse.Statement, used map[string]bool) {
+	switch s := stmt.(type) {
+	case *parse.VariableDeclaration:
+		if s.Type != nil {
+			collectImportUsesInType(s.Type, used)
+		}
+		collectImportUsesInExpression(s.Value, used)
+	case *parse.VariableAssignment:
+		collectImportUsesInExpression(s.Target, used)
+		collectImportUsesInExpression(s.Value, used)
+	case *parse.FunctionDeclaration:
+		for _, p := range s.Parameters {
+			if p.Type != nil {
+				collectImportUsesInType(p.Type, used)
+			}
+		}
+		if s.ReturnType != nil {
+			collectImportUsesInType(s.ReturnType, used)
+		}
+		for _, body := range s.Body {
+			collectImportUsesInStatement(body, used)
+		}
+	case *parse.StaticFunctionDeclaration:
+		collectImportUsesInExpression(&s.Path, used)
+		collectImportUsesInStatement(&s.FunctionDeclaration, used)
+	case *parse.ExternalFunction:
+		for _, p := range s.Parameters {
+			if p.Type != nil {
+				collectImportUsesInType(p.Type, used)
+			}
+		}
+		if s.ReturnType != nil {
+			collectImportUsesInType(s.ReturnType, used)
+		}
+	case *parse.TypeDeclaration:
+		for _, t := range s.Type {
+			collectImportUsesInType(t, used)
+		}
+	case *parse.StructDefinition:
+		for _, field := range s.Fields {
+			collectImportUsesInType(field.Type, used)
+		}
+	case *parse.ImplBlock:
+		collectImportUsesInExpression(s.Target, used)
+		for i := range s.Methods {
+			collectImportUsesInStatement(&s.Methods[i], used)
+		}
+	case *parse.TraitDefinition:
+		for i := range s.Methods {
+			collectImportUsesInStatement(&s.Methods[i], used)
+		}
+	case *parse.TraitImplementation:
+		collectImportUsesInExpression(s.ForType, used)
+		for i := range s.Methods {
+			collectImportUsesInStatement(&s.Methods[i], used)
+		}
+	case *parse.StructInstance:
+		collectImportUsesInExpression(s, used)
+	case *parse.EnumDefinition:
+		for _, variant := range s.Variants {
+			collectImportUsesInExpression(variant.Value, used)
+		}
+	case *parse.WhileLoop:
+		collectImportUsesInExpression(s.Condition, used)
+		for _, body := range s.Body {
+			collectImportUsesInStatement(body, used)
+		}
+	case *parse.RangeLoop:
+		collectImportUsesInExpression(s.Start, used)
+		collectImportUsesInExpression(s.End, used)
+		for _, body := range s.Body {
+			collectImportUsesInStatement(body, used)
+		}
+	case *parse.ForInLoop:
+		collectImportUsesInExpression(s.Iterable, used)
+		for _, body := range s.Body {
+			collectImportUsesInStatement(body, used)
+		}
+	case *parse.ForLoop:
+		collectImportUsesInStatement(s.Init, used)
+		collectImportUsesInExpression(s.Condition, used)
+		collectImportUsesInStatement(s.Incrementer, used)
+		for _, body := range s.Body {
+			collectImportUsesInStatement(body, used)
+		}
+	case *parse.IfStatement:
+		collectImportUsesInExpression(s.Condition, used)
+		for _, body := range s.Body {
+			collectImportUsesInStatement(body, used)
+		}
+		collectImportUsesInStatement(s.Else, used)
+	case *parse.MatchExpression, *parse.ConditionalMatchExpression, *parse.Try, *parse.BlockExpression:
+		collectImportUsesInExpression(s, used)
+	}
+}
+
+func collectImportUsesInExpression(expr parse.Expression, used map[string]bool) {
+	switch e := expr.(type) {
+	case nil:
+		return
+	case *parse.StaticProperty:
+		if name := simpleImportUseName(e.Target); name != "" {
+			used[name] = true
+		}
+		collectImportUsesInExpression(e.Target, used)
+		collectImportUsesInExpression(e.Property, used)
+	case *parse.StaticFunction:
+		if name := simpleImportUseName(e.Target); name != "" {
+			used[name] = true
+		}
+		collectImportUsesInExpression(e.Target, used)
+		for _, arg := range e.Function.Args {
+			collectImportUsesInExpression(arg.Value, used)
+		}
+	case *parse.FunctionCall:
+		for _, arg := range e.Args {
+			collectImportUsesInExpression(arg.Value, used)
+		}
+	case *parse.InstanceProperty:
+		collectImportUsesInExpression(e.Target, used)
+		collectImportUsesInExpression(e.Property, used)
+	case *parse.InstanceMethod:
+		collectImportUsesInExpression(e.Target, used)
+		for _, arg := range e.Method.Args {
+			collectImportUsesInExpression(arg.Value, used)
+		}
+	case *parse.StructInstance:
+		if strings.Contains(e.Name.Name, "::") {
+			used[strings.SplitN(e.Name.Name, "::", 2)[0]] = true
+		}
+		for _, prop := range e.Properties {
+			collectImportUsesInExpression(prop.Value, used)
+		}
+	case *parse.AnonymousFunction:
+		for _, p := range e.Parameters {
+			if p.Type != nil {
+				collectImportUsesInType(p.Type, used)
+			}
+		}
+		if e.ReturnType != nil {
+			collectImportUsesInType(e.ReturnType, used)
+		}
+		for _, body := range e.Body {
+			collectImportUsesInStatement(body, used)
+		}
+	case *parse.BinaryExpression:
+		collectImportUsesInExpression(e.Left, used)
+		collectImportUsesInExpression(e.Right, used)
+	case *parse.UnaryExpression:
+		collectImportUsesInExpression(e.Operand, used)
+	case *parse.ChainedComparison:
+		for _, operand := range e.Operands {
+			collectImportUsesInExpression(operand, used)
+		}
+	case *parse.RangeExpression:
+		collectImportUsesInExpression(e.Start, used)
+		collectImportUsesInExpression(e.End, used)
+	case *parse.InterpolatedStr:
+		for _, chunk := range e.Chunks {
+			collectImportUsesInExpression(chunk, used)
+		}
+	case *parse.ListLiteral:
+		for _, item := range e.Items {
+			collectImportUsesInExpression(item, used)
+		}
+	case *parse.MapLiteral:
+		for _, entry := range e.Entries {
+			collectImportUsesInExpression(entry.Key, used)
+			collectImportUsesInExpression(entry.Value, used)
+		}
+	case *parse.MatchExpression:
+		collectImportUsesInExpression(e.Subject, used)
+		for _, c := range e.Cases {
+			collectImportUsesInExpression(c.Pattern, used)
+			for _, body := range c.Body {
+				collectImportUsesInStatement(body, used)
+			}
+		}
+	case *parse.ConditionalMatchExpression:
+		for _, c := range e.Cases {
+			collectImportUsesInExpression(c.Condition, used)
+			for _, body := range c.Body {
+				collectImportUsesInStatement(body, used)
+			}
+		}
+	case *parse.Try:
+		collectImportUsesInExpression(e.Expression, used)
+		for _, body := range e.CatchBlock {
+			collectImportUsesInStatement(body, used)
+		}
+	case *parse.BlockExpression:
+		for _, body := range e.Statements {
+			collectImportUsesInStatement(body, used)
+		}
+	case *parse.IfStatement:
+		collectImportUsesInStatement(e, used)
+	}
+}
+
+func simpleImportUseName(expr parse.Expression) string {
+	id, ok := expr.(*parse.Identifier)
+	if !ok {
+		return ""
+	}
+	return id.Name
+}

--- a/compiler/lsp/completion.go
+++ b/compiler/lsp/completion.go
@@ -336,7 +336,7 @@ func moduleCompletionItems(alias string, mod checker.Module, prog *parse.Program
 		if stmt.Expr != nil {
 			switch fn := stmt.Expr.(type) {
 			case *checker.FunctionDef:
-				if strings.Contains(fn.Name, "::") || mod.Get(fn.Name).IsZero() {
+				if fn.IsTest || strings.Contains(fn.Name, "::") || mod.Get(fn.Name).IsZero() {
 					continue
 				}
 				items = append(items, staticFunctionCompletionItem(alias, fn.Name, fn.Type(), prog, filePath))

--- a/compiler/lsp/completion.go
+++ b/compiler/lsp/completion.go
@@ -17,19 +17,24 @@ type completionKind int
 const (
 	completionInstance completionKind = iota + 1
 	completionStatic
+	completionImport
 )
 
 type completionContext struct {
-	kind   completionKind
-	prefix string
-	sepEnd int
-	offset int
+	kind       completionKind
+	prefix     string
+	importPath string
+	sepEnd     int
+	offset     int
 }
 
 func computeCompletions(source string, filePath string, position protocol.Position) []protocol.CompletionItem {
 	ctx, ok := completionContextAt(source, position)
 	if !ok {
 		return []protocol.CompletionItem{}
+	}
+	if ctx.kind == completionImport {
+		return withCompletionTextEdits(importPathCompletionItems(ctx.importPath, filePath), ctx, position)
 	}
 
 	parseSource := source[:ctx.sepEnd] + completionPlaceholder + source[ctx.offset:]
@@ -70,6 +75,13 @@ func completionContextAt(source string, position protocol.Position) (completionC
 		identStart--
 	}
 	prefix := source[identStart:offset]
+	lineStart := strings.LastIndex(source[:offset], "\n") + 1
+	linePrefix := source[lineStart:offset]
+	if importPrefix, ok := importCompletionPrefix(linePrefix); ok {
+		segmentStart := strings.LastIndex(importPrefix, "/") + 1
+		return completionContext{kind: completionImport, prefix: importPrefix[segmentStart:], importPath: importPrefix, sepEnd: lineStart + len(linePrefix) - len(importPrefix) + segmentStart, offset: offset}, true
+	}
+
 	sepEnd := identStart
 	if sepEnd >= 1 && source[sepEnd-1] == '.' {
 		return completionContext{kind: completionInstance, prefix: prefix, sepEnd: sepEnd, offset: offset}, true

--- a/compiler/lsp/diagnostics.go
+++ b/compiler/lsp/diagnostics.go
@@ -15,6 +15,10 @@ import (
 // parseAndCheck runs the Ard parser and checker on a source file.
 // It returns the parsed AST, the checked module, and any diagnostics.
 func parseAndCheck(source string, filePath string) ([]checker.Diagnostic, error) {
+	return parseAndCheckWithOverlays(source, filePath, nil)
+}
+
+func parseAndCheckWithOverlays(source string, filePath string, overlays map[string]string) ([]checker.Diagnostic, error) {
 	// Parse the source
 	result := parse.Parse([]byte(source), filePath)
 	if result.Program == nil {
@@ -37,6 +41,9 @@ func parseAndCheck(source string, filePath string) ([]checker.Diagnostic, error)
 	moduleResolver, err := checker.NewModuleResolver(workingDir)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing module resolver: %w", err)
+	}
+	for overlayPath, overlaySource := range overlays {
+		moduleResolver.SetOverlay(overlayPath, overlaySource)
 	}
 
 	relPath, err := filepath.Rel(workingDir, filePath)
@@ -132,7 +139,11 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI uri.URI) {
 	}
 
 	filePath := doc.URI.Filename()
-	diags, err := parseAndCheck(doc.Text, filePath)
+	overlays := map[string]string{}
+	for _, cached := range s.cache.Snapshot() {
+		overlays[cached.URI.Filename()] = cached.Text
+	}
+	diags, err := parseAndCheckWithOverlays(doc.Text, filePath, overlays)
 	if err != nil {
 		// If we can't analyze, publish the error as a diagnostic
 		s.sendDiagnostics(ctx, docURI, []protocol.Diagnostic{

--- a/compiler/lsp/diagnostics_test.go
+++ b/compiler/lsp/diagnostics_test.go
@@ -2,6 +2,8 @@ package lsp
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -57,6 +59,32 @@ func TestParseAndCheckWithParseError(t *testing.T) {
 		t.Fatal("expected diagnostics for parse error, got none")
 	}
 	t.Logf("parse error diagnostics: %v", diags)
+}
+
+func TestParseAndCheckUsesOpenDocumentOverlaysForImports(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.0.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	modPath := filepath.Join(root, "tools.ard")
+	if err := os.WriteFile(modPath, []byte("fn old_name() Int { 1 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(root, "main.ard")
+	source := `use test_project/tools
+
+let value = tools::new_name()
+`
+
+	diags, err := parseAndCheckWithOverlays(source, mainPath, map[string]string{
+		modPath: "fn new_name() Int { 1 }\n",
+	})
+	if err != nil {
+		t.Fatalf("parseAndCheckWithOverlays failed: %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("expected overlay import to clear stale diagnostics, got %v", diags)
+	}
 }
 
 // TestPublishDiagnosticsLifecycle verifies the full cycle doesn't panic.

--- a/compiler/lsp/import_completion.go
+++ b/compiler/lsp/import_completion.go
@@ -1,0 +1,125 @@
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/akonwi/ard/checker"
+	"go.lsp.dev/protocol"
+)
+
+func importCompletionPrefix(linePrefix string) (string, bool) {
+	trimmed := strings.TrimLeft(linePrefix, " \t")
+	if !strings.HasPrefix(trimmed, "use ") {
+		return "", false
+	}
+	pathPrefix := strings.TrimSpace(strings.TrimPrefix(trimmed, "use "))
+	if strings.Contains(pathPrefix, " ") || strings.Contains(pathPrefix, "\t") {
+		return "", false
+	}
+	return pathPrefix, true
+}
+
+func importPathCompletionItems(pathPrefix string, filePath string) []protocol.CompletionItem {
+	workingDir := filepath.Dir(filePath)
+	resolver, err := checker.NewModuleResolver(workingDir)
+	if err != nil {
+		return nil
+	}
+	project := resolver.GetProjectInfo()
+	if project == nil {
+		return nil
+	}
+
+	segments := strings.Split(pathPrefix, "/")
+	if pathPrefix == "" {
+		segments = []string{""}
+	}
+	current := segments[len(segments)-1]
+	base := strings.Join(segments[:len(segments)-1], "/")
+
+	candidates := map[string]protocol.CompletionItem{}
+	add := func(label string) {
+		if label == "" || !strings.HasPrefix(label, current) {
+			return
+		}
+		candidates[label] = protocol.CompletionItem{Label: label, Kind: protocol.CompletionItemKindModule, InsertText: label}
+	}
+
+	if base == "" {
+		add("ard")
+		add(project.ProjectName)
+		for alias := range project.Dependencies {
+			add(alias)
+		}
+	} else if base == "ard" {
+		for _, entry := range listArdStdlibImportChildren("") {
+			add(entry)
+		}
+	} else if strings.HasPrefix(base, "ard/") {
+		for _, entry := range listArdStdlibImportChildren(strings.TrimPrefix(base, "ard/")) {
+			add(entry)
+		}
+	} else {
+		root := ""
+		rootName := strings.Split(base, "/")[0]
+		if rootName == project.ProjectName {
+			root = project.RootPath
+		} else if dep, ok := project.Dependencies[rootName]; ok {
+			root = dep.VendorPath
+		}
+		if root != "" {
+			rel := strings.TrimPrefix(base, rootName)
+			rel = strings.TrimPrefix(rel, "/")
+			for _, entry := range listProjectImportChildren(root, rel) {
+				add(entry)
+			}
+		}
+	}
+
+	items := make([]protocol.CompletionItem, 0, len(candidates))
+	for _, item := range candidates {
+		items = append(items, item)
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Label < items[j].Label })
+	return items
+}
+
+func listArdStdlibImportChildren(rel string) []string {
+	root := filepath.Dir(stdLibSourcePath("ard/io"))
+	return listImportChildren(root, rel)
+}
+
+func listProjectImportChildren(root string, rel string) []string {
+	return listImportChildren(root, rel)
+}
+
+func listImportChildren(root string, rel string) []string {
+	dir := filepath.Join(root, filepath.FromSlash(rel))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") || name == "ard-out" || name == ".ard" {
+			continue
+		}
+		if entry.IsDir() {
+			seen[name] = true
+			continue
+		}
+		if strings.HasSuffix(name, ".ard") {
+			seen[strings.TrimSuffix(name, ".ard")] = true
+		}
+	}
+	children := make([]string, 0, len(seen))
+	for child := range seen {
+		children = append(children, child)
+	}
+	sort.Strings(children)
+	return children
+}

--- a/compiler/lsp/server.go
+++ b/compiler/lsp/server.go
@@ -121,6 +121,7 @@ func (s *Server) registerHandlers() {
 	s.handlers[protocol.MethodTextDocumentDocumentSymbol] = s.handleDocumentSymbol
 	s.handlers[protocol.MethodTextDocumentCompletion] = s.handleCompletion
 	s.handlers[protocol.MethodTextDocumentFormatting] = s.handleFormatting
+	s.handlers[protocol.MethodTextDocumentCodeAction] = s.handleCodeAction
 	s.handlers[protocol.MethodTextDocumentSignatureHelp] = s.handleSignatureHelp
 	s.handlers[protocol.MethodTextDocumentDocumentHighlight] = s.handleDocumentHighlight
 	s.handlers[protocol.MethodTextDocumentRename] = s.handleRename
@@ -160,6 +161,7 @@ func (s *Server) handleInitialize(ctx context.Context, reply jsonrpc2.Replier, r
 			},
 			DocumentHighlightProvider:  true,
 			DocumentFormattingProvider: true,
+			CodeActionProvider:         true,
 			RenameProvider:             &protocol.RenameOptions{PrepareProvider: true},
 		},
 		ServerInfo: &protocol.ServerInfo{
@@ -374,6 +376,23 @@ func (s *Server) handleCompletion(ctx context.Context, reply jsonrpc2.Replier, r
 	}, nil)
 }
 
+func fullDocumentEdit(oldText string, newText string) protocol.TextEdit {
+	lines := strings.Count(oldText, "\n")
+	endChar := 0
+	if lastLineStart := strings.LastIndex(oldText, "\n"); lastLineStart >= 0 {
+		endChar = len(oldText) - lastLineStart - 1
+	} else {
+		endChar = len(oldText)
+	}
+	return protocol.TextEdit{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: uint32(lines), Character: uint32(endChar)},
+		},
+		NewText: newText,
+	}
+}
+
 func (s *Server) handleFormatting(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
 	var params protocol.DocumentFormattingParams
 	if err := json.Unmarshal(req.Params(), &params); err != nil {
@@ -391,23 +410,46 @@ func (s *Server) handleFormatting(ctx context.Context, reply jsonrpc2.Replier, r
 		return reply(ctx, []protocol.TextEdit{}, nil)
 	}
 
-	lines := strings.Count(doc.Text, "\n")
-	endChar := 0
-	if lastLineStart := strings.LastIndex(doc.Text, "\n"); lastLineStart >= 0 {
-		endChar = len(doc.Text) - lastLineStart - 1
-	} else {
-		endChar = len(doc.Text)
+	return reply(ctx, []protocol.TextEdit{fullDocumentEdit(doc.Text, string(formatted))}, nil)
+}
+
+func (s *Server) handleCodeAction(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+	var params protocol.CodeActionParams
+	if err := json.Unmarshal(req.Params(), &params); err != nil {
+		return reply(ctx, nil, fmt.Errorf("%s: %w", jsonrpc2.ErrParse, err))
 	}
 
-	edit := protocol.TextEdit{
-		Range: protocol.Range{
-			Start: protocol.Position{Line: 0, Character: 0},
-			End:   protocol.Position{Line: uint32(lines), Character: uint32(endChar)},
-		},
-		NewText: string(formatted),
+	if len(params.Context.Only) > 0 {
+		allowed := false
+		for _, kind := range params.Context.Only {
+			if kind == protocol.Source || kind == protocol.SourceOrganizeImports {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return reply(ctx, []protocol.CodeAction{}, nil)
+		}
 	}
 
-	return reply(ctx, []protocol.TextEdit{edit}, nil)
+	doc := s.cache.Get(params.TextDocument.URI)
+	if doc == nil {
+		return reply(ctx, []protocol.CodeAction{}, nil)
+	}
+	formatted, err := formatSource(doc.Text, doc.URI.Filename())
+	if err != nil || formatted == doc.Text {
+		return reply(ctx, []protocol.CodeAction{}, nil)
+	}
+
+	action := protocol.CodeAction{
+		Title:       "Remove unused imports",
+		Kind:        protocol.SourceOrganizeImports,
+		IsPreferred: true,
+		Edit: &protocol.WorkspaceEdit{Changes: map[protocol.DocumentURI][]protocol.TextEdit{
+			params.TextDocument.URI: {fullDocumentEdit(doc.Text, string(formatted))},
+		}},
+	}
+	return reply(ctx, []protocol.CodeAction{action}, nil)
 }
 
 func (s *Server) handleSignatureHelp(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {

--- a/compiler/lsp/server.go
+++ b/compiler/lsp/server.go
@@ -153,7 +153,7 @@ func (s *Server) handleInitialize(ctx context.Context, reply jsonrpc2.Replier, r
 			ReferencesProvider:     true,
 			DocumentSymbolProvider: true,
 			CompletionProvider: &protocol.CompletionOptions{
-				TriggerCharacters: []string{".", ":"},
+				TriggerCharacters: []string{".", ":", "/"},
 			},
 			SignatureHelpProvider: &protocol.SignatureHelpOptions{
 				TriggerCharacters:   []string{"(", ",", ":"},

--- a/compiler/lsp/server_test.go
+++ b/compiler/lsp/server_test.go
@@ -55,6 +55,7 @@ func TestServerInitializes(t *testing.T) {
 		"textDocument/documentSymbol",
 		"textDocument/completion",
 		"textDocument/formatting",
+		"textDocument/codeAction",
 		"textDocument/signatureHelp",
 		"textDocument/documentHighlight",
 	}
@@ -1277,6 +1278,40 @@ func TestTicTacToeLine42TypingDoesNotHang(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("typing line 42 in tic-tac-toe sample timed out")
+	}
+}
+
+func TestCompletionImportPaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.0.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "tui", "core"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "tui", "core", "text.ard"), []byte("fn new() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "tui", "core", "stack.ard"), []byte("fn hstack() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(root, "main.ard")
+
+	rootItems := computeCompletions("use ", filePath, protocol.Position{Line: 0, Character: 4})
+	assertCompletion(t, rootItems, "ard", "")
+	assertCompletion(t, rootItems, "test_project", "")
+
+	moduleItems := computeCompletions("use test_project/tui/core/", filePath, protocol.Position{Line: 0, Character: 26})
+	assertCompletion(t, moduleItems, "stack", "")
+	assertCompletion(t, moduleItems, "text", "")
+
+	prefixedItems := computeCompletions("use test_project/tui/core/st", filePath, protocol.Position{Line: 0, Character: 28})
+	item, ok := completionItemByLabel(prefixedItems, "stack")
+	if !ok || item.TextEdit == nil {
+		t.Fatalf("expected stack completion with text edit, got %#v", prefixedItems)
+	}
+	if item.TextEdit.NewText != "stack" {
+		t.Fatalf("completion edit text = %q, want stack", item.TextEdit.NewText)
 	}
 }
 

--- a/compiler/lsp/server_test.go
+++ b/compiler/lsp/server_test.go
@@ -1316,6 +1316,36 @@ fn main() {
 }
 
 // TestCompletionUserModuleStaticMembers verifies user module functions and variables complete after ::.
+func TestCompletionUserModuleStaticMembersExcludesTests(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.0.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	toolsSource := `fn helper() Int { 1 }
+
+test fn helper_test() Void!Str { Result::ok(()) }
+`
+	if err := os.WriteFile(filepath.Join(root, "tools.ard"), []byte(toolsSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	source := `use test_project/tools
+
+fn main() {
+  tools::
+}
+`
+	filePath := filepath.Join(root, "main.ard")
+	if err := os.WriteFile(filePath, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	items := computeCompletions(source, filePath, protocol.Position{Line: 3, Character: 9})
+	assertCompletion(t, items, "helper", "fn () Int")
+	if _, ok := completionItemByLabel(items, "helper_test"); ok {
+		t.Fatalf("test function completion should be excluded: %#v", items)
+	}
+}
+
 func TestCompletionUserModuleStaticMembers(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.0.0\"\n"), 0o644); err != nil {

--- a/compiler/lsp/server_test.go
+++ b/compiler/lsp/server_test.go
@@ -232,6 +232,48 @@ func TestFormatSource(t *testing.T) {
 	}
 }
 
+func TestCodeActionRemoveUnusedImports(t *testing.T) {
+	server := NewServer()
+	docURI := uri.New("file:///test.ard")
+	server.cache.Open(docURI, "ard", 1, "use app/unused\nuse app/text\n\nlet label = text::new(\"hi\")\n")
+
+	req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), protocol.MethodTextDocumentCodeAction, protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+		Context:      protocol.CodeActionContext{Only: []protocol.CodeActionKind{protocol.SourceOrganizeImports}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var actions []protocol.CodeAction
+	reply := jsonrpc2.Replier(func(ctx context.Context, result interface{}, err error) error {
+		if err != nil {
+			return err
+		}
+		var ok bool
+		actions, ok = result.([]protocol.CodeAction)
+		if !ok {
+			t.Fatalf("result = %T, want []protocol.CodeAction", result)
+		}
+		return nil
+	})
+	if err := server.handleCodeAction(context.Background(), reply, req); err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if actions[0].Kind != protocol.SourceOrganizeImports {
+		t.Fatalf("action kind = %q, want %q", actions[0].Kind, protocol.SourceOrganizeImports)
+	}
+	edits := actions[0].Edit.Changes[protocol.DocumentURI(docURI)]
+	if len(edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(edits))
+	}
+	if strings.Contains(edits[0].NewText, "app/unused") {
+		t.Fatalf("expected unused import to be removed, got:\n%s", edits[0].NewText)
+	}
+}
+
 // TestFormattingHandler verifies the full handleFormatting flow.
 func TestFormattingHandler(t *testing.T) {
 	server := NewServer()

--- a/compiler/lsp/server_test.go
+++ b/compiler/lsp/server_test.go
@@ -804,6 +804,38 @@ fn main() Int {
 }
 
 // TestDefinitionImportedModuleSymbols verifies go-to-definition across imported modules.
+func TestDefinitionNestedStaticFunctionUsesInnerModuleAlias(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.0.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "text.ard"), []byte(`fn new(label: Str) Str { label }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "stack.ard"), []byte(`fn hstack(children: [Str]) Str { "" }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	source := `use test_project/stack
+use test_project/text
+
+fn main() {
+  let tabs = stack::hstack([
+    text::new("Inbox"),
+  ])
+}
+`
+	filePath := filepath.Join(root, "main.ard")
+	if err := os.WriteFile(filePath, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	textPath := filepath.Join(root, "text.ard")
+
+	loc := requireDefinition(t, source, filePath, 5, 5)
+	assertDefinitionStart(t, loc, textPath, 0, 0)
+}
+
 func TestDefinitionImportedModuleSymbols(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.0.0\"\n"), 0o644); err != nil {

--- a/compiler/parse/expressions_test.go
+++ b/compiler/parse/expressions_test.go
@@ -33,6 +33,27 @@ func TestListLiterals(t *testing.T) {
 	})
 }
 
+func TestMultilineListLiteralLocationSpansClosingBracket(t *testing.T) {
+	result := Parse([]byte("let items = [\n  one::new(),\n]\n"), "test.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse errors: %v", result.Errors)
+	}
+	decl, ok := result.Program.Statements[0].(*VariableDeclaration)
+	if !ok {
+		t.Fatalf("statement = %T, want VariableDeclaration", result.Program.Statements[0])
+	}
+	list, ok := decl.Value.(*ListLiteral)
+	if !ok {
+		t.Fatalf("value = %T, want ListLiteral", decl.Value)
+	}
+	if got, want := list.Location.End.Row, 3; got != want {
+		t.Fatalf("list end row = %d, want %d", got, want)
+	}
+	if got, want := list.Location.End.Col, 0; got != want {
+		t.Fatalf("list end col = %d, want %d", got, want)
+	}
+}
+
 func TestMapLiterals(t *testing.T) {
 	runTests(t, []test{
 		{

--- a/compiler/parse/parser.go
+++ b/compiler/parse/parser.go
@@ -3332,9 +3332,13 @@ func (p *parser) list() (Expression, error) {
 		p.match(comma)
 		p.match(new_line)
 	}
+	endToken := p.previous()
 	result := &ListLiteral{
-		Items:    items,
-		Location: startToken.getLocation(),
+		Items: items,
+		Location: Location{
+			Start: startToken.getLocation().Start,
+			End:   endToken.getLocation().End,
+		},
 	}
 	if len(comments) > 0 {
 		result.Comments = comments


### PR DESCRIPTION
## Summary
- exclude test functions from static member completions
- fix go-to-definition inside multiline list arguments
- use open editor buffers when checking diagnostics for imports
- remove unused imports during formatting and via source organize imports
- add import path completions for stdlib, project modules, and dependencies

## Tests
- cd compiler && go test ./lsp -count=1
- cd compiler && go test ./formatter -count=1
- cd compiler && go test ./checker ./lsp -run 'TestParseAndCheckUsesOpenDocumentOverlaysForImports|TestCompletionUserModuleStaticMembersExcludesTests|TestDefinitionNestedStaticFunctionUsesInnerModuleAlias|TestLoadModule' -count=1