### PR TITLE
fix(checker): resolve common match result types

### DIFF
--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -4022,36 +4022,41 @@ func (fl *functionLowerer) resolveLocal(name string) (LocalID, bool, error) {
 	if fl.parent == nil {
 		return 0, false, nil
 	}
-	local, _, ok, err := fl.captureLocal(name)
+	local, _, _, ok, err := fl.captureLocal(name)
 	return local, ok, err
 }
 
 func (fl *functionLowerer) ensureLocalForNestedCapture(name string) (LocalID, TypeID, bool, error) {
+	local, typeID, _, ok, err := fl.ensureLocalForNestedCaptureWithMutability(name)
+	return local, typeID, ok, err
+}
+
+func (fl *functionLowerer) ensureLocalForNestedCaptureWithMutability(name string) (LocalID, TypeID, bool, bool, error) {
 	if local, ok := fl.locals[name]; ok {
-		return local, fl.fn.Locals[local].Type, true, nil
+		return local, fl.fn.Locals[local].Type, fl.fn.Locals[local].Mutable, true, nil
 	}
 	if fl.parent == nil {
-		return 0, NoType, false, nil
+		return 0, NoType, false, false, nil
 	}
 	return fl.captureLocal(name)
 }
 
-func (fl *functionLowerer) captureLocal(name string) (LocalID, TypeID, bool, error) {
+func (fl *functionLowerer) captureLocal(name string) (LocalID, TypeID, bool, bool, error) {
 	if fl.captureByName == nil {
 		fl.captureByName = map[string]LocalID{}
 	}
 	if local, ok := fl.captureByName[name]; ok {
-		return local, fl.fn.Locals[local].Type, true, nil
+		return local, fl.fn.Locals[local].Type, fl.fn.Locals[local].Mutable, true, nil
 	}
-	sourceLocal, typeID, ok, err := fl.parent.ensureLocalForNestedCapture(name)
+	sourceLocal, typeID, mutable, ok, err := fl.parent.ensureLocalForNestedCaptureWithMutability(name)
 	if err != nil || !ok {
-		return 0, NoType, ok, err
+		return 0, NoType, false, ok, err
 	}
-	local := fl.defineLocal(name, typeID, false)
+	local := fl.defineLocal(name, typeID, mutable)
 	fl.captureByName[name] = local
 	fl.captureLocals = append(fl.captureLocals, sourceLocal)
 	fl.fn.Captures = append(fl.fn.Captures, Capture{Name: name, Type: typeID, Local: local})
-	return local, typeID, true, nil
+	return local, typeID, mutable, true, nil
 }
 
 func (fl *functionLowerer) localKind(local LocalID) TypeKind {

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -693,6 +693,21 @@ func formatTypeForDisplay(t Type) string {
 	return t.String()
 }
 
+func mergeMatchResultType(c *Checker, current Type, next Type, loc parse.Location) (Type, bool) {
+	if current == nil {
+		return next, true
+	}
+	merged, ok := commonResultType(current, next)
+	if ok {
+		return merged, true
+	}
+	if c.expectedExpr != nil && areCompatible(c.expectedExpr, current) && areCompatible(c.expectedExpr, next) {
+		return c.expectedExpr, true
+	}
+	c.addError(typeMismatch(current, next), loc)
+	return nil, false
+}
+
 func typeMismatch(expected, got Type) string {
 	exMsg := formatTypeForDisplay(expected)
 	if _, isTrait := expected.(*Trait); isTrait {
@@ -1629,8 +1644,12 @@ func (c *Checker) checkBlockWithExpected(stmts []parse.Statement, setup func(), 
 
 func canCheckStatementAsExpectedExpression(stmt parse.Statement, expectedFinal Type, onlyMatchFinal bool) bool {
 	if onlyMatchFinal && expectedFinal != Void {
-		_, ok := stmt.(*parse.MatchExpression)
-		return ok
+		switch stmt.(type) {
+		case *parse.MatchExpression, *parse.ConditionalMatchExpression:
+			return true
+		default:
+			return false
+		}
 	}
 	if expectedFinal == Void {
 		switch stmt.(type) {
@@ -1647,7 +1666,7 @@ func canCheckStatementAsExpectedExpression(stmt parse.Statement, expectedFinal T
 	}
 
 	switch stmt.(type) {
-	case *parse.MatchExpression, *parse.IfStatement, *parse.StaticFunction, *parse.ListLiteral, *parse.MapLiteral, *parse.AnonymousFunction:
+	case *parse.MatchExpression, *parse.ConditionalMatchExpression, *parse.IfStatement, *parse.StaticFunction, *parse.ListLiteral, *parse.MapLiteral, *parse.AnonymousFunction:
 		return true
 	default:
 		return false
@@ -3341,6 +3360,12 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				return nil
 			}
 
+			resultType, ok := commonResultType(someBody.Type(), noneBody.Type())
+			if !ok {
+				c.addError(typeMismatch(someBody.Type(), noneBody.Type()), s.GetLocation())
+				return nil
+			}
+
 			// Create the OptionMatch
 			return &OptionMatch{
 				Subject:   subject,
@@ -3349,7 +3374,8 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 					Pattern: patternIdent,
 					Body:    someBody,
 				},
-				None: noneBody,
+				None:       noneBody,
+				ResultType: resultType,
 			}
 		}
 
@@ -3430,29 +3456,23 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				}
 			}
 
-			// Ensure all cases return the same type
-			if len(cases) > 0 {
-				// Find the first non-nil case to use as reference type
-				var referenceType Type
-				for _, caseBody := range cases {
-					if caseBody != nil {
-						referenceType = caseBody.Type()
-						break
-					}
+			// Ensure all cases return compatible types
+			var enumResultType Type
+			for _, caseBody := range cases {
+				if caseBody == nil {
+					continue
 				}
-
-				if referenceType != nil {
-					if catchAllBody != nil && !referenceType.equal(catchAllBody.Type()) {
-						c.addError(typeMismatch(referenceType, catchAllBody.Type()), s.GetLocation())
-						return nil
-					}
-
-					for _, caseBody := range cases {
-						if caseBody != nil && !referenceType.equal(caseBody.Type()) {
-							c.addError(typeMismatch(referenceType, caseBody.Type()), s.GetLocation())
-							return nil
-						}
-					}
+				var ok bool
+				enumResultType, ok = mergeMatchResultType(c, enumResultType, caseBody.Type(), s.GetLocation())
+				if !ok {
+					return nil
+				}
+			}
+			if catchAllBody != nil {
+				var ok bool
+				enumResultType, ok = mergeMatchResultType(c, enumResultType, catchAllBody.Type(), s.GetLocation())
+				if !ok {
+					return nil
 				}
 			}
 
@@ -3466,6 +3486,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				Cases:               cases,
 				CatchAll:            catchAllBody,
 				DiscriminantToIndex: discriminantToIndex,
+				ResultType:          enumResultType,
 			}
 
 			return enumMatch
@@ -3526,17 +3547,20 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				return nil
 			}
 
-			// Ensure both branches return the same type
-			if !trueBody.Type().equal(falseBody.Type()) {
+			// Ensure both branches return compatible types. This allows one branch to
+			// return a trait object while the other returns a concrete implementation.
+			resultType, ok := commonResultType(trueBody.Type(), falseBody.Type())
+			if !ok {
 				c.addError(typeMismatch(trueBody.Type(), falseBody.Type()), s.GetLocation())
 				return nil
 			}
 
 			// Create and return the BoolMatch
 			return &BoolMatch{
-				Subject: subject,
-				True:    trueBody,
-				False:   falseBody,
+				Subject:    subject,
+				True:       trueBody,
+				False:      falseBody,
+				ResultType: resultType,
 			}
 		}
 
@@ -3628,26 +3652,23 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				}
 			}
 
-			// Ensure all cases return the same type
-			var referenceType Type
+			// Ensure all cases return compatible types
+			var unionResultType Type
 			for _, caseBody := range typeCases {
-				if caseBody != nil {
-					referenceType = caseBody.Body.Type()
-					break
+				if caseBody == nil {
+					continue
 				}
-			}
-
-			if referenceType != nil {
-				if catchAllBody != nil && !referenceType.equal(catchAllBody.Type()) {
-					c.addError(typeMismatch(referenceType, catchAllBody.Type()), s.GetLocation())
+				var ok bool
+				unionResultType, ok = mergeMatchResultType(c, unionResultType, caseBody.Body.Type(), s.GetLocation())
+				if !ok {
 					return nil
 				}
-
-				for _, caseBody := range typeCases {
-					if caseBody != nil && !referenceType.equal(caseBody.Body.Type()) {
-						c.addError(typeMismatch(referenceType, caseBody.Body.Type()), s.GetLocation())
-						return nil
-					}
+			}
+			if catchAllBody != nil {
+				var ok bool
+				unionResultType, ok = mergeMatchResultType(c, unionResultType, catchAllBody.Type(), s.GetLocation())
+				if !ok {
+					return nil
 				}
 			}
 
@@ -3662,6 +3683,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				TypeCases:       typeCases,
 				TypeCasesByType: typeCasesByType,
 				CatchAll:        catchAllBody,
+				ResultType:      unionResultType,
 			}
 		}
 
@@ -3732,19 +3754,25 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				return nil
 			}
 
+			matchResultType, ok := commonResultType(okCase.Body.Type(), errCase.Body.Type())
+			if !ok {
+				c.addError(typeMismatch(okCase.Body.Type(), errCase.Body.Type()), s.GetLocation())
+				return nil
+			}
 			return &ResultMatch{
-				Subject: subject,
-				Ok:      okCase,
-				Err:     errCase,
-				OkType:  resultType.Val(),
-				ErrType: resultType.Err(),
+				Subject:    subject,
+				Ok:         okCase,
+				Err:        errCase,
+				OkType:     resultType.Val(),
+				ErrType:    resultType.Err(),
+				ResultType: matchResultType,
 			}
 		}
 
 		if subject.Type() == Str {
 			strCases := make(map[string]*Block)
 			var catchAll *Block
-			var referenceType Type
+			var strResultType Type
 
 			for _, matchCase := range s.Cases {
 				if id, ok := matchCase.Pattern.(*parse.Identifier); ok && id.Name == "_" {
@@ -3753,10 +3781,9 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 						return nil
 					}
 					catchAll = c.checkMatchArmBlock(matchCase.Body, nil)
-					if referenceType == nil {
-						referenceType = catchAll.Type()
-					} else if !referenceType.equal(catchAll.Type()) {
-						c.addError(typeMismatch(referenceType, catchAll.Type()), matchCase.Pattern.GetLocation())
+					var ok bool
+					strResultType, ok = mergeMatchResultType(c, strResultType, catchAll.Type(), matchCase.Pattern.GetLocation())
+					if !ok {
 						return nil
 					}
 					continue
@@ -3773,10 +3800,9 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				}
 				caseBlock := c.checkMatchArmBlock(matchCase.Body, nil)
 				strCases[literal.Value] = caseBlock
-				if referenceType == nil {
-					referenceType = caseBlock.Type()
-				} else if !referenceType.equal(caseBlock.Type()) {
-					c.addError(typeMismatch(referenceType, caseBlock.Type()), matchCase.Pattern.GetLocation())
+				var mergeOK bool
+				strResultType, mergeOK = mergeMatchResultType(c, strResultType, caseBlock.Type(), matchCase.Pattern.GetLocation())
+				if !mergeOK {
 					return nil
 				}
 			}
@@ -3786,7 +3812,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				return nil
 			}
 
-			return &StrMatch{Subject: subject, Cases: strCases, CatchAll: catchAll}
+			return &StrMatch{Subject: subject, Cases: strCases, CatchAll: catchAll, ResultType: strResultType}
 		}
 
 		// Check for Int matching
@@ -3794,11 +3820,17 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 			intCases := make(map[int]*Block)
 			rangeCases := make(map[IntRange]*Block)
 			var catchAll *Block
+			var intResultType Type
 
 			for _, matchCase := range s.Cases {
 				// Check if it's the default case (_)
 				if id, ok := matchCase.Pattern.(*parse.Identifier); ok && id.Name == "_" {
 					catchAll = c.checkMatchArmBlock(matchCase.Body, nil)
+					var ok bool
+					intResultType, ok = mergeMatchResultType(c, intResultType, catchAll.Type(), matchCase.Pattern.GetLocation())
+					if !ok {
+						return nil
+					}
 				} else if literal, ok := matchCase.Pattern.(*parse.NumLiteral); ok {
 					// Convert string to int
 					value, err := strconv.Atoi(literal.Value)
@@ -3808,6 +3840,11 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 					}
 					caseBlock := c.checkMatchArmBlock(matchCase.Body, nil)
 					intCases[value] = caseBlock
+					var ok bool
+					intResultType, ok = mergeMatchResultType(c, intResultType, caseBlock.Type(), matchCase.Pattern.GetLocation())
+					if !ok {
+						return nil
+					}
 				} else if unaryExpr, ok := matchCase.Pattern.(*parse.UnaryExpression); ok && unaryExpr.Operator == parse.Minus {
 					// Handle negative numbers like -1, -5, etc.
 					if literal, ok := unaryExpr.Operand.(*parse.NumLiteral); ok {
@@ -3820,6 +3857,11 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 						negativeValue := -value
 						caseBlock := c.checkMatchArmBlock(matchCase.Body, nil)
 						intCases[negativeValue] = caseBlock
+						var ok bool
+						intResultType, ok = mergeMatchResultType(c, intResultType, caseBlock.Type(), matchCase.Pattern.GetLocation())
+						if !ok {
+							return nil
+						}
 					} else {
 						c.addError(fmt.Sprintf("Invalid pattern for Int match: %T", matchCase.Pattern), matchCase.Pattern.GetLocation())
 						return nil
@@ -3845,6 +3887,11 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 
 					caseBlock := c.checkMatchArmBlock(matchCase.Body, nil)
 					rangeCases[IntRange{Start: startValue, End: endValue}] = caseBlock
+					var ok bool
+					intResultType, ok = mergeMatchResultType(c, intResultType, caseBlock.Type(), matchCase.Pattern.GetLocation())
+					if !ok {
+						return nil
+					}
 				} else if staticProp, ok := matchCase.Pattern.(*parse.StaticProperty); ok {
 					// Handle enum variant pattern like Status::active
 					patternExpr := c.checkExpr(staticProp)
@@ -3863,6 +3910,11 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 					value := enumVariant.enum.Values[enumVariant.Variant].Value
 					caseBlock := c.checkMatchArmBlock(matchCase.Body, nil)
 					intCases[value] = caseBlock
+					var mergeOK bool
+					intResultType, mergeOK = mergeMatchResultType(c, intResultType, caseBlock.Type(), matchCase.Pattern.GetLocation())
+					if !mergeOK {
+						return nil
+					}
 				} else {
 					c.addError(fmt.Sprintf("Invalid pattern for Int match: %T", matchCase.Pattern), matchCase.Pattern.GetLocation())
 					return nil
@@ -3879,6 +3931,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				IntCases:   intCases,
 				RangeCases: rangeCases,
 				CatchAll:   catchAll,
+				ResultType: intResultType,
 			}
 		}
 
@@ -3887,7 +3940,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 	case *parse.ConditionalMatchExpression:
 		var cases []ConditionalCase
 		var catchAll *Block
-		var referenceType Type
+		var conditionalResultType Type
 
 		for _, matchCase := range s.Cases {
 			if matchCase.Condition == nil {
@@ -3896,10 +3949,10 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 					c.addError("Duplicate catch-all case", matchCase.GetLocation())
 				} else {
 					catchAll = c.checkMatchArmBlock(matchCase.Body, nil)
-					if referenceType == nil {
-						referenceType = catchAll.Type()
-					} else if !referenceType.equal(catchAll.Type()) {
-						c.addError(fmt.Sprintf("All cases must return the same type. Expected %s, got %s", referenceType.String(), catchAll.Type().String()), matchCase.GetLocation())
+					var ok bool
+					conditionalResultType, ok = mergeMatchResultType(c, conditionalResultType, catchAll.Type(), matchCase.GetLocation())
+					if !ok {
+						return nil
 					}
 				}
 			} else {
@@ -3911,10 +3964,10 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 					}
 
 					body := c.checkMatchArmBlock(matchCase.Body, nil)
-					if referenceType == nil {
-						referenceType = body.Type()
-					} else if !referenceType.equal(body.Type()) {
-						c.addError(fmt.Sprintf("All cases must return the same type. Expected %s, got %s", referenceType.String(), body.Type().String()), matchCase.GetLocation())
+					var ok bool
+					conditionalResultType, ok = mergeMatchResultType(c, conditionalResultType, body.Type(), matchCase.GetLocation())
+					if !ok {
+						return nil
 					}
 
 					cases = append(cases, ConditionalCase{
@@ -3931,8 +3984,9 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 		}
 
 		return &ConditionalMatch{
-			Cases:    cases,
-			CatchAll: catchAll,
+			Cases:      cases,
+			CatchAll:   catchAll,
+			ResultType: conditionalResultType,
 		}
 	case *parse.StaticProperty:
 		{
@@ -4420,6 +4474,10 @@ func (c *Checker) checkExprAs(expr parse.Expression, expectedType Type) Expressi
 			return c.checkExpr(s)
 		})
 	case *parse.IfStatement:
+		return c.withExpectedExpr(expectedType, func() Expression {
+			return c.checkExpr(s)
+		})
+	case *parse.ConditionalMatchExpression:
 		return c.withExpectedExpr(expectedType, func() Expression {
 			return c.checkExpr(s)
 		})

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -19,7 +19,9 @@ type test struct {
 
 var compareOptions = cmp.Options{
 	cmpopts.SortMaps(func(a, b string) bool { return a < b }),
-	cmpopts.IgnoreFields(checker.EnumMatch{}, "DiscriminantToIndex"),
+	cmpopts.IgnoreFields(checker.BoolMatch{}, "ResultType"),
+	cmpopts.IgnoreFields(checker.OptionMatch{}, "ResultType"),
+	cmpopts.IgnoreFields(checker.EnumMatch{}, "DiscriminantToIndex", "ResultType"),
 	cmpopts.IgnoreFields(checker.EnumVariant{}, "EnumType", "Discriminant"),
 	cmpopts.IgnoreFields(checker.ListLiteral{}, "ListType"),
 	cmpopts.IgnoreFields(checker.InstanceMethod{}, "ReceiverKind", "StructType", "EnumType", "TraitType"),
@@ -30,11 +32,14 @@ var compareOptions = cmp.Options{
 	cmpopts.IgnoreFields(checker.FunctionCall{}, "ExternalBinding"),
 	cmpopts.IgnoreFields(checker.MaybeMethod{}, "ReturnType"),
 	cmpopts.IgnoreFields(checker.ResultMethod{}, "ReturnType"),
-	cmpopts.IgnoreFields(checker.ResultMatch{}, "OkType", "ErrType"),
+	cmpopts.IgnoreFields(checker.ResultMatch{}, "OkType", "ErrType", "ResultType"),
 	cmpopts.IgnoreFields(checker.TryOp{}, "OkType", "ErrType"),
 	cmpopts.IgnoreFields(checker.StructInstance{}, "StructType"),
 	cmpopts.IgnoreFields(checker.TryOp{}, "OkType"),
-	cmpopts.IgnoreFields(checker.UnionMatch{}, "TypeCasesByType"),
+	cmpopts.IgnoreFields(checker.IntMatch{}, "ResultType"),
+	cmpopts.IgnoreFields(checker.StrMatch{}, "ResultType"),
+	cmpopts.IgnoreFields(checker.UnionMatch{}, "TypeCasesByType", "ResultType"),
+	cmpopts.IgnoreFields(checker.ConditionalMatch{}, "ResultType"),
 	cmpopts.IgnoreUnexported(
 		checker.TypeVar{},
 		checker.BoolMethod{},

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -617,13 +617,17 @@ type Match struct {
 }
 
 type OptionMatch struct {
-	Subject   Expression
-	Some      *Match
-	None      *Block
-	InnerType Type // Pre-computed inner type of Maybe
+	Subject    Expression
+	Some       *Match
+	None       *Block
+	InnerType  Type // Pre-computed inner type of Maybe
+	ResultType Type
 }
 
 func (o *OptionMatch) Type() Type {
+	if o.ResultType != nil {
+		return o.ResultType
+	}
 	return o.Some.Body.Type()
 }
 
@@ -632,9 +636,13 @@ type EnumMatch struct {
 	Cases               []*Block
 	CatchAll            *Block
 	DiscriminantToIndex map[int]int8 // Pre-computed discriminant lookup
+	ResultType          Type
 }
 
 func (e *EnumMatch) Type() Type {
+	if e.ResultType != nil {
+		return e.ResultType
+	}
 	// Find the first non-nil case
 	for _, c := range e.Cases {
 		if c != nil {
@@ -649,12 +657,16 @@ func (e *EnumMatch) Type() Type {
 }
 
 type BoolMatch struct {
-	Subject Expression
-	True    *Block
-	False   *Block
+	Subject    Expression
+	True       *Block
+	False      *Block
+	ResultType Type
 }
 
 func (b *BoolMatch) Type() Type {
+	if b.ResultType != nil {
+		return b.ResultType
+	}
 	return b.True.Type()
 }
 
@@ -668,15 +680,20 @@ type IntMatch struct {
 	IntCases   map[int]*Block      // keys are integer values
 	RangeCases map[IntRange]*Block // keys are integer ranges
 	CatchAll   *Block
+	ResultType Type
 }
 
 type StrMatch struct {
-	Subject  Expression
-	Cases    map[string]*Block
-	CatchAll *Block
+	Subject    Expression
+	Cases      map[string]*Block
+	CatchAll   *Block
+	ResultType Type
 }
 
 func (s *StrMatch) Type() Type {
+	if s.ResultType != nil {
+		return s.ResultType
+	}
 	for _, block := range s.Cases {
 		if block != nil {
 			return block.Type()
@@ -689,6 +706,9 @@ func (s *StrMatch) Type() Type {
 }
 
 func (i *IntMatch) Type() Type {
+	if i.ResultType != nil {
+		return i.ResultType
+	}
 	// Find the first non-nil case and return its type
 	for _, block := range i.IntCases {
 		if block != nil {
@@ -715,9 +735,13 @@ type UnionMatch struct {
 	TypeCases       map[string]*Match
 	TypeCasesByType map[Type]*Match // Pre-computed type lookup
 	CatchAll        *Block
+	ResultType      Type
 }
 
 func (u *UnionMatch) Type() Type {
+	if u.ResultType != nil {
+		return u.ResultType
+	}
 	// Find the first non-nil case and return its type
 	for _, block := range u.TypeCases {
 		if block != nil {
@@ -734,11 +758,15 @@ func (u *UnionMatch) Type() Type {
 }
 
 type ConditionalMatch struct {
-	Cases    []ConditionalCase
-	CatchAll *Block
+	Cases      []ConditionalCase
+	CatchAll   *Block
+	ResultType Type
 }
 
 func (c *ConditionalMatch) Type() Type {
+	if c.ResultType != nil {
+		return c.ResultType
+	}
 	if len(c.Cases) > 0 {
 		return c.Cases[0].Body.Type()
 	}
@@ -1418,14 +1446,18 @@ func (s StructInstance) Type() Type {
 }
 
 type ResultMatch struct {
-	Subject Expression
-	Ok      *Match
-	Err     *Match
-	OkType  Type // Pre-computed ok type
-	ErrType Type // Pre-computed err type
+	Subject    Expression
+	Ok         *Match
+	Err        *Match
+	OkType     Type // Pre-computed ok type
+	ErrType    Type // Pre-computed err type
+	ResultType Type
 }
 
 func (r ResultMatch) Type() Type {
+	if r.ResultType != nil {
+		return r.ResultType
+	}
 	return r.Ok.Body.Type()
 }
 

--- a/compiler/checker/traits_test.go
+++ b/compiler/checker/traits_test.go
@@ -6,6 +6,130 @@ import (
 	"github.com/akonwi/ard/checker"
 )
 
+func TestMatchAllowsConcreteTraitImplementationBranch(t *testing.T) {
+	traitFixture := `trait View {
+  fn render()
+}
+
+struct Screen {}
+
+impl View for Screen {
+  fn render() {}
+}
+
+fn make_view() View {
+  Screen{}
+}
+`
+	run(t, []test{
+		{
+			name: "bool match can return trait and implementing struct",
+			input: traitFixture + `
+fn main(flag: Bool) View {
+  match flag {
+    true => make_view(),
+    false => Screen{},
+  }
+}`,
+		},
+		{
+			name: "maybe match can return trait and implementing struct",
+			input: traitFixture + `
+fn main(flag: Bool?) View {
+  match flag {
+    value => make_view(),
+    _ => Screen{},
+  }
+}`,
+		},
+		{
+			name: "string match can return trait and implementing struct",
+			input: traitFixture + `
+fn main(name: Str) View {
+  match name {
+    "home" => Screen{},
+    _ => make_view(),
+  }
+}`,
+		},
+		{
+			name: "enum match can return trait and implementing struct",
+			input: traitFixture + `
+enum Route {
+  home
+  other
+}
+
+fn main(route: Route) View {
+  match route {
+    Route::home => Screen{},
+    Route::other => make_view(),
+  }
+}`,
+		},
+		{
+			name: "result match can return trait and implementing struct",
+			input: traitFixture + `
+fn main(res: Screen!Str) View {
+  match res {
+    ok(screen) => screen,
+    err(_message) => make_view(),
+  }
+}`,
+		},
+		{
+			name: "int match can return trait and implementing struct",
+			input: traitFixture + `
+fn main(n: Int) View {
+  match n {
+    1 => Screen{},
+    _ => make_view(),
+  }
+}`,
+		},
+		{
+			name: "conditional match can return trait and implementing struct",
+			input: traitFixture + `
+fn main(flag: Bool) View {
+  match {
+    flag => Screen{},
+    _ => make_view(),
+  }
+}`,
+		},
+		{
+			name: "union match can return trait and implementing struct",
+			input: traitFixture + `
+type ScreenOrInt = Screen | Int
+
+fn main(value: ScreenOrInt) View {
+  match value {
+    Screen(screen) => screen,
+    _ => make_view(),
+  }
+}`,
+		},
+		{
+			name: "conditional match uses expected result union type for result constructors",
+			input: traitFixture + `
+struct OtherScreen {}
+
+impl View for OtherScreen {
+  fn render() {}
+}
+
+type AnyScreen = Screen | OtherScreen
+
+fn main(flag: Bool) AnyScreen!Str {
+  match {
+    flag => Result::ok(Screen{}),
+    _ => Result::ok(OtherScreen{}),
+  }
+}`,
+		},
+	})
+}
+
 func TestTraitDefinitions(t *testing.T) {
 	run(t, []test{
 		{

--- a/compiler/checker/types.go
+++ b/compiler/checker/types.go
@@ -14,6 +14,25 @@ func areCompatible(expected Type, actual Type) bool {
 	return expected.equal(actual)
 }
 
+func commonResultType(a Type, b Type) (Type, bool) {
+	if a == nil || b == nil {
+		return nil, false
+	}
+	if a.equal(b) {
+		return a, true
+	}
+	if a == Void || b == Void {
+		return Void, true
+	}
+	if areCompatible(a, b) {
+		return a, true
+	}
+	if areCompatible(b, a) {
+		return b, true
+	}
+	return nil, false
+}
+
 func HasTrait(t Type, trait *Trait) bool {
 	if t == nil || trait == nil {
 		return false

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -549,7 +549,11 @@ func (l *lowerer) lowerFunction(fn air.Function) (ast.Decl, error) {
 	l.declaredLocals = map[air.LocalID]bool{}
 	params := []*ast.Field{}
 	for _, capture := range fn.Captures {
-		captureType, err := l.goType(capture.Type)
+		captureParam := air.Param{Name: capture.Name, Type: capture.Type}
+		if int(capture.Local) >= 0 && int(capture.Local) < len(fn.Locals) {
+			captureParam.Mutable = fn.Locals[capture.Local].Mutable
+		}
+		captureType, err := l.goParamType(captureParam)
 		if err != nil {
 			return nil, err
 		}
@@ -3182,8 +3186,17 @@ func (l *lowerer) lowerMakeClosure(fn air.Function, expr air.Expr) (loweredExpr,
 	funcType, _ := closureType.(*ast.FuncType)
 	callArgs := make([]ast.Expr, 0, len(expr.CaptureLocals)+len(closureFn.Signature.Params))
 	stmts := []ast.Stmt{}
-	for _, local := range expr.CaptureLocals {
-		callArgs = append(callArgs, ast.NewIdent(localName(fn, local)))
+	for i, local := range expr.CaptureLocals {
+		argExpr := ast.Expr(ast.NewIdent(localName(fn, local)))
+		if i < len(closureFn.Captures) {
+			capture := closureFn.Captures[i]
+			captureParam := air.Param{Name: capture.Name, Type: capture.Type}
+			if int(capture.Local) >= 0 && int(capture.Local) < len(closureFn.Locals) {
+				captureParam.Mutable = closureFn.Locals[capture.Local].Mutable
+			}
+			argExpr = l.adaptCallArg(fn, air.Expr{Kind: air.ExprLoadLocal, Type: capture.Type, Local: local}, argExpr, captureParam)
+		}
+		callArgs = append(callArgs, argExpr)
 	}
 	params := []*ast.Field{}
 	for i, param := range closureFn.Signature.Params {

--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -1163,6 +1163,34 @@ func TestGoTargetParityNestedClosureCaptures(t *testing.T) {
 	})
 }
 
+func TestGoTargetParityMutMethodClosureCapturesSelf(t *testing.T) {
+	program := lowerParitySource(t, `
+		use ard/io
+
+		struct Box {
+			value: Int,
+		}
+
+		impl Box {
+			fn mut bump_with_closure() {
+				let bump = fn() {
+					self.value = self.value + 1
+				}
+				bump()
+			}
+		}
+
+		fn main() Int {
+			mut box = Box{value: 0}
+			box.bump_with_closure()
+			box.value
+		}
+	`)
+	if got := runGoTargetParityJSON(t, program); got != "1" {
+		t.Fatalf("got %s, want 1", got)
+	}
+}
+
 func TestGoTargetParityMethodClosureCapturesSelf(t *testing.T) {
 	program := lowerParitySource(t, `
 		struct Counter {


### PR DESCRIPTION
## Summary
- resolve common result types for match branches instead of relying on strict equality or first branch type
- allow trait object/concrete implementer branch combinations across match forms
- add regression coverage for bool, maybe, str, enum, result, int, conditional, and union matches

## Tests
- cd compiler && go test ./checker -count=1
- cd compiler && go run main.go check /Users/akonwi/Developer/agent/tinear/commands/next.ard