### PR TITLE
feat(checker): support recursive struct fields

### DIFF
--- a/compiler/air/go_types.go
+++ b/compiler/air/go_types.go
@@ -48,7 +48,20 @@ func GenerateGoStructDeclarations(program *Program, options GoTypeOptions) ([]by
 func goStructDecl(program *Program, typ TypeInfo, runtimeQualifier string) (ast.Decl, error) {
 	fields := make([]*ast.Field, 0, len(typ.Fields))
 	for _, field := range typ.Fields {
-		fieldType, err := goTypeExpr(program, field.Type, runtimeQualifier)
+		var fieldType ast.Expr
+		var err error
+		if field.RecursiveNullable {
+			maybeType, maybeErr := goTypeInfo(program, field.Type)
+			if maybeErr != nil {
+				return nil, fmt.Errorf("field %s type: %w", field.Name, maybeErr)
+			}
+			fieldType, err = goTypeExpr(program, maybeType.Elem, runtimeQualifier)
+			if err == nil {
+				fieldType = &ast.StarExpr{X: fieldType}
+			}
+		} else {
+			fieldType, err = goTypeExpr(program, field.Type, runtimeQualifier)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("field %s type: %w", field.Name, err)
 		}

--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -1127,11 +1127,12 @@ func (l *lowerer) internType(t checker.Type) (TypeID, error) {
 		fields := sortedFieldNames(typ.Fields)
 		info.Fields = make([]FieldInfo, len(fields))
 		for i, name := range fields {
-			fieldType, err := l.internType(typ.Fields[name])
+			fieldTypeValue := typ.Fields[name]
+			fieldType, err := l.internType(fieldTypeValue)
 			if err != nil {
 				return NoType, err
 			}
-			info.Fields[i] = FieldInfo{Name: name, Type: fieldType, Index: i}
+			info.Fields[i] = FieldInfo{Name: name, Type: fieldType, Index: i, RecursiveNullable: isRecursiveNullableStructField(typ, fieldTypeValue)}
 		}
 	case *checker.Enum:
 		info.Kind = TypeEnum
@@ -1401,32 +1402,41 @@ func typeContainsTypeVar(t checker.Type) bool {
 }
 
 func typeHasUnresolvedTypeVar(t checker.Type) bool {
-	switch typ := t.(type) {
-	case nil:
+	return typeHasUnresolvedTypeVarSeen(t, map[checker.Type]struct{}{})
+}
+
+func typeHasUnresolvedTypeVarSeen(t checker.Type, seen map[checker.Type]struct{}) bool {
+	if t == nil {
 		return false
+	}
+	if _, ok := seen[t]; ok {
+		return false
+	}
+	seen[t] = struct{}{}
+	switch typ := t.(type) {
 	case *checker.TypeVar:
 		if typ.Actual() == nil {
 			return true
 		}
-		return typeHasUnresolvedTypeVar(typ.Actual())
+		return typeHasUnresolvedTypeVarSeen(typ.Actual(), seen)
 	case *checker.List:
-		return typeHasUnresolvedTypeVar(typ.Of())
+		return typeHasUnresolvedTypeVarSeen(typ.Of(), seen)
 	case *checker.Map:
-		return typeHasUnresolvedTypeVar(typ.Key()) || typeHasUnresolvedTypeVar(typ.Value())
+		return typeHasUnresolvedTypeVarSeen(typ.Key(), seen) || typeHasUnresolvedTypeVarSeen(typ.Value(), seen)
 	case *checker.Maybe:
-		return typeHasUnresolvedTypeVar(typ.Of())
+		return typeHasUnresolvedTypeVarSeen(typ.Of(), seen)
 	case *checker.Result:
-		return typeHasUnresolvedTypeVar(typ.Val()) || typeHasUnresolvedTypeVar(typ.Err())
+		return typeHasUnresolvedTypeVarSeen(typ.Val(), seen) || typeHasUnresolvedTypeVarSeen(typ.Err(), seen)
 	case *checker.Union:
 		for _, member := range typ.Types {
-			if typeHasUnresolvedTypeVar(member) {
+			if typeHasUnresolvedTypeVarSeen(member, seen) {
 				return true
 			}
 		}
 		return false
 	case *checker.StructDef:
 		for _, fieldType := range typ.Fields {
-			if typeHasUnresolvedTypeVar(fieldType) {
+			if typeHasUnresolvedTypeVarSeen(fieldType, seen) {
 				return true
 			}
 		}
@@ -1437,7 +1447,7 @@ func typeHasUnresolvedTypeVar(t checker.Type) bool {
 		return externalFunctionHasUnresolvedTypeVar(typ)
 	case *checker.ExternType:
 		for _, typeArg := range typ.TypeArgs {
-			if typeHasUnresolvedTypeVar(typeArg) {
+			if typeHasUnresolvedTypeVarSeen(typeArg, seen) {
 				return true
 			}
 		}
@@ -1478,28 +1488,39 @@ func airTypeName(t checker.Type) string {
 }
 
 func airTypeKey(t checker.Type) string {
+	return airTypeKeySeen(t, map[checker.Type]struct{}{})
+}
+
+func airTypeKeySeen(t checker.Type, seen map[checker.Type]struct{}) string {
 	if t == nil {
 		return "<nil>"
 	}
 	if tv, ok := t.(*checker.TypeVar); ok && tv.Actual() != nil {
-		return airTypeKey(tv.Actual())
+		return airTypeKeySeen(tv.Actual(), seen)
 	}
+	if _, ok := seen[t]; ok {
+		return t.String()
+	}
+	seen[t] = struct{}{}
 	switch typ := t.(type) {
 	case *checker.List:
-		return "list<" + airTypeKey(typ.Of()) + ">"
+		return "list<" + airTypeKeySeen(typ.Of(), seen) + ">"
 	case *checker.Map:
-		return "map<" + airTypeKey(typ.Key()) + "," + airTypeKey(typ.Value()) + ">"
+		return "map<" + airTypeKeySeen(typ.Key(), seen) + "," + airTypeKeySeen(typ.Value(), seen) + ">"
 	case *checker.Maybe:
-		return "maybe<" + airTypeKey(typ.Of()) + ">"
+		return "maybe<" + airTypeKeySeen(typ.Of(), seen) + ">"
 	case *checker.Result:
-		return "result<" + airTypeKey(typ.Val()) + "," + airTypeKey(typ.Err()) + ">"
+		return "result<" + airTypeKeySeen(typ.Val(), seen) + "," + airTypeKeySeen(typ.Err(), seen) + ">"
 	case *checker.StructDef:
 		if typ.Name == "Fiber" {
 			if elem, ok := typ.Fields["result"]; ok {
 				return "fiber<" + airTypeKey(elem) + ">"
 			}
 		}
-		return airStructKey(typ)
+		if hasSelfReference(typ) {
+			return "recursive struct " + typ.Name
+		}
+		return airStructKeySeen(typ, seen)
 	case *checker.Enum:
 		return airEnumKey(typ)
 	case *checker.Union:
@@ -1514,7 +1535,7 @@ func airTypeKey(t checker.Type) string {
 		}
 		parts := make([]string, len(typ.TypeArgs))
 		for i, arg := range typ.TypeArgs {
-			parts[i] = airTypeKey(arg)
+			parts[i] = airTypeKeySeen(arg, seen)
 		}
 		return "extern " + typ.Name_ + "<" + strings.Join(parts, ",") + ">"
 	default:
@@ -1523,13 +1544,17 @@ func airTypeKey(t checker.Type) string {
 }
 
 func airStructKey(typ *checker.StructDef) string {
+	return airStructKeySeen(typ, map[checker.Type]struct{}{})
+}
+
+func airStructKeySeen(typ *checker.StructDef, seen map[checker.Type]struct{}) string {
 	fields := sortedFieldNames(typ.Fields)
 	key := "struct " + typ.Name + "{"
 	for i, name := range fields {
 		if i > 0 {
 			key += ","
 		}
-		key += name + ":" + airTypeKey(typ.Fields[name])
+		key += name + ":" + airTypeKeySeen(typ.Fields[name], seen)
 	}
 	key += "}"
 	if len(typ.Methods) == 0 {

--- a/compiler/air/recursive_types.go
+++ b/compiler/air/recursive_types.go
@@ -1,0 +1,50 @@
+package air
+
+import "github.com/akonwi/ard/checker"
+
+func isRecursiveNullableStructField(owner *checker.StructDef, field checker.Type) bool {
+	maybe, ok := field.(*checker.Maybe)
+	if !ok {
+		return false
+	}
+	structType, ok := maybe.Of().(*checker.StructDef)
+	return ok && structType.Name == owner.Name
+}
+
+func hasSelfReference(owner *checker.StructDef) bool {
+	for _, field := range owner.Fields {
+		if typeReferencesStruct(field, owner, map[checker.Type]struct{}{}) {
+			return true
+		}
+	}
+	return false
+}
+
+func typeReferencesStruct(t checker.Type, owner *checker.StructDef, seen map[checker.Type]struct{}) bool {
+	if t == nil {
+		return false
+	}
+	if _, ok := seen[t]; ok {
+		return false
+	}
+	seen[t] = struct{}{}
+	switch typ := t.(type) {
+	case *checker.StructDef:
+		return typ == owner || typ.Name == owner.Name
+	case *checker.List:
+		return typeReferencesStruct(typ.Of(), owner, seen)
+	case *checker.Map:
+		return typeReferencesStruct(typ.Key(), owner, seen) || typeReferencesStruct(typ.Value(), owner, seen)
+	case *checker.Maybe:
+		return typeReferencesStruct(typ.Of(), owner, seen)
+	case *checker.Result:
+		return typeReferencesStruct(typ.Val(), owner, seen) || typeReferencesStruct(typ.Err(), owner, seen)
+	case *checker.Union:
+		for _, member := range typ.Types {
+			if typeReferencesStruct(member, owner, seen) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/compiler/air/types.go
+++ b/compiler/air/types.go
@@ -120,9 +120,10 @@ type TypeInfo struct {
 }
 
 type FieldInfo struct {
-	Name  string
-	Type  TypeID
-	Index int
+	Name              string
+	Type              TypeID
+	Index             int
+	RecursiveNullable bool
 }
 
 type VariantInfo struct {

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -1451,6 +1451,7 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 				Methods: make(map[string]*FunctionDef),
 				Private: s.Private,
 			}
+			c.scope.add(def.name(), def, false)
 			seenGenerics := make(map[string]bool)
 			for _, field := range s.Fields {
 				fieldType := c.resolveType(field.Type)
@@ -1462,10 +1463,12 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 					c.addError(fmt.Sprintf("Duplicate field: %s", field.Name.Name), field.Name.GetLocation())
 					return nil
 				}
+				if recursiveFieldHasInfiniteSize(field.Type, def.Name, false) {
+					c.addError(fmt.Sprintf("Recursive field %s.%s has infinite size. Put the recursive reference behind a list, map, or nullable type.", def.Name, field.Name.Name), field.Name.GetLocation())
+				}
 				def.Fields[field.Name.Name] = fieldType
 				collectGenericsFromType(fieldType, &def.GenericParams, seenGenerics)
 			}
-			c.scope.add(def.name(), def, false)
 			return &Statement{Stmt: def}
 		}
 	case *parse.ImplBlock:

--- a/compiler/checker/recursive_types.go
+++ b/compiler/checker/recursive_types.go
@@ -1,0 +1,52 @@
+package checker
+
+import "github.com/akonwi/ard/parse"
+
+func recursiveFieldHasInfiniteSize(t parse.DeclaredType, self string, indirect bool) bool {
+	if t == nil {
+		return false
+	}
+	if t.IsNullable() {
+		indirect = true
+	}
+	switch typ := t.(type) {
+	case *parse.CustomType:
+		return typ.GetName() == self && !indirect
+	case parse.CustomType:
+		return typ.GetName() == self && !indirect
+	case *parse.List:
+		return recursiveFieldHasInfiniteSize(typ.Element, self, true)
+	case parse.List:
+		return recursiveFieldHasInfiniteSize(typ.Element, self, true)
+	case *parse.Map:
+		return recursiveFieldHasInfiniteSize(typ.Key, self, false) || recursiveFieldHasInfiniteSize(typ.Value, self, true)
+	case parse.Map:
+		return recursiveFieldHasInfiniteSize(typ.Key, self, false) || recursiveFieldHasInfiniteSize(typ.Value, self, true)
+	case *parse.ResultType:
+		return recursiveFieldHasInfiniteSize(typ.Val, self, indirect) || recursiveFieldHasInfiniteSize(typ.Err, self, indirect)
+	case parse.ResultType:
+		return recursiveFieldHasInfiniteSize(typ.Val, self, indirect) || recursiveFieldHasInfiniteSize(typ.Err, self, indirect)
+	case *parse.FunctionType:
+		if recursiveFieldHasInfiniteSize(typ.Return, self, indirect) {
+			return true
+		}
+		for _, param := range typ.Params {
+			if recursiveFieldHasInfiniteSize(param, self, indirect) {
+				return true
+			}
+		}
+		return false
+	case parse.FunctionType:
+		if recursiveFieldHasInfiniteSize(typ.Return, self, indirect) {
+			return true
+		}
+		for _, param := range typ.Params {
+			if recursiveFieldHasInfiniteSize(param, self, indirect) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}

--- a/compiler/checker/scope.go
+++ b/compiler/checker/scope.go
@@ -221,36 +221,47 @@ func extractGenericNames(t Type, names map[string]bool) {
 // hasGenericsInType checks if a type contains any generic parameters.
 // Used for quick detection before generic handling.
 func hasGenericsInType(t Type) bool {
+	return hasGenericsInTypeSeen(t, map[Type]struct{}{})
+}
+
+func hasGenericsInTypeSeen(t Type, seen map[Type]struct{}) bool {
+	if t == nil {
+		return false
+	}
+	if _, ok := seen[t]; ok {
+		return false
+	}
+	seen[t] = struct{}{}
 	switch t := t.(type) {
 	case *TypeVar:
 		return true
 	case *List:
-		return hasGenericsInType(t.of)
+		return hasGenericsInTypeSeen(t.of, seen)
 	case *Map:
-		return hasGenericsInType(t.key) || hasGenericsInType(t.value)
+		return hasGenericsInTypeSeen(t.key, seen) || hasGenericsInTypeSeen(t.value, seen)
 	case *Maybe:
-		return hasGenericsInType(t.of)
+		return hasGenericsInTypeSeen(t.of, seen)
 	case *Result:
-		return hasGenericsInType(t.val) || hasGenericsInType(t.err)
+		return hasGenericsInTypeSeen(t.val, seen) || hasGenericsInTypeSeen(t.err, seen)
 	case *Union:
-		return slices.ContainsFunc(t.Types, hasGenericsInType)
+		return slices.ContainsFunc(t.Types, func(member Type) bool { return hasGenericsInTypeSeen(member, seen) })
 	case *StructDef:
 		for _, fieldType := range t.Fields {
-			if hasGenericsInType(fieldType) {
+			if hasGenericsInTypeSeen(fieldType, seen) {
 				return true
 			}
 		}
 		return false
 	case *FunctionDef:
 		for _, param := range t.Parameters {
-			if hasGenericsInType(param.Type) {
+			if hasGenericsInTypeSeen(param.Type, seen) {
 				return true
 			}
 		}
-		return hasGenericsInType(t.ReturnType)
+		return hasGenericsInTypeSeen(t.ReturnType, seen)
 	case *ExternType:
 		for _, typeArg := range t.TypeArgs {
-			if hasGenericsInType(typeArg) {
+			if hasGenericsInTypeSeen(typeArg, seen) {
 				return true
 			}
 		}

--- a/compiler/checker/traits_test.go
+++ b/compiler/checker/traits_test.go
@@ -6,6 +6,40 @@ import (
 	"github.com/akonwi/ard/checker"
 )
 
+func TestSelfRecursiveStructFieldsThroughIndirection(t *testing.T) {
+	run(t, []test{
+		{
+			name: "list self reference",
+			input: `struct Node {
+  children: [Node],
+}
+`,
+		},
+		{
+			name: "map value self reference",
+			input: `struct Node {
+  children: [Str:Node],
+}
+`,
+		},
+		{
+			name: "nullable self reference",
+			input: `struct Node {
+  parent: Node?,
+}
+`,
+		},
+		{
+			name: "direct self reference is rejected",
+			input: `struct Node {
+  child: Node,
+}
+`,
+			diagnostics: []checker.Diagnostic{{Kind: checker.Error, Message: "Recursive field Node.child has infinite size. Put the recursive reference behind a list, map, or nullable type."}},
+		},
+	})
+}
+
 func TestRecursiveTraitChildManagementTypeDoesNotOverflow(t *testing.T) {
 	run(t, []test{{
 		name: "struct method can accept list of trait that accepts struct",

--- a/compiler/checker/type_equal.go
+++ b/compiler/checker/type_equal.go
@@ -53,6 +53,20 @@ func equalTypesSeen(left Type, right Type, seen map[typeEqualKey]struct{}) bool 
 			return equalTypesSeen(r, l, seen)
 		}
 		return false
+	case *Map:
+		if r, ok := right.(*Map); ok {
+			return equalTypesSeen(l.key, r.key, seen) && equalTypesSeen(l.value, r.value, seen)
+		}
+		if r, ok := right.(Map); ok {
+			return equalTypesSeen(l.key, r.key, seen) && equalTypesSeen(l.value, r.value, seen)
+		}
+		if r, ok := right.(*TypeVar); ok {
+			return r.actual == nil || equalTypesSeen(l, r.actual, seen)
+		}
+		if r, ok := right.(*Union); ok {
+			return equalTypesSeen(r, l, seen)
+		}
+		return false
 	case Map:
 		if r, ok := right.(*Map); ok {
 			return equalTypesSeen(l.key, r.key, seen) && equalTypesSeen(l.value, r.value, seen)
@@ -227,10 +241,14 @@ func typeEqualID(t Type) string {
 	switch v := t.(type) {
 	case *Trait:
 		return fmt.Sprintf("Trait:%p", v)
+	case Trait:
+		return fmt.Sprintf("Trait:%s", v.Name)
 	case *List:
 		return fmt.Sprintf("List:%p", v)
 	case *Map:
 		return fmt.Sprintf("Map:%p", v)
+	case Map:
+		return fmt.Sprintf("Map:%p", &v)
 	case *Maybe:
 		return fmt.Sprintf("Maybe:%p", v)
 	case *TypeVar:
@@ -241,12 +259,21 @@ func typeEqualID(t Type) string {
 		return fmt.Sprintf("Extern:%p", v)
 	case *FunctionDef:
 		return fmt.Sprintf("Function:%p", v)
+	case FunctionDef:
+		return fmt.Sprintf("Function:%s", v.Name)
 	case *ExternalFunctionDef:
 		return fmt.Sprintf("ExternalFunction:%p", v)
 	case *StructDef:
+		if v.Name != "" {
+			return fmt.Sprintf("Struct:%s", v.Name)
+		}
 		return fmt.Sprintf("Struct:%p", v)
+	case StructDef:
+		return fmt.Sprintf("Struct:%s", v.Name)
 	case *Union:
 		return fmt.Sprintf("Union:%p", v)
+	case Union:
+		return fmt.Sprintf("Union:%s", v.Name)
 	default:
 		return fmt.Sprintf("%T:%s", t, t.String())
 	}

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -488,7 +488,17 @@ func (l *lowerer) lowerTypeDecls(typ air.TypeInfo) ([]ast.Decl, error) {
 		}
 		fields := make([]*ast.Field, 0, len(typ.Fields))
 		for _, field := range typ.Fields {
-			fieldType, err := l.goType(field.Type)
+			var fieldType ast.Expr
+			var err error
+			if field.RecursiveNullable {
+				maybeType := l.program.Types[field.Type-1]
+				fieldType, err = l.goType(maybeType.Elem)
+				if err == nil {
+					fieldType = &ast.StarExpr{X: fieldType}
+				}
+			} else {
+				fieldType, err = l.goType(field.Type)
+			}
 			if err != nil {
 				return nil, err
 			}
@@ -1195,7 +1205,11 @@ func (l *lowerer) lowerExpr(fn air.Function, expr air.Expr) (loweredExpr, error)
 				return loweredExpr{}, err
 			}
 			stmts = append(stmts, value.stmts...)
-			elts = append(elts, &ast.KeyValueExpr{Key: ast.NewIdent(l.goFieldName(typ, field.Name)), Value: value.expr})
+			fieldValue := value.expr
+			if fieldInfo, ok := structFieldByName(typ, field.Name); ok && fieldInfo.RecursiveNullable {
+				fieldValue = recursiveNullableValueAsPointer(l, fieldInfo.Type, fieldValue)
+			}
+			elts = append(elts, &ast.KeyValueExpr{Key: ast.NewIdent(l.goFieldName(typ, field.Name)), Value: fieldValue})
 		}
 		return loweredExpr{stmts: stmts, expr: &ast.CompositeLit{Type: ast.NewIdent(typeName(l.program, typ)), Elts: elts}}, nil
 	case air.ExprGetField:
@@ -1237,7 +1251,9 @@ func (l *lowerer) lowerExpr(fn air.Function, expr air.Expr) (loweredExpr, error)
 			stmts = append(stmts, resultDecls...)
 			fieldExpr := &ast.SelectorExpr{X: &ast.SelectorExpr{X: targetExpr, Sel: ast.NewIdent("Value")}, Sel: ast.NewIdent(l.goFieldName(elemType, field.Name))}
 			assignValue := ast.Expr(fieldExpr)
-			if expr.Type != field.Type {
+			if field.RecursiveNullable {
+				assignValue = recursiveNullableFieldAsMaybe(l, field.Type, fieldExpr)
+			} else if expr.Type != field.Type {
 				resultInfo := l.program.Types[expr.Type-1]
 				if resultInfo.Kind == air.TypeMaybe && resultInfo.Elem == field.Type {
 					assignValue = &ast.CompositeLit{Type: mustTypeExpr(l, expr.Type), Elts: []ast.Expr{
@@ -1257,7 +1273,12 @@ func (l *lowerer) lowerExpr(fn air.Function, expr air.Expr) (loweredExpr, error)
 		if targetType.Kind != air.TypeStruct || expr.Field < 0 || expr.Field >= len(targetType.Fields) {
 			return loweredExpr{}, fmt.Errorf("invalid field index %d", expr.Field)
 		}
-		return loweredExpr{stmts: target.stmts, expr: &ast.SelectorExpr{X: target.expr, Sel: ast.NewIdent(l.goFieldName(targetType, targetType.Fields[expr.Field].Name))}}, nil
+		field := targetType.Fields[expr.Field]
+		fieldExpr := &ast.SelectorExpr{X: target.expr, Sel: ast.NewIdent(l.goFieldName(targetType, field.Name))}
+		if field.RecursiveNullable {
+			return loweredExpr{stmts: target.stmts, expr: recursiveNullableFieldAsMaybe(l, expr.Type, fieldExpr)}, nil
+		}
+		return loweredExpr{stmts: target.stmts, expr: fieldExpr}, nil
 	case air.ExprBlock:
 		return l.lowerBlockExpr(fn, expr)
 	case air.ExprIf:

--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -28,6 +28,55 @@ type goParityCase struct {
 	input string
 }
 
+func TestGoTargetParityRecursiveStructFields(t *testing.T) {
+	runGoParityCases(t, []goParityCase{
+		{
+			name: "list self reference",
+			input: `
+				struct Node { value: Int, children: [Node] }
+				fn main() Int {
+					let root = Node{value: 1, children: [Node{value: 2, children: []}]}
+					root.children.at(0).value
+				}
+			`,
+		},
+		{
+			name: "map value self reference",
+			input: `
+				struct Node { value: Int, children: [Str:Node] }
+				fn main() Int {
+					let root = Node{value: 1, children: ["leaf": Node{value: 3, children: [:]}]}
+					root.children.get("leaf").expect("").value
+				}
+			`,
+		},
+		{
+			name: "nullable self reference",
+			input: `
+				use ard/maybe
+				struct Node { value: Int, parent: Node? }
+				fn main() Bool {
+					let missing: Node? = maybe::none()
+					let root = Node{value: 1, parent: missing}
+					root.parent.is_none()
+				}
+			`,
+		},
+		{
+			name: "nullable self reference some value",
+			input: `
+				use ard/maybe
+				struct Node { value: Int, parent: Node? }
+				fn main() Int {
+					let root = Node{value: 1, parent: maybe::none()}
+					let child = Node{value: 2, parent: maybe::some(root)}
+					child.parent.expect("").value
+				}
+			`,
+		},
+	})
+}
+
 func TestGoTargetParityCoreCorpus(t *testing.T) {
 	runGoParityCases(t, []goParityCase{
 		{

--- a/compiler/go/recursive_types.go
+++ b/compiler/go/recursive_types.go
@@ -1,0 +1,60 @@
+package gotarget
+
+import (
+	"go/ast"
+	"go/token"
+
+	"github.com/akonwi/ard/air"
+)
+
+func structFieldByName(typ air.TypeInfo, name string) (air.FieldInfo, bool) {
+	for _, field := range typ.Fields {
+		if field.Name == name {
+			return field, true
+		}
+	}
+	return air.FieldInfo{}, false
+}
+
+func recursiveNullableValueAsPointer(l *lowerer, maybeType air.TypeID, expr ast.Expr) ast.Expr {
+	if !validTypeID(l.program, maybeType) {
+		return expr
+	}
+	maybeInfo := l.program.Types[maybeType-1]
+	if maybeInfo.Kind != air.TypeMaybe || !validTypeID(l.program, maybeInfo.Elem) {
+		return expr
+	}
+	maybeExpr := mustTypeExpr(l, maybeType)
+	elemExpr := mustTypeExpr(l, maybeInfo.Elem)
+	param := ast.NewIdent("value")
+	return &ast.CallExpr{Fun: &ast.FuncLit{
+		Type: &ast.FuncType{
+			Params:  &ast.FieldList{List: []*ast.Field{{Names: []*ast.Ident{param}, Type: maybeExpr}}},
+			Results: &ast.FieldList{List: []*ast.Field{{Type: &ast.StarExpr{X: elemExpr}}}},
+		},
+		Body: &ast.BlockStmt{List: []ast.Stmt{
+			&ast.IfStmt{
+				Cond: &ast.UnaryExpr{Op: token.NOT, X: &ast.SelectorExpr{X: param, Sel: ast.NewIdent("Some")}},
+				Body: &ast.BlockStmt{List: []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{ast.NewIdent("nil")}}}},
+			},
+			&ast.ReturnStmt{Results: []ast.Expr{&ast.UnaryExpr{Op: token.AND, X: &ast.SelectorExpr{X: param, Sel: ast.NewIdent("Value")}}}},
+		}},
+	}, Args: []ast.Expr{expr}}
+}
+
+func recursiveNullableFieldAsMaybe(l *lowerer, maybeType air.TypeID, fieldExpr ast.Expr) ast.Expr {
+	maybeExpr := mustTypeExpr(l, maybeType)
+	return &ast.CallExpr{Fun: &ast.FuncLit{
+		Type: &ast.FuncType{Params: &ast.FieldList{}, Results: &ast.FieldList{List: []*ast.Field{{Type: maybeExpr}}}},
+		Body: &ast.BlockStmt{List: []ast.Stmt{
+			&ast.IfStmt{
+				Cond: &ast.BinaryExpr{X: fieldExpr, Op: token.EQL, Y: ast.NewIdent("nil")},
+				Body: &ast.BlockStmt{List: []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{&ast.CompositeLit{Type: maybeExpr}}}}},
+			},
+			&ast.ReturnStmt{Results: []ast.Expr{&ast.CompositeLit{Type: maybeExpr, Elts: []ast.Expr{
+				&ast.KeyValueExpr{Key: ast.NewIdent("Value"), Value: &ast.StarExpr{X: fieldExpr}},
+				&ast.KeyValueExpr{Key: ast.NewIdent("Some"), Value: ast.NewIdent("true")},
+			}}}},
+		}},
+	}}
+}

--- a/docs/adrs/0020-support-recursive-struct-fields-through-indirection.md
+++ b/docs/adrs/0020-support-recursive-struct-fields-through-indirection.md
@@ -1,0 +1,88 @@
+# 0020: Support Recursive Struct Fields Through Indirection
+
+## Status
+
+Accepted
+
+## Context
+
+Ard currently resolves struct field types while the struct being declared is not yet available as a type name. This prevents intuitive recursive data structures such as trees:
+
+```ard
+struct Node {
+  children: [Node],
+}
+```
+
+The checker reports `Unrecognized type: Node` for the field type. This is an implementation limitation rather than a durable language rule users should have to model around.
+
+Recursive value types also need a sound representation rule. A direct inline field such as:
+
+```ard
+struct Node {
+  child: Node,
+}
+```
+
+has infinite size in value-oriented targets such as Go and should not be accepted as ordinary inline storage. In Go, the equivalent `child Node` field is invalid, while recursive references through fixed-size descriptors such as slices, maps, pointers, or interfaces are valid.
+
+Ard already has source-level type constructors that can act as representation boundaries for common recursive shapes:
+
+```ard
+struct Node {
+  parent: Node?,
+  children: [Node],
+  children_by_id: [Str:Node],
+}
+```
+
+Lists and maps are naturally indirect/container-backed. Nullable recursive fields should also be treated as an indirection boundary so parent pointers and linked structures can be expressed without requiring a separate user-visible `Box` or `Ref` type for common cases.
+
+This decision is separate from broader declaration-order cycles between different type declarations, such as a `Node` field containing `[View]` while the `View` trait also mentions `Node`. Those cycles are out of scope for this decision. The immediate goal is sound support for explicit self-reference in struct fields.
+
+## Decision
+
+Allow a struct declaration to reference its own type name within its field types.
+
+Accept self-recursive field references when the recursive occurrence is beneath one of Ard's supported indirection boundaries:
+
+- list values, for example `[Node]`
+- map values, for example `[Str:Node]`
+- nullable values, for example `Node?`
+
+Reject direct inline self-recursive fields because they have infinite value size:
+
+```ard
+struct Node {
+  child: Node, // invalid
+}
+```
+
+The checker should produce a clear diagnostic explaining that the recursive field has infinite size and should be placed behind a supported indirection boundary such as a list, map, or nullable field:
+
+```text
+Recursive field Node.child has infinite size. Put the recursive reference behind a list, map, or nullable type.
+```
+
+Recursive nullable fields are part of the supported surface, not a follow-up feature. Backends must represent nullable self-recursive fields with finite storage. For the Go target, recursive nullable struct fields should lower as pointer-backed optional fields, such as `*Node`, instead of inline `Maybe<Node>`. The backend must adapt source-level `Maybe` operations on those fields so `none` maps to `nil`, `some(value)` stores an allocated value, absence checks compare with `nil`, and unwrapping performs a nil check before dereferencing.
+
+Lists and maps of recursive structs should lower to the target's ordinary finite container representations where possible. On the Go target, `[Node]` can lower to `[]Node` and `[Str:Node]` can lower to `map[string]Node` because slices and maps are fixed-size descriptors that point to separately allocated storage.
+
+Do not add user-visible forward declarations, mutually recursive declaration groups, or a first-class `Box`/`Ref` type as part of this decision. Those features may still be useful later, but self-recursive struct fields through existing indirection forms should work directly and idiomatically.
+
+## Consequences
+
+- Ard can model common recursive data structures such as trees and parent-linked nodes directly.
+- The checker must register a struct's own type name before resolving that struct's fields, then complete the struct definition after field resolution.
+- The checker must validate recursive field paths and reject inline cycles that do not pass through an accepted indirection boundary.
+- Backends must preserve finite representations for all accepted recursive shapes.
+- Nullable recursive fields require special care because a generic inline `Maybe<T>` representation would be infinitely recursive for `T == Node`.
+- Direct recursive value fields remain invalid, preserving soundness and avoiding target compiler failures.
+- This does not solve cross-type declaration-order cycles. Broader same-module type hoisting or explicit recursive declaration mechanisms are out of scope.
+
+## Related
+
+- `docs/adrs/0012-represent-optional-values-with-maybe.md`
+- `docs/adrs/0009-support-traits-for-shared-behavior.md`
+- `compiler/checker`
+- `compiler/go`


### PR DESCRIPTION
## Summary
- add ADR 0020 for recursive struct fields through list, map, and nullable indirection
- allow structs to reference themselves in field types
- reject direct inline recursive fields with a clear diagnostic
- lower recursive nullable fields to pointer-backed Go fields while preserving Maybe semantics
- add checker and Go parity coverage for recursive list/map/nullable fields

## Validation
- cd compiler && go test ./checker ./air ./go -count=1

Note: RETAINED_TREE_TYPE_SHAPE_LIMITATION.md is a local untracked note and is not included.