### PR TITLE
fix(go): pass pointer for mutating trait dispatch

### DIFF
--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -1131,6 +1131,40 @@ func TestGenerateSourcesSupportsCapturedClosureSort(t *testing.T) {
 	}
 }
 
+func TestGenerateSourcesPassesPointerReceiverForMutatingTraitImpl(t *testing.T) {
+	program := lowerSource(t, `
+		trait Writer {
+			fn write(text: Str)
+		}
+
+		struct Buffer {
+			contents: Str,
+		}
+
+		impl Writer for Buffer {
+			fn mut write(text: Str) {
+				self.contents = self.contents + text
+			}
+		}
+
+		fn send(w: Writer) {
+			w.write("hi")
+		}
+	`)
+
+	sources, err := GenerateSources(program, Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("GenerateSources error = %v", err)
+	}
+	source := string(sources["test.go"])
+	if !strings.Contains(source, "_Buffer_Writer_write(self *") {
+		t.Fatalf("generated source missing pointer receiver for mutating trait impl:\n%s", source)
+	}
+	if !strings.Contains(source, "_Buffer_Writer_write(&typed, \"hi\")") {
+		t.Fatalf("generated source missing address-of for mutating trait dispatch receiver:\n%s", source)
+	}
+}
+
 func TestGenerateSourcesSupportsUserTraitObjectDispatch(t *testing.T) {
 	program := lowerSource(t, `
 		trait Renderable {

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -3647,7 +3647,14 @@ func (l *lowerer) lowerTraitObjectCall(fn air.Function, target loweredExpr, expr
 			continue
 		}
 		methodFn := l.program.Functions[impl.Methods[expr.Method]]
-		args := []ast.Expr{ast.NewIdent("typed")}
+		receiver := ast.Expr(ast.NewIdent("typed"))
+		if len(methodFn.Signature.Params) > 0 {
+			receiverParam := methodFn.Signature.Params[0]
+			if receiverParam.Mutable && validTypeID(l.program, receiverParam.Type) && l.program.Types[receiverParam.Type-1].Kind == air.TypeStruct {
+				receiver = &ast.UnaryExpr{Op: token.AND, X: receiver}
+			}
+		}
+		args := []ast.Expr{receiver}
 		for i, loweredArg := range loweredArgs {
 			argExpr := loweredArg.expr
 			paramIndex := i + 1 // skip receiver


### PR DESCRIPTION
## Summary
- fix Go trait-object dispatch to pass `&typed` for mutating struct trait impl receivers
- add a regression test covering trait contracts without mutability implemented by a mutating struct method

## Tests
- cd compiler && go test ./go -run 'TestGenerateSourcesPassesPointerReceiverForMutatingTraitImpl|TestGenerateSourcesSupportsUserTraitObjectDispatch|TestGenerateSourcesPassesMutTraitArgsByPointer|TestGenerateSourcesTakesAddressOfLocalMutTraitArgs' -count=1
