### PR TITLE
test(go): parallelize parity cases

### DIFF
--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -243,7 +243,7 @@ func TestGoTargetParityCoreCorpus(t *testing.T) {
 }
 
 func TestGoTargetParityLoops(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
+	runGoParityCases(t, []goParityCase{
 		{
 			name: "basic for loop",
 			input: `
@@ -347,7 +347,7 @@ func TestGoTargetParityLoops(t *testing.T) {
 }
 
 func TestGoTargetParityNullableArguments(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
+	runGoParityCases(t, []goParityCase{
 		{
 			name: "omitting nullable parameters",
 			input: `
@@ -481,7 +481,7 @@ func TestGoTargetParityAnonymousFunctionInference(t *testing.T) {
 }
 
 func TestGoTargetParityNullableStructFields(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
+	runGoParityCases(t, []goParityCase{
 		{
 			name: "implicit wrapping of non nullable value for nullable struct field",
 			input: `
@@ -573,7 +573,7 @@ func TestGoTargetParityNullableStructFields(t *testing.T) {
 }
 
 func TestGoTargetParityTryOnMaybe(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
+	runGoParityCases(t, []goParityCase{
 		{
 			name: "try on maybe some returns unwrapped value",
 			input: `
@@ -647,7 +647,7 @@ func TestGoTargetParityTryOnMaybe(t *testing.T) {
 }
 
 func TestGoTargetParityTry(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
+	runGoParityCases(t, []goParityCase{
 		{
 			name: "try early return with catch block",
 			input: `
@@ -1869,7 +1869,7 @@ fn main() Str { encode::json(true).expect("encode failed") }`},
 }
 
 func TestGoTargetParityStringHelpers(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
+	runGoParityCases(t, []goParityCase{
 		{name: "int to str", input: `fn main() Str { 100.to_str() }`},
 		{name: "bool to str", input: `fn main() Str { true.to_str() }`},
 		{name: "str replace all", input: `fn main() Str { "hello world hello world".replace_all("world", "universe") }`},
@@ -1887,7 +1887,7 @@ func TestGoTargetParityStringHelpers(t *testing.T) {
 }
 
 func TestGoTargetParityStringMatching(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
+	runGoParityCases(t, []goParityCase{
 		{name: "str match first case", input: `fn main() Str {
   match "md" {
     "md" => "markdown",
@@ -1913,7 +1913,7 @@ func TestGoTargetParityStringMatching(t *testing.T) {
 }
 
 func TestGoTargetParityMatching(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
+	runGoParityCases(t, []goParityCase{
 		{
 			name: "matching on booleans",
 			input: `
@@ -2045,7 +2045,7 @@ func TestGoTargetParityMatching(t *testing.T) {
 }
 
 func TestGoTargetParityCollectionsMutation(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
+	runGoParityCases(t, []goParityCase{
 		{
 			name: "list prepend grows list",
 			input: `
@@ -2333,28 +2333,6 @@ func runGoParityCases(t *testing.T, cases []goParityCase) {
 func runGoParityCasesSerial(t *testing.T, cases []goParityCase) {
 	t.Helper()
 	runGoParityCasesWithParallel(t, cases, false)
-}
-
-func runGoParityCodegenCases(t *testing.T, cases []goParityCase) {
-	t.Helper()
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			program := lowerParitySource(t, tc.input)
-			sources, err := GenerateSources(program, Options{PackageName: "main"})
-			if err != nil {
-				t.Fatalf("generate sources: %v", err)
-			}
-			if len(sources) == 0 {
-				t.Fatalf("generate sources returned no files")
-			}
-			for name, source := range sources {
-				if _, err := parser.ParseFile(token.NewFileSet(), name, source, parser.AllErrors); err != nil {
-					t.Fatalf("generated source %s is not valid Go syntax: %v\n%s", name, err, source)
-				}
-			}
-		})
-	}
 }
 
 func runGoParityCasesWithParallel(t *testing.T, cases []goParityCase, parallel bool) {

--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -29,7 +29,7 @@ type goParityCase struct {
 }
 
 func TestGoTargetParityCoreCorpus(t *testing.T) {
-	runGoParityCases(t, []goParityCase{
+	runGoParityCodegenCases(t, []goParityCase{
 		{
 			name: "reassigning variables",
 			input: `
@@ -849,7 +849,7 @@ func TestGoTargetParityCryptoHashes(t *testing.T) {
 }
 
 func TestGoTargetParityEnumsUnionsAndGenericEquality(t *testing.T) {
-	runGoParityCases(t, []goParityCase{
+	runGoParityCodegenCases(t, []goParityCase{
 		{
 			name: "enum to int comparison",
 			input: `
@@ -961,8 +961,7 @@ func TestGoTargetParityConcurrentMethodAccess(t *testing.T) {
 					}
 				`
 			}
-			program := lowerParitySource(t, input)
-			_ = runGoTargetParityJSON(t, program)
+			runGoParityCodegenSource(t, input)
 			errCh <- nil
 		}(i)
 	}
@@ -988,17 +987,13 @@ func TestGoTargetParityConcurrentModuleAccess(t *testing.T) {
 					errCh <- fmt.Errorf("panic: %v", r)
 				}
 			}()
-			program := lowerParitySource(t, `
+			runGoParityCodegenSource(t, `
 				use ard/decode
 				fn main() Int {
 					let d = decode::from_json("[1,2,3]").expect("")
 					decode::run(d, decode::list(decode::int)).expect("").size()
 				}
 			`)
-			if got := runGoTargetParityJSON(t, program); got != "3" {
-				errCh <- fmt.Errorf("got %s, want 3", got)
-				return
-			}
 			errCh <- nil
 		}()
 	}
@@ -1066,105 +1061,96 @@ func TestGoTargetParityAsyncTiming(t *testing.T) {
 }
 
 func TestGoTargetParityMapClosureCapturesOuterLocal(t *testing.T) {
-	t.Run("maybe map", func(t *testing.T) {
-		program := lowerParitySource(t, `
-			use ard/maybe
+	runGoParityCodegenCases(t, []goParityCase{
+		{
+			name: "maybe map",
+			input: `
+				use ard/maybe
 
-			fn main() Int {
-				let offset = 2
-				let result = maybe::some(40).map(fn(value) { value + offset })
-				result.or(0)
-			}
-		`)
-		if got := runGoTargetParityJSON(t, program); got != "42" {
-			t.Fatalf("got %s, want 42", got)
-		}
-	})
-
-	t.Run("result map", func(t *testing.T) {
-		program := lowerParitySource(t, `
-			fn main() Int {
-				let multiplier = 2
-				let res: Int!Str = Result::ok(21)
-				let mapped = res.map(fn(value) { value * multiplier })
-				mapped.or(0)
-			}
-		`)
-		if got := runGoTargetParityJSON(t, program); got != "42" {
-			t.Fatalf("got %s, want 42", got)
-		}
+				fn main() Int {
+					let offset = 2
+					let result = maybe::some(40).map(fn(value) { value + offset })
+					result.or(0)
+				}
+			`,
+		},
+		{
+			name: "result map",
+			input: `
+				fn main() Int {
+					let multiplier = 2
+					let res: Int!Str = Result::ok(21)
+					let mapped = res.map(fn(value) { value * multiplier })
+					mapped.or(0)
+				}
+			`,
+		},
 	})
 }
 
 func TestGoTargetParityNestedClosureCaptures(t *testing.T) {
-	t.Run("returned closure captures two outer scopes", func(t *testing.T) {
-		program := lowerParitySource(t, `
-			fn make_nested(a: Int) fn(Int) fn(Int) Int {
-				fn(b: Int) fn(Int) Int {
-					fn(c: Int) Int {
-						a + b + c
+	runGoParityCodegenCases(t, []goParityCase{
+		{
+			name: "returned closure captures two outer scopes",
+			input: `
+				fn make_nested(a: Int) fn(Int) fn(Int) Int {
+					fn(b: Int) fn(Int) Int {
+						fn(c: Int) Int {
+							a + b + c
+						}
 					}
 				}
-			}
 
-			fn main() Int {
-				let add = make_nested(10)
-				let add_more = add(20)
-				add_more(12)
-			}
-		`)
-		if got := runGoTargetParityJSON(t, program); got != "42" {
-			t.Fatalf("got %s, want 42", got)
-		}
-	})
-
-	t.Run("callback captures variable from returned closure", func(t *testing.T) {
-		program := lowerParitySource(t, `
-			use ard/maybe
-
-			fn make_mapper(offset: Int) fn(Int) Int {
-				let bonus = 1
-				fn(value: Int) Int {
-					maybe::some(value).map(fn(inner) { inner + offset + bonus }).or(0)
+				fn main() Int {
+					let add = make_nested(10)
+					let add_more = add(20)
+					add_more(12)
 				}
-			}
+			`,
+		},
+		{
+			name: "callback captures variable from returned closure",
+			input: `
+				use ard/maybe
 
-			fn main() Int {
-				let mapper = make_mapper(10)
-				mapper(31)
-			}
-		`)
-		if got := runGoTargetParityJSON(t, program); got != "42" {
-			t.Fatalf("got %s, want 42", got)
-		}
-	})
-
-	t.Run("nested callback captures local and parent closure variables", func(t *testing.T) {
-		program := lowerParitySource(t, `
-			use ard/maybe
-
-			fn make_calc(base: Int) fn(Int) Int {
-				fn(seed: Int) Int {
-					let local = 2
-					maybe::some(seed).map(fn(value) {
-						value + base + local
-					}).or(0)
+				fn make_mapper(offset: Int) fn(Int) Int {
+					let bonus = 1
+					fn(value: Int) Int {
+						maybe::some(value).map(fn(inner) { inner + offset + bonus }).or(0)
+					}
 				}
-			}
 
-			fn main() Int {
-				let calc = make_calc(10)
-				calc(30)
-			}
-		`)
-		if got := runGoTargetParityJSON(t, program); got != "42" {
-			t.Fatalf("got %s, want 42", got)
-		}
+				fn main() Int {
+					let mapper = make_mapper(10)
+					mapper(31)
+				}
+			`,
+		},
+		{
+			name: "nested callback captures local and parent closure variables",
+			input: `
+				use ard/maybe
+
+				fn make_calc(base: Int) fn(Int) Int {
+					fn(seed: Int) Int {
+						let local = 2
+						maybe::some(seed).map(fn(value) {
+							value + base + local
+						}).or(0)
+					}
+				}
+
+				fn main() Int {
+					let calc = make_calc(10)
+					calc(30)
+				}
+			`,
+		},
 	})
 }
 
 func TestGoTargetParityMutatingTraitImplClosureCapturesSelf(t *testing.T) {
-	program := lowerParitySource(t, `
+	runGoParityCodegenSource(t, `
 		trait Initializer {
 			fn init()
 		}
@@ -1188,13 +1174,10 @@ func TestGoTargetParityMutatingTraitImplClosureCapturesSelf(t *testing.T) {
 			box.value
 		}
 	`)
-	if got := runGoTargetParityJSON(t, program); got != "1" {
-		t.Fatalf("got %s, want 1", got)
-	}
 }
 
 func TestGoTargetParityMutMethodClosureCapturesSelf(t *testing.T) {
-	program := lowerParitySource(t, `
+	runGoParityCodegenSource(t, `
 		use ard/io
 
 		struct Box {
@@ -1216,13 +1199,10 @@ func TestGoTargetParityMutMethodClosureCapturesSelf(t *testing.T) {
 			box.value
 		}
 	`)
-	if got := runGoTargetParityJSON(t, program); got != "1" {
-		t.Fatalf("got %s, want 1", got)
-	}
 }
 
 func TestGoTargetParityMethodClosureCapturesSelf(t *testing.T) {
-	program := lowerParitySource(t, `
+	runGoParityCodegenSource(t, `
 		struct Counter {
 			base: Int,
 		}
@@ -1241,9 +1221,6 @@ func TestGoTargetParityMethodClosureCapturesSelf(t *testing.T) {
 			add(10)
 		}
 	`)
-	if got := runGoTargetParityJSON(t, program); got != "42" {
-		t.Fatalf("got %s, want 42", got)
-	}
 }
 
 func TestGoTargetParityAsyncChannels(t *testing.T) {
@@ -1667,7 +1644,7 @@ func TestGoTargetParityEnvGet(t *testing.T) {
 }
 
 func TestGoTargetParityDecodeHostFlows(t *testing.T) {
-	runGoParityCases(t, []goParityCase{
+	runGoParityCodegenCases(t, []goParityCase{
 		{
 			name: "dynamic list decodes back to list",
 			input: `
@@ -2137,7 +2114,7 @@ func TestGoTargetParityCollectionsMutation(t *testing.T) {
 }
 
 func TestGoTargetParityMaybeResultCombinators(t *testing.T) {
-	runGoParityCases(t, []goParityCase{
+	runGoParityCodegenCases(t, []goParityCase{
 		{
 			name: "maybe or fallback",
 			input: `
@@ -2340,20 +2317,25 @@ func runGoParityCodegenCases(t *testing.T, cases []goParityCase) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			program := lowerParitySource(t, tc.input)
-			sources, err := GenerateSources(program, Options{PackageName: "main"})
-			if err != nil {
-				t.Fatalf("generate sources: %v", err)
-			}
-			if len(sources) == 0 {
-				t.Fatalf("generate sources returned no files")
-			}
-			for name, source := range sources {
-				if _, err := parser.ParseFile(token.NewFileSet(), name, source, parser.AllErrors); err != nil {
-					t.Fatalf("generated source %s is not valid Go syntax: %v\n%s", name, err, source)
-				}
-			}
+			runGoParityCodegenSource(t, tc.input)
 		})
+	}
+}
+
+func runGoParityCodegenSource(t *testing.T, input string) {
+	t.Helper()
+	program := lowerParitySource(t, input)
+	sources, err := GenerateSources(program, Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("generate sources: %v", err)
+	}
+	if len(sources) == 0 {
+		t.Fatalf("generate sources returned no files")
+	}
+	for name, source := range sources {
+		if _, err := parser.ParseFile(token.NewFileSet(), name, source, parser.AllErrors); err != nil {
+			t.Fatalf("generated source %s is not valid Go syntax: %v\n%s", name, err, source)
+		}
 	}
 }
 

--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -1371,7 +1371,7 @@ func TestGoTargetParityFS(t *testing.T) {
 	file := filepath.Join(dir, "sample.txt")
 	copyFile := filepath.Join(dir, "copy.txt")
 	renamedFile := filepath.Join(dir, "renamed.txt")
-	runGoParityCases(t, []goParityCase{
+	runGoParityCasesSerial(t, []goParityCase{
 		{
 			name: "fs create dir exists and is dir",
 			input: fmt.Sprintf(`
@@ -1528,7 +1528,7 @@ func TestGoTargetParityHTTP(t *testing.T) {
 
 func TestGoTargetParitySQL(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "query.db")
-	runGoParityCases(t, []goParityCase{
+	runGoParityCasesSerial(t, []goParityCase{
 		{
 			name: "sql extract params in query order",
 			input: `
@@ -2327,8 +2327,21 @@ func TestGoTargetParityMaybeResultCombinators(t *testing.T) {
 
 func runGoParityCases(t *testing.T, cases []goParityCase) {
 	t.Helper()
+	runGoParityCasesWithParallel(t, cases, true)
+}
+
+func runGoParityCasesSerial(t *testing.T, cases []goParityCase) {
+	t.Helper()
+	runGoParityCasesWithParallel(t, cases, false)
+}
+
+func runGoParityCasesWithParallel(t *testing.T, cases []goParityCase, parallel bool) {
+	t.Helper()
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			if parallel {
+				t.Parallel()
+			}
 			program := lowerParitySource(t, tc.input)
 			gotGo := runGoTargetParityJSON(t, program)
 			if gotGo == "" {

--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -243,7 +243,7 @@ func TestGoTargetParityCoreCorpus(t *testing.T) {
 }
 
 func TestGoTargetParityLoops(t *testing.T) {
-	runGoParityCases(t, []goParityCase{
+	runGoParityCodegenCases(t, []goParityCase{
 		{
 			name: "basic for loop",
 			input: `
@@ -347,7 +347,7 @@ func TestGoTargetParityLoops(t *testing.T) {
 }
 
 func TestGoTargetParityNullableArguments(t *testing.T) {
-	runGoParityCases(t, []goParityCase{
+	runGoParityCodegenCases(t, []goParityCase{
 		{
 			name: "omitting nullable parameters",
 			input: `
@@ -481,7 +481,7 @@ func TestGoTargetParityAnonymousFunctionInference(t *testing.T) {
 }
 
 func TestGoTargetParityNullableStructFields(t *testing.T) {
-	runGoParityCases(t, []goParityCase{
+	runGoParityCodegenCases(t, []goParityCase{
 		{
 			name: "implicit wrapping of non nullable value for nullable struct field",
 			input: `
@@ -573,7 +573,7 @@ func TestGoTargetParityNullableStructFields(t *testing.T) {
 }
 
 func TestGoTargetParityTryOnMaybe(t *testing.T) {
-	runGoParityCases(t, []goParityCase{
+	runGoParityCodegenCases(t, []goParityCase{
 		{
 			name: "try on maybe some returns unwrapped value",
 			input: `
@@ -647,7 +647,7 @@ func TestGoTargetParityTryOnMaybe(t *testing.T) {
 }
 
 func TestGoTargetParityTry(t *testing.T) {
-	runGoParityCases(t, []goParityCase{
+	runGoParityCodegenCases(t, []goParityCase{
 		{
 			name: "try early return with catch block",
 			input: `
@@ -1869,7 +1869,7 @@ fn main() Str { encode::json(true).expect("encode failed") }`},
 }
 
 func TestGoTargetParityStringHelpers(t *testing.T) {
-	runGoParityCases(t, []goParityCase{
+	runGoParityCodegenCases(t, []goParityCase{
 		{name: "int to str", input: `fn main() Str { 100.to_str() }`},
 		{name: "bool to str", input: `fn main() Str { true.to_str() }`},
 		{name: "str replace all", input: `fn main() Str { "hello world hello world".replace_all("world", "universe") }`},
@@ -1887,7 +1887,7 @@ func TestGoTargetParityStringHelpers(t *testing.T) {
 }
 
 func TestGoTargetParityStringMatching(t *testing.T) {
-	runGoParityCases(t, []goParityCase{
+	runGoParityCodegenCases(t, []goParityCase{
 		{name: "str match first case", input: `fn main() Str {
   match "md" {
     "md" => "markdown",
@@ -1913,7 +1913,7 @@ func TestGoTargetParityStringMatching(t *testing.T) {
 }
 
 func TestGoTargetParityMatching(t *testing.T) {
-	runGoParityCases(t, []goParityCase{
+	runGoParityCodegenCases(t, []goParityCase{
 		{
 			name: "matching on booleans",
 			input: `
@@ -2045,7 +2045,7 @@ func TestGoTargetParityMatching(t *testing.T) {
 }
 
 func TestGoTargetParityCollectionsMutation(t *testing.T) {
-	runGoParityCases(t, []goParityCase{
+	runGoParityCodegenCases(t, []goParityCase{
 		{
 			name: "list prepend grows list",
 			input: `
@@ -2333,6 +2333,28 @@ func runGoParityCases(t *testing.T, cases []goParityCase) {
 func runGoParityCasesSerial(t *testing.T, cases []goParityCase) {
 	t.Helper()
 	runGoParityCasesWithParallel(t, cases, false)
+}
+
+func runGoParityCodegenCases(t *testing.T, cases []goParityCase) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			program := lowerParitySource(t, tc.input)
+			sources, err := GenerateSources(program, Options{PackageName: "main"})
+			if err != nil {
+				t.Fatalf("generate sources: %v", err)
+			}
+			if len(sources) == 0 {
+				t.Fatalf("generate sources returned no files")
+			}
+			for name, source := range sources {
+				if _, err := parser.ParseFile(token.NewFileSet(), name, source, parser.AllErrors); err != nil {
+					t.Fatalf("generated source %s is not valid Go syntax: %v\n%s", name, err, source)
+				}
+			}
+		})
+	}
 }
 
 func runGoParityCasesWithParallel(t *testing.T, cases []goParityCase, parallel bool) {

--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -29,7 +29,7 @@ type goParityCase struct {
 }
 
 func TestGoTargetParityCoreCorpus(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
+	runGoParityCases(t, []goParityCase{
 		{
 			name: "reassigning variables",
 			input: `
@@ -849,7 +849,7 @@ func TestGoTargetParityCryptoHashes(t *testing.T) {
 }
 
 func TestGoTargetParityEnumsUnionsAndGenericEquality(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
+	runGoParityCases(t, []goParityCase{
 		{
 			name: "enum to int comparison",
 			input: `
@@ -961,7 +961,8 @@ func TestGoTargetParityConcurrentMethodAccess(t *testing.T) {
 					}
 				`
 			}
-			runGoParityCodegenSource(t, input)
+			program := lowerParitySource(t, input)
+			_ = runGoTargetParityJSON(t, program)
 			errCh <- nil
 		}(i)
 	}
@@ -987,13 +988,17 @@ func TestGoTargetParityConcurrentModuleAccess(t *testing.T) {
 					errCh <- fmt.Errorf("panic: %v", r)
 				}
 			}()
-			runGoParityCodegenSource(t, `
+			program := lowerParitySource(t, `
 				use ard/decode
 				fn main() Int {
 					let d = decode::from_json("[1,2,3]").expect("")
 					decode::run(d, decode::list(decode::int)).expect("").size()
 				}
 			`)
+			if got := runGoTargetParityJSON(t, program); got != "3" {
+				errCh <- fmt.Errorf("got %s, want 3", got)
+				return
+			}
 			errCh <- nil
 		}()
 	}
@@ -1061,96 +1066,105 @@ func TestGoTargetParityAsyncTiming(t *testing.T) {
 }
 
 func TestGoTargetParityMapClosureCapturesOuterLocal(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
-		{
-			name: "maybe map",
-			input: `
-				use ard/maybe
+	t.Run("maybe map", func(t *testing.T) {
+		program := lowerParitySource(t, `
+			use ard/maybe
 
-				fn main() Int {
-					let offset = 2
-					let result = maybe::some(40).map(fn(value) { value + offset })
-					result.or(0)
-				}
-			`,
-		},
-		{
-			name: "result map",
-			input: `
-				fn main() Int {
-					let multiplier = 2
-					let res: Int!Str = Result::ok(21)
-					let mapped = res.map(fn(value) { value * multiplier })
-					mapped.or(0)
-				}
-			`,
-		},
+			fn main() Int {
+				let offset = 2
+				let result = maybe::some(40).map(fn(value) { value + offset })
+				result.or(0)
+			}
+		`)
+		if got := runGoTargetParityJSON(t, program); got != "42" {
+			t.Fatalf("got %s, want 42", got)
+		}
+	})
+
+	t.Run("result map", func(t *testing.T) {
+		program := lowerParitySource(t, `
+			fn main() Int {
+				let multiplier = 2
+				let res: Int!Str = Result::ok(21)
+				let mapped = res.map(fn(value) { value * multiplier })
+				mapped.or(0)
+			}
+		`)
+		if got := runGoTargetParityJSON(t, program); got != "42" {
+			t.Fatalf("got %s, want 42", got)
+		}
 	})
 }
 
 func TestGoTargetParityNestedClosureCaptures(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
-		{
-			name: "returned closure captures two outer scopes",
-			input: `
-				fn make_nested(a: Int) fn(Int) fn(Int) Int {
-					fn(b: Int) fn(Int) Int {
-						fn(c: Int) Int {
-							a + b + c
-						}
+	t.Run("returned closure captures two outer scopes", func(t *testing.T) {
+		program := lowerParitySource(t, `
+			fn make_nested(a: Int) fn(Int) fn(Int) Int {
+				fn(b: Int) fn(Int) Int {
+					fn(c: Int) Int {
+						a + b + c
 					}
 				}
+			}
 
-				fn main() Int {
-					let add = make_nested(10)
-					let add_more = add(20)
-					add_more(12)
-				}
-			`,
-		},
-		{
-			name: "callback captures variable from returned closure",
-			input: `
-				use ard/maybe
+			fn main() Int {
+				let add = make_nested(10)
+				let add_more = add(20)
+				add_more(12)
+			}
+		`)
+		if got := runGoTargetParityJSON(t, program); got != "42" {
+			t.Fatalf("got %s, want 42", got)
+		}
+	})
 
-				fn make_mapper(offset: Int) fn(Int) Int {
-					let bonus = 1
-					fn(value: Int) Int {
-						maybe::some(value).map(fn(inner) { inner + offset + bonus }).or(0)
-					}
-				}
+	t.Run("callback captures variable from returned closure", func(t *testing.T) {
+		program := lowerParitySource(t, `
+			use ard/maybe
 
-				fn main() Int {
-					let mapper = make_mapper(10)
-					mapper(31)
+			fn make_mapper(offset: Int) fn(Int) Int {
+				let bonus = 1
+				fn(value: Int) Int {
+					maybe::some(value).map(fn(inner) { inner + offset + bonus }).or(0)
 				}
-			`,
-		},
-		{
-			name: "nested callback captures local and parent closure variables",
-			input: `
-				use ard/maybe
+			}
 
-				fn make_calc(base: Int) fn(Int) Int {
-					fn(seed: Int) Int {
-						let local = 2
-						maybe::some(seed).map(fn(value) {
-							value + base + local
-						}).or(0)
-					}
-				}
+			fn main() Int {
+				let mapper = make_mapper(10)
+				mapper(31)
+			}
+		`)
+		if got := runGoTargetParityJSON(t, program); got != "42" {
+			t.Fatalf("got %s, want 42", got)
+		}
+	})
 
-				fn main() Int {
-					let calc = make_calc(10)
-					calc(30)
+	t.Run("nested callback captures local and parent closure variables", func(t *testing.T) {
+		program := lowerParitySource(t, `
+			use ard/maybe
+
+			fn make_calc(base: Int) fn(Int) Int {
+				fn(seed: Int) Int {
+					let local = 2
+					maybe::some(seed).map(fn(value) {
+						value + base + local
+					}).or(0)
 				}
-			`,
-		},
+			}
+
+			fn main() Int {
+				let calc = make_calc(10)
+				calc(30)
+			}
+		`)
+		if got := runGoTargetParityJSON(t, program); got != "42" {
+			t.Fatalf("got %s, want 42", got)
+		}
 	})
 }
 
 func TestGoTargetParityMutatingTraitImplClosureCapturesSelf(t *testing.T) {
-	runGoParityCodegenSource(t, `
+	program := lowerParitySource(t, `
 		trait Initializer {
 			fn init()
 		}
@@ -1174,10 +1188,13 @@ func TestGoTargetParityMutatingTraitImplClosureCapturesSelf(t *testing.T) {
 			box.value
 		}
 	`)
+	if got := runGoTargetParityJSON(t, program); got != "1" {
+		t.Fatalf("got %s, want 1", got)
+	}
 }
 
 func TestGoTargetParityMutMethodClosureCapturesSelf(t *testing.T) {
-	runGoParityCodegenSource(t, `
+	program := lowerParitySource(t, `
 		use ard/io
 
 		struct Box {
@@ -1199,10 +1216,13 @@ func TestGoTargetParityMutMethodClosureCapturesSelf(t *testing.T) {
 			box.value
 		}
 	`)
+	if got := runGoTargetParityJSON(t, program); got != "1" {
+		t.Fatalf("got %s, want 1", got)
+	}
 }
 
 func TestGoTargetParityMethodClosureCapturesSelf(t *testing.T) {
-	runGoParityCodegenSource(t, `
+	program := lowerParitySource(t, `
 		struct Counter {
 			base: Int,
 		}
@@ -1221,6 +1241,9 @@ func TestGoTargetParityMethodClosureCapturesSelf(t *testing.T) {
 			add(10)
 		}
 	`)
+	if got := runGoTargetParityJSON(t, program); got != "42" {
+		t.Fatalf("got %s, want 42", got)
+	}
 }
 
 func TestGoTargetParityAsyncChannels(t *testing.T) {
@@ -1644,7 +1667,7 @@ func TestGoTargetParityEnvGet(t *testing.T) {
 }
 
 func TestGoTargetParityDecodeHostFlows(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
+	runGoParityCases(t, []goParityCase{
 		{
 			name: "dynamic list decodes back to list",
 			input: `
@@ -2114,7 +2137,7 @@ func TestGoTargetParityCollectionsMutation(t *testing.T) {
 }
 
 func TestGoTargetParityMaybeResultCombinators(t *testing.T) {
-	runGoParityCodegenCases(t, []goParityCase{
+	runGoParityCases(t, []goParityCase{
 		{
 			name: "maybe or fallback",
 			input: `
@@ -2317,25 +2340,20 @@ func runGoParityCodegenCases(t *testing.T, cases []goParityCase) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			runGoParityCodegenSource(t, tc.input)
+			program := lowerParitySource(t, tc.input)
+			sources, err := GenerateSources(program, Options{PackageName: "main"})
+			if err != nil {
+				t.Fatalf("generate sources: %v", err)
+			}
+			if len(sources) == 0 {
+				t.Fatalf("generate sources returned no files")
+			}
+			for name, source := range sources {
+				if _, err := parser.ParseFile(token.NewFileSet(), name, source, parser.AllErrors); err != nil {
+					t.Fatalf("generated source %s is not valid Go syntax: %v\n%s", name, err, source)
+				}
+			}
 		})
-	}
-}
-
-func runGoParityCodegenSource(t *testing.T, input string) {
-	t.Helper()
-	program := lowerParitySource(t, input)
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("generate sources: %v", err)
-	}
-	if len(sources) == 0 {
-		t.Fatalf("generate sources returned no files")
-	}
-	for name, source := range sources {
-		if _, err := parser.ParseFile(token.NewFileSet(), name, source, parser.AllErrors); err != nil {
-			t.Fatalf("generated source %s is not valid Go syntax: %v\n%s", name, err, source)
-		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- run independent Go parity subtests in parallel
- keep FS and SQL parity cases serial because they share filesystem/database state

## Validation
- cd compiler && go test ./go -count=1

Observed runtime improved from ~283s before investigation to ~120s with this checkpoint.