### PR TITLE
fix(checker): require generic type arguments

### DIFF
--- a/compiler/air/lower_test.go
+++ b/compiler/air/lower_test.go
@@ -831,3 +831,15 @@ func testTypeInfo(t *testing.T, program *Program, id TypeID) TypeInfo {
 	t.Fatalf("type id %d not found", id)
 	return TypeInfo{}
 }
+
+func TestLowerImportedGenericStructReturnTypeWithTypeArg(t *testing.T) {
+	lowerSource(t, `
+use ard/async/channel
+extern type RawEvent = "RawEvent"
+extern fn events() channel::Channel<RawEvent> = "Events"
+fn run() {
+  let ch = events()
+}
+fn main() { run() }
+`)
+}

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -623,6 +623,9 @@ func (c *Checker) resolveType(t parse.DeclaredType) Type {
 			if len(ty.TypeArgs) > 0 {
 				baseType = c.specializeAliasedType(sym.Type, ty.TypeArgs, ty.GetLocation())
 			} else {
+				if hasGenericsInType(sym.Type) {
+					c.addError(fmt.Sprintf("Generic type %s requires type arguments", t.GetName()), ty.GetLocation())
+				}
 				baseType = sym.Type
 			}
 			break
@@ -636,6 +639,9 @@ func (c *Checker) resolveType(t parse.DeclaredType) Type {
 					if len(ty.TypeArgs) > 0 {
 						baseType = c.specializeAliasedType(sym.Type, ty.TypeArgs, ty.GetLocation())
 					} else {
+						if hasGenericsInType(sym.Type) {
+							c.addError(fmt.Sprintf("Generic type %s::%s requires type arguments", ty.Type.Target, ty.Type.Property), ty.GetLocation())
+						}
 						baseType = sym.Type
 					}
 					break

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -96,6 +96,19 @@ func run(t *testing.T, tests []test) {
 	}
 }
 
+func TestGenericImportedTypeRequiresTypeArguments(t *testing.T) {
+	run(t, []test{
+		{
+			name: "generic imported struct without type args is an error",
+			input: `use ard/async/channel
+extern fn events() channel::Channel = "Events"`,
+			diagnostics: []checker.Diagnostic{
+				{Kind: checker.Error, Message: "Generic type channel::Channel requires type arguments"},
+			},
+		},
+	})
+}
+
 func TestImports(t *testing.T) {
 	run(t, []test{
 		{


### PR DESCRIPTION
## Summary
- report a checker diagnostic when generic types are used without required type arguments
- prevent unresolved TypeVars from reaching AIR lowering for imported generic types like `channel::Channel`
- add regression coverage for the checker diagnostic and typed generic lowering

## Tests
- cd compiler && go test ./checker ./air -run 'TestGenericImportedTypeRequiresTypeArguments|TestLowerImportedGenericStructReturnTypeWithTypeArg' -count=1
