### PR TITLE
fix(go): persist mutating trait-object dispatch

### DIFF
--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -125,7 +125,7 @@ func TestGenerateSourcesTakesAddressOfLocalMutTraitArgs(t *testing.T) {
 		t.Fatalf("GenerateSources error = %v", err)
 	}
 	source := string(sources["test.go"])
-	if !strings.Contains(source, "Doubler_Bumpable_poke(typed, &c_0)") {
+	if !regexp.MustCompile(`Doubler_Bumpable_poke\(_tmp_[0-9]+, &c_0\)`).MatchString(source) {
 		t.Fatalf("generated source missing address-of for local mutable trait dispatch arg:\n%s", source)
 	}
 }
@@ -161,10 +161,10 @@ func TestGenerateSourcesPassesMutTraitArgsByPointer(t *testing.T) {
 		t.Fatalf("GenerateSources error = %v", err)
 	}
 	source := string(sources["test.go"])
-	if !strings.Contains(source, "Doubler_Bumpable_poke(typed, c)") {
+	if !regexp.MustCompile(`Doubler_Bumpable_poke\(_tmp_[0-9]+, c\)`).MatchString(source) {
 		t.Fatalf("generated source missing pointer trait dispatch arg:\n%s", source)
 	}
-	if strings.Contains(source, "Doubler_Bumpable_poke(typed, *c)") {
+	if regexp.MustCompile(`Doubler_Bumpable_poke\(_tmp_[0-9]+, \*c\)`).MatchString(source) {
 		t.Fatalf("generated source dereferences mutable trait dispatch arg:\n%s", source)
 	}
 }
@@ -1219,7 +1219,7 @@ func TestGenerateSourcesPassesPointerReceiverForMutatingTraitImpl(t *testing.T) 
 	if !strings.Contains(source, "_Buffer_Writer_write(self *") {
 		t.Fatalf("generated source missing pointer receiver for mutating trait impl:\n%s", source)
 	}
-	if !strings.Contains(source, "_Buffer_Writer_write(&typed, \"hi\")") {
+	if !regexp.MustCompile(`_Buffer_Writer_write\(&_tmp_[0-9]+, "hi"\)`).MatchString(source) {
 		t.Fatalf("generated source missing address-of for mutating trait dispatch receiver:\n%s", source)
 	}
 }
@@ -1264,13 +1264,13 @@ func TestGenerateSourcesSupportsUserTraitObjectDispatch(t *testing.T) {
 		t.Fatalf("GenerateSources error = %v", err)
 	}
 	source := string(sources["test.go"])
-	if !strings.Contains(source, "switch typed := r.(type)") {
+	if !regexp.MustCompile(`switch _tmp_[0-9]+ := r\.\(type\)`).MatchString(source) {
 		t.Fatalf("generated source missing trait object dispatch lowering:\n%s", source)
 	}
-	if !strings.Contains(source, "Block_Renderable_render(typed)") {
+	if !regexp.MustCompile(`Block_Renderable_render\(_tmp_[0-9]+\)`).MatchString(source) {
 		t.Fatalf("generated source missing Block trait dispatch call:\n%s", source)
 	}
-	if !strings.Contains(source, "Para_Renderable_render(typed)") {
+	if !regexp.MustCompile(`Para_Renderable_render\(_tmp_[0-9]+\)`).MatchString(source) {
 		t.Fatalf("generated source missing Para trait dispatch call:\n%s", source)
 	}
 	if !strings.Contains(source, "panic(") {
@@ -1334,7 +1334,7 @@ fn main() {
 	}
 	source := ""
 	for _, data := range sources {
-		if strings.Contains(string(data), "switch typed := t_1.(type)") {
+		if regexp.MustCompile(`switch _tmp_[0-9]+ := t_1\.\(type\)`).MatchString(string(data)) {
 			source = string(data)
 			break
 		}
@@ -1345,7 +1345,7 @@ fn main() {
 	if !strings.Contains(source, "case checkprobe_widget__Text:") {
 		t.Fatalf("generated source missing cross-module trait dispatch case:\n%s", source)
 	}
-	if !strings.Contains(source, "checkprobe_widget__Text_Widget_render(typed, f_0)") {
+	if !regexp.MustCompile(`checkprobe_widget__Text_Widget_render\(_tmp_[0-9]+, f_0\)`).MatchString(source) {
 		t.Fatalf("generated source missing cross-module trait dispatch call:\n%s", source)
 	}
 }
@@ -1443,7 +1443,7 @@ fn main() {
 	}
 	source := ""
 	for _, data := range sources {
-		if strings.Contains(string(data), "switch typed := demo_1.(type)") {
+		if regexp.MustCompile(`switch _tmp_[0-9]+ := demo_1\.\(type\)`).MatchString(string(data)) {
 			source = string(data)
 			break
 		}
@@ -1552,7 +1552,7 @@ fn main() { demo::run() }
 	}
 	source := ""
 	for _, data := range sources {
-		if strings.Contains(string(data), "switch typed := w_1.(type)") {
+		if regexp.MustCompile(`switch _tmp_[0-9]+ := w_1\.\(type\)`).MatchString(string(data)) {
 			source = string(data)
 			break
 		}
@@ -1600,13 +1600,13 @@ func TestGenerateSourcesSupportsVoidTraitObjectDispatch(t *testing.T) {
 		t.Fatalf("GenerateSources error = %v", err)
 	}
 	source := string(sources["test.go"])
-	if !strings.Contains(source, "switch typed := g.(type)") {
+	if !regexp.MustCompile(`switch _tmp_[0-9]+ := g\.\(type\)`).MatchString(source) {
 		t.Fatalf("generated source missing void trait object dispatch lowering:\n%s", source)
 	}
-	if !strings.Contains(source, "Cat_Greet_say(typed)") {
+	if !regexp.MustCompile(`Cat_Greet_say\(_tmp_[0-9]+\)`).MatchString(source) {
 		t.Fatalf("generated source missing void trait dispatch call:\n%s", source)
 	}
-	if strings.Contains(source, "= test_ard__Cat_Greet_say(typed)") || strings.Contains(source, "= Cat_Greet_say(typed)") {
+	if regexp.MustCompile(`= .*Cat_Greet_say\(_tmp_[0-9]+\)`).MatchString(source) {
 		t.Fatalf("generated source assigns void trait dispatch result:\n%s", source)
 	}
 	if !strings.Contains(source, "invoke(any(") {
@@ -1666,10 +1666,10 @@ func TestGenerateSourcesSupportsStoredTraitObjectDispatch(t *testing.T) {
 	if !strings.Contains(source, "[]any{any(") {
 		t.Fatalf("generated source missing list element trait-object upcast:\n%s", source)
 	}
-	if !strings.Contains(source, "switch typed := d_0.(type)") {
+	if !regexp.MustCompile(`switch _tmp_[0-9]+ := d_0\.\(type\)`).MatchString(source) {
 		t.Fatalf("generated source missing local trait-object dispatch:\n%s", source)
 	}
-	if !strings.Contains(source, "switch typed := c_1.child.(type)") {
+	if !regexp.MustCompile(`switch _tmp_[0-9]+ := c_1\.child\.\(type\)`).MatchString(source) {
 		t.Fatalf("generated source missing struct field trait-object dispatch:\n%s", source)
 	}
 	if !strings.Contains(source, "show(items_2[0])") {
@@ -1705,10 +1705,10 @@ func TestGenerateSourcesSupportsTraitObjectDispatch(t *testing.T) {
 		t.Fatalf("GenerateSources error = %v", err)
 	}
 	source := string(sources["test.go"])
-	if !strings.Contains(source, "type switch") && !strings.Contains(source, "switch typed := item.(type)") {
+	if !strings.Contains(source, "type switch") && !regexp.MustCompile(`switch _tmp_[0-9]+ := item\.\(type\)`).MatchString(source) {
 		t.Fatalf("generated source missing trait object dispatch lowering:\n%s", source)
 	}
-	if !strings.Contains(source, "Book_ToString_to_str(typed)") {
+	if !regexp.MustCompile(`Book_ToString_to_str\(_tmp_[0-9]+\)`).MatchString(source) {
 		t.Fatalf("generated source missing concrete trait dispatch call:\n%s", source)
 	}
 }

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -3675,13 +3675,15 @@ func (l *lowerer) lowerTraitObjectCall(fn air.Function, target loweredExpr, expr
 		loweredArgs[i] = loweredArg
 	}
 
+	switchVar := l.nextTemp()
+	switchVarExpr := ast.NewIdent(switchVar)
 	cases := []ast.Stmt{}
 	for _, impl := range l.program.Impls {
 		if impl.Trait != expr.Trait || expr.Method >= len(impl.Methods) || !validTypeID(l.program, impl.ForType) {
 			continue
 		}
 		methodFn := l.program.Functions[impl.Methods[expr.Method]]
-		receiver := ast.Expr(ast.NewIdent("typed"))
+		receiver := ast.Expr(switchVarExpr)
 		if len(methodFn.Signature.Params) > 0 {
 			receiverParam := methodFn.Signature.Params[0]
 			if receiverParam.Mutable && validTypeID(l.program, receiverParam.Type) && l.program.Types[receiverParam.Type-1].Kind == air.TypeStruct {
@@ -3698,23 +3700,50 @@ func (l *lowerer) lowerTraitObjectCall(fn air.Function, target loweredExpr, expr
 			args = append(args, argExpr)
 		}
 		call := &ast.CallExpr{Fun: ast.NewIdent(functionName(l.program, methodFn)), Args: args}
-		var body ast.Stmt
+		body := []ast.Stmt{}
 		if isVoid {
-			body = &ast.ExprStmt{X: call}
+			body = append(body, &ast.ExprStmt{X: call})
 		} else {
-			body = &ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(resultTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{call}}
+			body = append(body, &ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(resultTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{call}})
+		}
+		if traitObjectWritebackAllowed(fn, *expr.Target) && len(methodFn.Signature.Params) > 0 {
+			receiverParam := methodFn.Signature.Params[0]
+			if receiverParam.Mutable && validTypeID(l.program, receiverParam.Type) && l.program.Types[receiverParam.Type-1].Kind == air.TypeStruct {
+				body = append(body, &ast.AssignStmt{
+					Lhs: []ast.Expr{target.expr},
+					Tok: token.ASSIGN,
+					Rhs: []ast.Expr{switchVarExpr},
+				})
+			}
 		}
 		cases = append(cases, &ast.CaseClause{
 			List: []ast.Expr{mustTypeExpr(l, impl.ForType)},
-			Body: []ast.Stmt{body},
+			Body: body,
 		})
 	}
 	cases = append(cases, &ast.CaseClause{Body: []ast.Stmt{&ast.ExprStmt{X: &ast.CallExpr{Fun: ast.NewIdent("panic"), Args: []ast.Expr{&ast.BasicLit{Kind: token.STRING, Value: "\"unsupported trait object dispatch\""}}}}}})
-	stmts = append(stmts, &ast.TypeSwitchStmt{Assign: &ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent("typed")}, Tok: token.DEFINE, Rhs: []ast.Expr{&ast.TypeAssertExpr{X: target.expr}}}, Body: &ast.BlockStmt{List: cases}})
+	stmts = append(stmts, &ast.TypeSwitchStmt{Assign: &ast.AssignStmt{Lhs: []ast.Expr{switchVarExpr}, Tok: token.DEFINE, Rhs: []ast.Expr{&ast.TypeAssertExpr{X: target.expr}}}, Body: &ast.BlockStmt{List: cases}})
 	if isVoid {
 		return loweredExpr{stmts: stmts, expr: ast.NewIdent("nil")}, nil
 	}
 	return loweredExpr{stmts: stmts, expr: ast.NewIdent(resultTemp)}, nil
+}
+
+func traitObjectWritebackAllowed(fn air.Function, expr air.Expr) bool {
+	switch expr.Kind {
+	case air.ExprLoadLocal:
+		if int(expr.Local) < 0 || int(expr.Local) >= len(fn.Locals) {
+			return false
+		}
+		return fn.Locals[expr.Local].Mutable
+	case air.ExprGetField:
+		if expr.Target == nil {
+			return false
+		}
+		return traitObjectWritebackAllowed(fn, *expr.Target)
+	default:
+		return false
+	}
 }
 
 func exportedFieldName(name string) string {

--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -1242,6 +1242,70 @@ func TestGoTargetParityMutatingTraitImplClosureCapturesSelf(t *testing.T) {
 	}
 }
 
+func TestGoTargetParityMutatingTraitDispatchUpdatesStoredTraitObject(t *testing.T) {
+	program := lowerParitySource(t, `
+		trait View {
+			fn handle_event()
+			fn value() Int
+		}
+
+		struct CounterView {
+			count: Int,
+		}
+
+		impl View for CounterView {
+			fn mut handle_event() {
+				self.count = self.count + 1
+			}
+
+			fn value() Int {
+				self.count
+			}
+		}
+
+		struct AppRoot {
+			view: View,
+		}
+
+		impl AppRoot {
+			fn mut dispatch() {
+				self.view.handle_event()
+			}
+
+			fn current() Int {
+				self.view.value()
+			}
+		}
+
+		fn run_typed(mut typed: AppRoot) Int {
+			typed.view.handle_event()
+			typed.view.value()
+		}
+
+		fn run_any(mut any: AppRoot) Int {
+			any.view.handle_event()
+			any.view.value()
+		}
+
+		fn main() Int {
+			mut app = AppRoot{view: CounterView{count: 0}}
+			app.dispatch()
+			let field_result = app.current()
+
+			mut typed_app = AppRoot{view: CounterView{count: 0}}
+			let typed_result = run_typed(mut typed_app)
+
+			mut any_app = AppRoot{view: CounterView{count: 0}}
+			let any_result = run_any(mut any_app)
+
+			field_result + typed_result + any_result
+		}
+	`)
+	if got := runGoTargetParityJSON(t, program); got != "3" {
+		t.Fatalf("got %s, want 3", got)
+	}
+}
+
 func TestGoTargetParityMutMethodClosureCapturesSelf(t *testing.T) {
 	program := lowerParitySource(t, `
 		use ard/io


### PR DESCRIPTION
## Summary
- persist mutating trait-object dispatch back into mutable stored trait-object slots
- use fresh Go type-switch temps to avoid helper-name collisions
- add Go parity coverage for stored trait-object fields and collision-prone names

## Tests
- `cd compiler && go test ./go -count=1`
- `cd compiler && go test ./checker -run Trait -count=1`
