### PR TITLE
fix(lsp): improve request concurrency and diagnostics

### DIFF
--- a/compiler/lsp/cache.go
+++ b/compiler/lsp/cache.go
@@ -56,11 +56,18 @@ func (c *DocumentCache) Close(u uri.URI) {
 	delete(c.docs, u)
 }
 
-// Get returns the document for the given URI, or nil if not open.
+// Get returns a snapshot copy of the document for the given URI, or nil if not open.
+// Returning a copy prevents async diagnostics and feature handlers from observing
+// partially-updated document state after the cache lock is released.
 func (c *DocumentCache) Get(u uri.URI) *Doc {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.docs[u]
+	doc := c.docs[u]
+	if doc == nil {
+		return nil
+	}
+	copy := *doc
+	return &copy
 }
 
 // Snapshot returns copies of all cached documents.

--- a/compiler/lsp/cache.go
+++ b/compiler/lsp/cache.go
@@ -16,8 +16,9 @@ type Doc struct {
 
 // DocumentCache tracks all open documents for the LSP workspace.
 type DocumentCache struct {
-	mu   sync.Mutex
-	docs map[uri.URI]*Doc
+	mu       sync.Mutex
+	docs     map[uri.URI]*Doc
+	revision uint64
 }
 
 // NewDocumentCache creates an empty document cache.
@@ -37,6 +38,7 @@ func (c *DocumentCache) Open(u uri.URI, language string, version int32, text str
 		Version:  version,
 		Text:     text,
 	}
+	c.revision++
 }
 
 // Update replaces the content of an already-open document.
@@ -46,6 +48,7 @@ func (c *DocumentCache) Update(u uri.URI, version int32, text string) {
 	if doc, ok := c.docs[u]; ok {
 		doc.Version = version
 		doc.Text = text
+		c.revision++
 	}
 }
 
@@ -53,7 +56,10 @@ func (c *DocumentCache) Update(u uri.URI, version int32, text string) {
 func (c *DocumentCache) Close(u uri.URI) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	delete(c.docs, u)
+	if _, ok := c.docs[u]; ok {
+		delete(c.docs, u)
+		c.revision++
+	}
 }
 
 // Get returns a snapshot copy of the document for the given URI, or nil if not open.
@@ -72,6 +78,14 @@ func (c *DocumentCache) Get(u uri.URI) *Doc {
 
 // Snapshot returns copies of all cached documents.
 func (c *DocumentCache) Snapshot() []Doc {
+	docs, _ := c.SnapshotWithRevision()
+	return docs
+}
+
+// SnapshotWithRevision returns copies of all cached documents and the cache
+// revision they came from. The revision changes whenever open document state
+// changes, so async analysis can discard diagnostics computed from stale overlays.
+func (c *DocumentCache) SnapshotWithRevision() ([]Doc, uint64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -82,5 +96,11 @@ func (c *DocumentCache) Snapshot() []Doc {
 		}
 		docs = append(docs, *doc)
 	}
-	return docs
+	return docs, c.revision
+}
+
+func (c *DocumentCache) Revision() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.revision
 }

--- a/compiler/lsp/completion.go
+++ b/compiler/lsp/completion.go
@@ -155,7 +155,7 @@ func offsetToParsePoint(source string, offset int) parse.Point {
 }
 
 func instanceCompletionItems(target parse.Expression, prog *parse.Program, filePath string) []protocol.CompletionItem {
-	ownerType := normalizeDisplayType(inferExprType(target))
+	ownerType := normalizeDisplayType(inferExprType(target, prog, filePath))
 	if ownerType == "" || ownerType == "?" {
 		return []protocol.CompletionItem{}
 	}

--- a/compiler/lsp/definition.go
+++ b/compiler/lsp/definition.go
@@ -386,7 +386,7 @@ func definitionForStaticProperty(sp *parse.StaticProperty, prog *parse.Program, 
 }
 
 func definitionForInstanceProperty(ip *parse.InstanceProperty, prog *parse.Program, filePath string) *definitionTarget {
-	ownerType := normalizeDisplayType(inferExprType(ip.Target))
+	ownerType := normalizeDisplayType(inferExprType(ip.Target, prog, filePath))
 	ownerType = strings.TrimSuffix(ownerType, "?")
 	if ownerType == "" || ownerType == "?" {
 		return nil
@@ -402,7 +402,7 @@ func definitionForInstanceProperty(ip *parse.InstanceProperty, prog *parse.Progr
 }
 
 func definitionForInstanceMethod(im *parse.InstanceMethod, prog *parse.Program, filePath string) *definitionTarget {
-	ownerType := normalizeDisplayType(inferExprType(im.Target))
+	ownerType := normalizeDisplayType(inferExprType(im.Target, prog, filePath))
 	ownerType = strings.TrimSuffix(ownerType, "?")
 	if ownerType == "" || ownerType == "?" {
 		return nil

--- a/compiler/lsp/diagnostics.go
+++ b/compiler/lsp/diagnostics.go
@@ -179,11 +179,11 @@ func (s *Server) analyzeDiagnostics(doc *Doc, docs []Doc) (diagnostics []checker
 		}
 	}()
 
-	filePath := doc.URI.Filename()
-	overlays := map[string]string{}
-	for _, cached := range docs {
-		overlays[cached.URI.Filename()] = cached.Text
+	filePath, err := filePathFromURI(doc.URI)
+	if err != nil {
+		return nil, err
 	}
+	overlays := overlaySources(docs)
 	analyzer := s.diagnosticsAnalyzer
 	if analyzer == nil {
 		analyzer = parseAndCheckWithOverlays

--- a/compiler/lsp/diagnostics.go
+++ b/compiler/lsp/diagnostics.go
@@ -12,13 +12,22 @@ import (
 	"go.lsp.dev/uri"
 )
 
+type diagnosticAnalyzer func(source string, filePath string, overlays map[string]string) ([]checker.Diagnostic, error)
+
 // parseAndCheck runs the Ard parser and checker on a source file.
 // It returns the parsed AST, the checked module, and any diagnostics.
 func parseAndCheck(source string, filePath string) ([]checker.Diagnostic, error) {
 	return parseAndCheckWithOverlays(source, filePath, nil)
 }
 
-func parseAndCheckWithOverlays(source string, filePath string, overlays map[string]string) ([]checker.Diagnostic, error) {
+func parseAndCheckWithOverlays(source string, filePath string, overlays map[string]string) (diagnostics []checker.Diagnostic, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			diagnostics = nil
+			err = fmt.Errorf("analysis panic: %v", r)
+		}
+	}()
+
 	// Parse the source
 	result := parse.Parse([]byte(source), filePath)
 	if result.Program == nil {
@@ -138,29 +147,47 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI uri.URI) {
 		return
 	}
 
+	diags, err := s.analyzeDiagnostics(doc)
+	if !s.isDiagnosticSnapshotCurrent(docURI, doc.Version) {
+		return
+	}
+	if err != nil {
+		// If we can't analyze, publish the error as a diagnostic so stale diagnostics
+		// are replaced instead of lingering until the server is restarted.
+		s.sendDiagnostics(ctx, docURI, doc.Version, []protocol.Diagnostic{analysisErrorDiagnostic(err)})
+		return
+	}
+
+	s.sendDiagnostics(ctx, docURI, doc.Version, checkerDiagnosticsToLSP(diags))
+}
+
+func (s *Server) analyzeDiagnostics(doc *Doc) (diagnostics []checker.Diagnostic, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			diagnostics = nil
+			err = fmt.Errorf("analysis panic: %v", r)
+		}
+	}()
+
 	filePath := doc.URI.Filename()
 	overlays := map[string]string{}
 	for _, cached := range s.cache.Snapshot() {
 		overlays[cached.URI.Filename()] = cached.Text
 	}
-	diags, err := parseAndCheckWithOverlays(doc.Text, filePath, overlays)
-	if !s.isDiagnosticSnapshotCurrent(docURI, doc.Version) {
-		return
+	analyzer := s.diagnosticsAnalyzer
+	if analyzer == nil {
+		analyzer = parseAndCheckWithOverlays
 	}
-	if err != nil {
-		// If we can't analyze, publish the error as a diagnostic
-		s.sendDiagnostics(ctx, docURI, doc.Version, []protocol.Diagnostic{
-			{
-				Range:    protocol.Range{Start: protocol.Position{Line: 0, Character: 0}, End: protocol.Position{Line: 0, Character: 1}},
-				Severity: protocol.DiagnosticSeverityError,
-				Source:   "ard",
-				Message:  fmt.Sprintf("Analysis error: %v", err),
-			},
-		})
-		return
-	}
+	return analyzer(doc.Text, filePath, overlays)
+}
 
-	s.sendDiagnostics(ctx, docURI, doc.Version, checkerDiagnosticsToLSP(diags))
+func analysisErrorDiagnostic(err error) protocol.Diagnostic {
+	return protocol.Diagnostic{
+		Range:    protocol.Range{Start: protocol.Position{Line: 0, Character: 0}, End: protocol.Position{Line: 0, Character: 1}},
+		Severity: protocol.DiagnosticSeverityError,
+		Source:   "ard",
+		Message:  fmt.Sprintf("Analysis error: %v", err),
+	}
 }
 
 func (s *Server) isDiagnosticSnapshotCurrent(docURI uri.URI, version int32) bool {

--- a/compiler/lsp/diagnostics.go
+++ b/compiler/lsp/diagnostics.go
@@ -140,15 +140,16 @@ func diagnosticKindToLSPSeverity(kind checker.DiagnosticKind) protocol.Diagnosti
 
 // publishDiagnostics analyzes the document at the given URI and publishes diagnostics.
 func (s *Server) publishDiagnostics(ctx context.Context, docURI uri.URI) {
-	doc := s.cache.Get(docURI)
+	docs, revision := s.cache.SnapshotWithRevision()
+	doc := findDiagnosticDocument(docs, docURI)
 	if doc == nil {
 		// Document not in cache; clear diagnostics.
 		s.sendDiagnostics(ctx, docURI, -1, nil)
 		return
 	}
 
-	diags, err := s.analyzeDiagnostics(doc)
-	if !s.isDiagnosticSnapshotCurrent(docURI, doc.Version) {
+	diags, err := s.analyzeDiagnostics(doc, docs)
+	if !s.isDiagnosticSnapshotCurrent(docURI, doc.Version, revision) {
 		return
 	}
 	if err != nil {
@@ -161,7 +162,16 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI uri.URI) {
 	s.sendDiagnostics(ctx, docURI, doc.Version, checkerDiagnosticsToLSP(diags))
 }
 
-func (s *Server) analyzeDiagnostics(doc *Doc) (diagnostics []checker.Diagnostic, err error) {
+func findDiagnosticDocument(docs []Doc, docURI uri.URI) *Doc {
+	for i := range docs {
+		if docs[i].URI == docURI {
+			return &docs[i]
+		}
+	}
+	return nil
+}
+
+func (s *Server) analyzeDiagnostics(doc *Doc, docs []Doc) (diagnostics []checker.Diagnostic, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			diagnostics = nil
@@ -171,7 +181,7 @@ func (s *Server) analyzeDiagnostics(doc *Doc) (diagnostics []checker.Diagnostic,
 
 	filePath := doc.URI.Filename()
 	overlays := map[string]string{}
-	for _, cached := range s.cache.Snapshot() {
+	for _, cached := range docs {
 		overlays[cached.URI.Filename()] = cached.Text
 	}
 	analyzer := s.diagnosticsAnalyzer
@@ -190,9 +200,9 @@ func analysisErrorDiagnostic(err error) protocol.Diagnostic {
 	}
 }
 
-func (s *Server) isDiagnosticSnapshotCurrent(docURI uri.URI, version int32) bool {
+func (s *Server) isDiagnosticSnapshotCurrent(docURI uri.URI, version int32, revision uint64) bool {
 	current := s.cache.Get(docURI)
-	return current != nil && current.Version == version
+	return current != nil && current.Version == version && s.cache.Revision() == revision
 }
 
 // sendDiagnostics sends a textDocument/publishDiagnostics notification to the client.

--- a/compiler/lsp/diagnostics.go
+++ b/compiler/lsp/diagnostics.go
@@ -134,7 +134,7 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI uri.URI) {
 	doc := s.cache.Get(docURI)
 	if doc == nil {
 		// Document not in cache; clear diagnostics.
-		s.sendDiagnostics(ctx, docURI, nil)
+		s.sendDiagnostics(ctx, docURI, -1, nil)
 		return
 	}
 
@@ -144,9 +144,12 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI uri.URI) {
 		overlays[cached.URI.Filename()] = cached.Text
 	}
 	diags, err := parseAndCheckWithOverlays(doc.Text, filePath, overlays)
+	if !s.isDiagnosticSnapshotCurrent(docURI, doc.Version) {
+		return
+	}
 	if err != nil {
 		// If we can't analyze, publish the error as a diagnostic
-		s.sendDiagnostics(ctx, docURI, []protocol.Diagnostic{
+		s.sendDiagnostics(ctx, docURI, doc.Version, []protocol.Diagnostic{
 			{
 				Range:    protocol.Range{Start: protocol.Position{Line: 0, Character: 0}, End: protocol.Position{Line: 0, Character: 1}},
 				Severity: protocol.DiagnosticSeverityError,
@@ -157,12 +160,17 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI uri.URI) {
 		return
 	}
 
-	s.sendDiagnostics(ctx, docURI, checkerDiagnosticsToLSP(diags))
+	s.sendDiagnostics(ctx, docURI, doc.Version, checkerDiagnosticsToLSP(diags))
+}
+
+func (s *Server) isDiagnosticSnapshotCurrent(docURI uri.URI, version int32) bool {
+	current := s.cache.Get(docURI)
+	return current != nil && current.Version == version
 }
 
 // sendDiagnostics sends a textDocument/publishDiagnostics notification to the client.
 // diags is converted to an empty slice if nil so JSON serializes as [] not null.
-func (s *Server) sendDiagnostics(ctx context.Context, docURI uri.URI, diags []protocol.Diagnostic) {
+func (s *Server) sendDiagnostics(ctx context.Context, docURI uri.URI, version int32, diags []protocol.Diagnostic) {
 	if s.conn == nil {
 		return
 	}
@@ -173,6 +181,9 @@ func (s *Server) sendDiagnostics(ctx context.Context, docURI uri.URI, diags []pr
 	params := &protocol.PublishDiagnosticsParams{
 		URI:         docURI,
 		Diagnostics: diags,
+	}
+	if version >= 0 {
+		params.Version = uint32(version)
 	}
 
 	// Ignore error — this is a notification; client may disconnect.

--- a/compiler/lsp/diagnostics_test.go
+++ b/compiler/lsp/diagnostics_test.go
@@ -201,3 +201,28 @@ func TestPublishDiagnosticsClearsClosedDocumentDiagnostics(t *testing.T) {
 		t.Fatalf("expected diagnostics to be cleared, got %#v", params.Diagnostics)
 	}
 }
+
+func TestPublishDiagnosticsReportsAnalysisPanic(t *testing.T) {
+	server := NewServer()
+	conn := newRecordingConn()
+	server.conn = conn
+	server.diagnosticsAnalyzer = func(source string, filePath string, overlays map[string]string) ([]checker.Diagnostic, error) {
+		panic("checker exploded")
+	}
+	docURI := uri.New("file:///tmp/test.ard")
+	server.cache.Open(docURI, "ard", 9, `let x = 5`)
+
+	server.publishDiagnostics(context.Background(), docURI)
+
+	params := conn.lastDiagnostics(t)
+	if params.Version != 9 {
+		t.Fatalf("diagnostic version = %d, want 9", params.Version)
+	}
+	if len(params.Diagnostics) != 1 {
+		t.Fatalf("expected one analysis diagnostic, got %#v", params.Diagnostics)
+	}
+	message := params.Diagnostics[0].Message
+	if !strings.Contains(message, "Analysis error") || !strings.Contains(message, "checker exploded") {
+		t.Fatalf("diagnostic message = %q", message)
+	}
+}

--- a/compiler/lsp/diagnostics_test.go
+++ b/compiler/lsp/diagnostics_test.go
@@ -56,6 +56,12 @@ func (c *recordingConn) Close() error {
 func (c *recordingConn) Done() <-chan struct{} { return c.done }
 func (c *recordingConn) Err() error            { return nil }
 
+func (c *recordingConn) notificationCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.notifications)
+}
+
 func (c *recordingConn) lastDiagnostics(t *testing.T) *protocol.PublishDiagnosticsParams {
 	t.Helper()
 	c.mu.Lock()
@@ -199,6 +205,39 @@ func TestPublishDiagnosticsClearsClosedDocumentDiagnostics(t *testing.T) {
 	}
 	if len(params.Diagnostics) != 0 {
 		t.Fatalf("expected diagnostics to be cleared, got %#v", params.Diagnostics)
+	}
+}
+
+func TestPublishDiagnosticsDiscardsStaleOverlaySnapshot(t *testing.T) {
+	server := NewServer()
+	conn := newRecordingConn()
+	server.conn = conn
+	mainURI := uri.New("file:///tmp/main.ard")
+	toolsURI := uri.New("file:///tmp/tools.ard")
+	server.cache.Open(mainURI, "ard", 1, "use app/tools\nlet value = tools::value()\n")
+	server.cache.Open(toolsURI, "ard", 1, "fn value() Int { 1 }\n")
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server.diagnosticsAnalyzer = func(source string, filePath string, overlays map[string]string) ([]checker.Diagnostic, error) {
+		close(started)
+		<-release
+		return nil, nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		server.publishDiagnostics(context.Background(), mainURI)
+		close(done)
+	}()
+
+	<-started
+	server.cache.Update(toolsURI, 2, "fn value() Int { 2 }\n")
+	close(release)
+	<-done
+
+	if got := conn.notificationCount(); got != 0 {
+		t.Fatalf("published %d stale diagnostic notifications, want none", got)
 	}
 }
 

--- a/compiler/lsp/diagnostics_test.go
+++ b/compiler/lsp/diagnostics_test.go
@@ -5,14 +5,75 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/akonwi/ard/checker"
+	"go.lsp.dev/jsonrpc2"
+	"go.lsp.dev/protocol"
 	"go.lsp.dev/uri"
 )
 
 // TestParseAndCheckWithError verifies diagnostics are produced for broken code.
 // Uses basic types that don't require stdlib imports.
+type recordedNotification struct {
+	method string
+	params interface{}
+}
+
+type recordingConn struct {
+	mu            sync.Mutex
+	notifications []recordedNotification
+	done          chan struct{}
+}
+
+func newRecordingConn() *recordingConn {
+	return &recordingConn{done: make(chan struct{})}
+}
+
+func (c *recordingConn) Call(ctx context.Context, method string, params, result interface{}) (jsonrpc2.ID, error) {
+	return jsonrpc2.ID{}, nil
+}
+
+func (c *recordingConn) Notify(ctx context.Context, method string, params interface{}) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.notifications = append(c.notifications, recordedNotification{method: method, params: params})
+	return nil
+}
+
+func (c *recordingConn) Go(ctx context.Context, handler jsonrpc2.Handler) {}
+
+func (c *recordingConn) Close() error {
+	select {
+	case <-c.done:
+	default:
+		close(c.done)
+	}
+	return nil
+}
+
+func (c *recordingConn) Done() <-chan struct{} { return c.done }
+func (c *recordingConn) Err() error            { return nil }
+
+func (c *recordingConn) lastDiagnostics(t *testing.T) *protocol.PublishDiagnosticsParams {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.notifications) == 0 {
+		t.Fatal("expected diagnostic notification")
+	}
+	n := c.notifications[len(c.notifications)-1]
+	if n.method != protocol.MethodTextDocumentPublishDiagnostics {
+		t.Fatalf("notification method = %q, want %q", n.method, protocol.MethodTextDocumentPublishDiagnostics)
+	}
+	params, ok := n.params.(*protocol.PublishDiagnosticsParams)
+	if !ok {
+		t.Fatalf("notification params = %T, want *protocol.PublishDiagnosticsParams", n.params)
+	}
+	return params
+}
+
 func TestParseAndCheckWithError(t *testing.T) {
 	source := `let x: Int = "hello"`
 	diags, err := parseAndCheck(source, "/tmp/test.ard")
@@ -104,4 +165,39 @@ func TestPublishDiagnosticsLifecycle(t *testing.T) {
 	// Close
 	server.cache.Close(docURI)
 	server.publishDiagnostics(ctx, docURI)
+}
+
+func TestPublishDiagnosticsIncludesDocumentVersion(t *testing.T) {
+	server := NewServer()
+	conn := newRecordingConn()
+	server.conn = conn
+	docURI := uri.New("file:///tmp/test.ard")
+	server.cache.Open(docURI, "ard", 7, `let x = 5`)
+
+	server.publishDiagnostics(context.Background(), docURI)
+
+	params := conn.lastDiagnostics(t)
+	if params.Version != 7 {
+		t.Fatalf("diagnostic version = %d, want 7", params.Version)
+	}
+	if len(params.Diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %#v", params.Diagnostics)
+	}
+}
+
+func TestPublishDiagnosticsClearsClosedDocumentDiagnostics(t *testing.T) {
+	server := NewServer()
+	conn := newRecordingConn()
+	server.conn = conn
+	docURI := uri.New("file:///tmp/test.ard")
+
+	server.publishDiagnostics(context.Background(), docURI)
+
+	params := conn.lastDiagnostics(t)
+	if params.URI != protocol.DocumentURI(docURI) {
+		t.Fatalf("diagnostic URI = %q, want %q", params.URI, docURI)
+	}
+	if len(params.Diagnostics) != 0 {
+		t.Fatalf("expected diagnostics to be cleared, got %#v", params.Diagnostics)
+	}
 }

--- a/compiler/lsp/diagnostics_test.go
+++ b/compiler/lsp/diagnostics_test.go
@@ -241,6 +241,44 @@ func TestPublishDiagnosticsDiscardsStaleOverlaySnapshot(t *testing.T) {
 	}
 }
 
+func TestPublishDiagnosticsHandlesNonFileURI(t *testing.T) {
+	server := NewServer()
+	conn := newRecordingConn()
+	server.conn = conn
+	docURI := uri.URI("untitled:Untitled-1")
+	server.cache.Open(docURI, "ard", 3, `let x = 5`)
+
+	server.publishDiagnostics(context.Background(), docURI)
+
+	params := conn.lastDiagnostics(t)
+	if params.Version != 3 {
+		t.Fatalf("diagnostic version = %d, want 3", params.Version)
+	}
+	if len(params.Diagnostics) != 1 {
+		t.Fatalf("expected one analysis diagnostic, got %#v", params.Diagnostics)
+	}
+	message := params.Diagnostics[0].Message
+	if !strings.Contains(message, "Analysis error") || !strings.Contains(message, "unsupported document URI") {
+		t.Fatalf("diagnostic message = %q", message)
+	}
+}
+
+func TestPublishDiagnosticsSkipsNonFileOverlays(t *testing.T) {
+	server := NewServer()
+	conn := newRecordingConn()
+	server.conn = conn
+	fileURI := uri.New("file:///tmp/test.ard")
+	server.cache.Open(fileURI, "ard", 1, `let x = 5`)
+	server.cache.Open(uri.URI("untitled:Untitled-1"), "ard", 1, `let y = 10`)
+
+	server.publishDiagnostics(context.Background(), fileURI)
+
+	params := conn.lastDiagnostics(t)
+	if len(params.Diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %#v", params.Diagnostics)
+	}
+}
+
 func TestPublishDiagnosticsReportsAnalysisPanic(t *testing.T) {
 	server := NewServer()
 	conn := newRecordingConn()

--- a/compiler/lsp/document_changes.go
+++ b/compiler/lsp/document_changes.go
@@ -1,0 +1,59 @@
+package lsp
+
+import (
+	"fmt"
+
+	"go.lsp.dev/protocol"
+)
+
+func applyDocumentChanges(text string, changes []documentContentChange) (string, error) {
+	updated := text
+	for _, change := range changes {
+		if change.Range == nil {
+			updated = change.Text
+			continue
+		}
+		start, err := lspPositionByteOffset(updated, change.Range.Start)
+		if err != nil {
+			return "", fmt.Errorf("change start: %w", err)
+		}
+		end, err := lspPositionByteOffset(updated, change.Range.End)
+		if err != nil {
+			return "", fmt.Errorf("change end: %w", err)
+		}
+		if end < start {
+			return "", fmt.Errorf("range end precedes start")
+		}
+		updated = updated[:start] + change.Text + updated[end:]
+	}
+	return updated, nil
+}
+
+func lspPositionByteOffset(text string, position protocol.Position) (int, error) {
+	line := uint32(0)
+	character := uint32(0)
+	for offset, r := range text {
+		if line == position.Line && character >= position.Character {
+			return offset, nil
+		}
+		if r == '\n' {
+			if line == position.Line {
+				return offset, nil
+			}
+			line++
+			character = 0
+			continue
+		}
+		if line == position.Line {
+			character += lspUTF16Width(r)
+		}
+	}
+	return len(text), nil
+}
+
+func lspUTF16Width(r rune) uint32 {
+	if r > 0xffff {
+		return 2
+	}
+	return 1
+}

--- a/compiler/lsp/document_highlight.go
+++ b/compiler/lsp/document_highlight.go
@@ -9,10 +9,6 @@ import (
 )
 
 func computeDocumentHighlights(source string, filePath string, position protocol.Position) []protocol.DocumentHighlight {
-	previousModulePathCache := referenceModulePathCache
-	referenceModulePathCache = map[string]referenceModulePathEntry{}
-	defer func() { referenceModulePathCache = previousModulePathCache }()
-
 	target := lspPositionToParsePoint(position)
 	prog := parseAndCache(source, filePath)
 	if prog == nil {
@@ -22,7 +18,7 @@ func computeDocumentHighlights(source string, filePath string, position protocol
 	var def *definitionTarget
 	var targetKind string
 	var targetName string
-	if resolved := findReferenceDeclarationTarget(prog.Statements, target, filePath, prog); resolved != nil {
+	if resolved := findReferenceDeclarationTarget(prog.Statements, target, filePath, source, prog); resolved != nil {
 		def = resolved.def
 		targetKind = resolved.kind
 		targetName = resolved.name

--- a/compiler/lsp/hover.go
+++ b/compiler/lsp/hover.go
@@ -54,14 +54,9 @@ func computeHover(source string, filePath string, position protocol.Position) *h
 	return describeExpr(expr, source, filePath, prog)
 }
 
-// parseAndCache caches the parsed program for type resolution.
+// parseAndCache parses source and returns the parsed program.
 func parseAndCache(source string, filePath string) *parse.Program {
 	result := parse.Parse([]byte(source), filePath)
-	if result.Program != nil {
-		lastParseSource = source
-		lastParseProgram = result.Program
-		lastParseFilepath = filePath
-	}
 	return result.Program
 }
 
@@ -897,7 +892,7 @@ func describeExpr(expr parse.Expression, source string, filePath string, prog *p
 		if len(e.Items) == 0 {
 			return simpleHover("[?]")
 		}
-		itemType := inferExprType(e.Items[0])
+		itemType := inferExprType(e.Items[0], prog, filePath)
 		if itemType == "" || itemType == "?" {
 			return simpleHover("List")
 		}
@@ -949,7 +944,7 @@ func describeIdentifier(id *parse.Identifier, source string, filePath string, pr
 	}
 
 	// Fall back to parse-tree scanning
-	info := scanForType(id.Name, prog.Statements)
+	info := scanForType(id.Name, prog.Statements, prog, filePath)
 	if info != nil {
 		return info
 	}
@@ -1260,7 +1255,7 @@ func findTypeInCheckerIf(name string, e *checker.If) string {
 }
 
 // scanForType searches parse-tree statements for a declaration matching name.
-func scanForType(name string, stmts []parse.Statement) *hoverInfo {
+func scanForType(name string, stmts []parse.Statement, prog *parse.Program, filePath string) *hoverInfo {
 	for _, stmt := range stmts {
 		if stmt == nil {
 			continue
@@ -1268,7 +1263,7 @@ func scanForType(name string, stmts []parse.Statement) *hoverInfo {
 		switch s := stmt.(type) {
 		case *parse.VariableDeclaration:
 			if s.Name == name {
-				return describeVariableDecl(s, "", "", nil)
+				return describeVariableDecl(s, "", filePath, prog)
 			}
 		case *parse.FunctionDeclaration:
 			if s.Name == name {
@@ -1279,7 +1274,7 @@ func scanForType(name string, stmts []parse.Statement) *hoverInfo {
 					return describeParam(&p)
 				}
 			}
-			if info := scanForType(name, s.Body); info != nil {
+			if info := scanForType(name, s.Body, prog, filePath); info != nil {
 				return info
 			}
 		case *parse.ImplBlock:
@@ -1287,7 +1282,7 @@ func scanForType(name string, stmts []parse.Statement) *hoverInfo {
 				return simpleHover(s.Target.Name)
 			}
 			for i := range s.Methods {
-				if info := scanForType(name, []parse.Statement{&s.Methods[i]}); info != nil {
+				if info := scanForType(name, []parse.Statement{&s.Methods[i]}, prog, filePath); info != nil {
 					return info
 				}
 			}
@@ -1299,7 +1294,7 @@ func scanForType(name string, stmts []parse.Statement) *hoverInfo {
 				return simpleHover(s.ForType.Name)
 			}
 			for i := range s.Methods {
-				if info := scanForType(name, []parse.Statement{&s.Methods[i]}); info != nil {
+				if info := scanForType(name, []parse.Statement{&s.Methods[i]}, prog, filePath); info != nil {
 					return info
 				}
 			}
@@ -1308,46 +1303,46 @@ func scanForType(name string, stmts []parse.Statement) *hoverInfo {
 				return simpleHover(s.Name.Name)
 			}
 			for i := range s.Methods {
-				if info := scanForType(name, []parse.Statement{&s.Methods[i]}); info != nil {
+				if info := scanForType(name, []parse.Statement{&s.Methods[i]}, prog, filePath); info != nil {
 					return info
 				}
 			}
 		case *parse.IfStatement:
-			if info := scanForType(name, s.Body); info != nil {
+			if info := scanForType(name, s.Body, prog, filePath); info != nil {
 				return info
 			}
 			if s.Else != nil {
-				if info := scanForType(name, []parse.Statement{s.Else}); info != nil {
+				if info := scanForType(name, []parse.Statement{s.Else}, prog, filePath); info != nil {
 					return info
 				}
 			}
 		case *parse.WhileLoop:
-			if info := scanForType(name, s.Body); info != nil {
+			if info := scanForType(name, s.Body, prog, filePath); info != nil {
 				return info
 			}
 		case *parse.ForInLoop:
 			if s.Cursor.Name == name {
-				return simpleHover(inferLoopCursorType(s.Iterable, false))
+				return simpleHover(inferLoopCursorType(s.Iterable, false, prog, filePath))
 			}
 			if s.Cursor2.Name == name {
-				return simpleHover(inferLoopCursorType(s.Iterable, true))
+				return simpleHover(inferLoopCursorType(s.Iterable, true, prog, filePath))
 			}
-			if info := scanForType(name, s.Body); info != nil {
+			if info := scanForType(name, s.Body, prog, filePath); info != nil {
 				return info
 			}
 		case *parse.RangeLoop:
 			if s.Cursor.Name == name || s.Cursor2.Name == name {
 				return simpleHover("Int")
 			}
-			if info := scanForType(name, s.Body); info != nil {
+			if info := scanForType(name, s.Body, prog, filePath); info != nil {
 				return info
 			}
 		case *parse.ForLoop:
-			if info := scanForType(name, s.Body); info != nil {
+			if info := scanForType(name, s.Body, prog, filePath); info != nil {
 				return info
 			}
 		case *parse.BlockExpression:
-			if info := scanForType(name, s.Statements); info != nil {
+			if info := scanForType(name, s.Statements, prog, filePath); info != nil {
 				return info
 			}
 		case *parse.Try:
@@ -1399,7 +1394,7 @@ func describeVariableDecl(vd *parse.VariableDeclaration, source string, filePath
 
 	// Fall back to parse-tree inference
 	if vd.Value != nil {
-		inferred := inferExprType(vd.Value)
+		inferred := inferExprType(vd.Value, prog, filePath)
 		if inferred != "" && inferred != "?" {
 			return simpleHover(inferred)
 		}
@@ -1427,7 +1422,7 @@ func resolveInstancePropertyType(ip *parse.InstanceProperty, prog *parse.Program
 		return "", ""
 	}
 
-	ownerType := normalizeDisplayType(inferExprType(ip.Target))
+	ownerType := normalizeDisplayType(inferExprType(ip.Target, prog, filePath))
 	ownerType = strings.TrimSuffix(ownerType, "?")
 	if ownerType == "" || ownerType == "?" {
 		return "", ""
@@ -1487,7 +1482,7 @@ func resolveInstanceMethodSignature(im *parse.InstanceMethod, prog *parse.Progra
 		return nil
 	}
 
-	ownerType := inferExprType(im.Target)
+	ownerType := inferExprType(im.Target, prog, filePath)
 	if ownerType == "" || ownerType == "?" {
 		return nil
 	}
@@ -2018,7 +2013,7 @@ func findFunctionDecl(name string, stmts []parse.Statement) *hoverInfo {
 }
 
 // inferExprType returns a type name for an expression, scanning the AST for declarations.
-func inferExprType(expr parse.Expression) string {
+func inferExprType(expr parse.Expression, prog *parse.Program, filePath string) string {
 	if expr == nil {
 		return ""
 	}
@@ -2039,7 +2034,7 @@ func inferExprType(expr parse.Expression) string {
 		if len(e.Items) == 0 {
 			return "[?]"
 		}
-		itemType := inferExprType(e.Items[0])
+		itemType := inferExprType(e.Items[0], prog, filePath)
 		if itemType == "" || itemType == "?" {
 			return "List"
 		}
@@ -2047,46 +2042,46 @@ func inferExprType(expr parse.Expression) string {
 	case *parse.MapLiteral:
 		return "Map"
 	case *parse.Identifier:
-		return resolveIdentType(e.Name)
+		return resolveIdentType(e.Name, prog, filePath)
 	case *parse.FunctionCall:
-		return resolveFunctionReturnType(e.Name)
+		return resolveFunctionReturnType(e.Name, prog)
 	case *parse.InstanceProperty:
-		_, fieldType := resolveInstancePropertyType(e, lastParseProgram, lastParseFilepath)
+		_, fieldType := resolveInstancePropertyType(e, prog, filePath)
 		if fieldType != "" {
-			return qualifyTypeDisplay(fieldType, lastParseProgram, lastParseFilepath)
+			return qualifyTypeDisplay(fieldType, prog, filePath)
 		}
-		return resolveIdentType(e.Property.Name)
+		return resolveIdentType(e.Property.Name, prog, filePath)
 	case *parse.InstanceMethod:
-		if sig := resolveInstanceMethodSignature(e, lastParseProgram, lastParseFilepath); sig != nil && sig.ReturnType != "" {
-			return qualifyTypeDisplay(sig.ReturnType, lastParseProgram, lastParseFilepath)
+		if sig := resolveInstanceMethodSignature(e, prog, filePath); sig != nil && sig.ReturnType != "" {
+			return qualifyTypeDisplay(sig.ReturnType, prog, filePath)
 		}
-		return resolveFunctionReturnType(e.Method.Name)
+		return resolveFunctionReturnType(e.Method.Name, prog)
 	case *parse.StaticFunction:
-		if ret := resolveStaticFunctionReturnType(e, lastParseProgram); ret != "" {
+		if ret := resolveStaticFunctionReturnType(e, prog, filePath); ret != "" {
 			return ret
 		}
 		return "?"
 	case *parse.StaticProperty:
 		if id, ok := e.Property.(*parse.Identifier); ok {
-			return resolveIdentType(id.Name)
+			return resolveIdentType(id.Name, prog, filePath)
 		}
 		return "?"
 	case *parse.UnaryExpression:
 		if e.Operator == parse.Bang || e.Operator == parse.Not {
 			return "Bool"
 		}
-		return inferExprType(e.Operand)
+		return inferExprType(e.Operand, prog, filePath)
 	case *parse.BinaryExpression:
-		return inferBinaryExprType(e)
+		return inferBinaryExprType(e, prog, filePath)
 	case *parse.IfStatement:
 		if len(e.Body) > 0 {
 			if last, ok := e.Body[len(e.Body)-1].(parse.Expression); ok {
-				return inferExprType(last)
+				return inferExprType(last, prog, filePath)
 			}
 		}
 		if e.Else != nil {
 			if last, ok := e.Else.(parse.Expression); ok {
-				return inferExprType(last)
+				return inferExprType(last, prog, filePath)
 			}
 		}
 		return "Void"
@@ -2097,12 +2092,8 @@ func inferExprType(expr parse.Expression) string {
 }
 
 // resolveIdentType resolves an identifier's type by scanning the parse tree.
-var lastParseSource string
-var lastParseFilepath string
-var lastParseProgram *parse.Program
-
-func resolveIdentType(name string) string {
-	if lastParseProgram == nil {
+func resolveIdentType(name string, prog *parse.Program, filePath string) string {
+	if prog == nil {
 		return "?"
 	}
 	switch name {
@@ -2113,11 +2104,11 @@ func resolveIdentType(name string) string {
 	case "panic":
 		return "?"
 	}
-	return scanIdentType(name, lastParseProgram.Statements)
+	return scanIdentType(name, prog.Statements, prog, filePath)
 }
 
 // scanIdentType searches parse-tree statements for a declaration matching name.
-func scanIdentType(name string, stmts []parse.Statement) string {
+func scanIdentType(name string, stmts []parse.Statement, prog *parse.Program, filePath string) string {
 	for _, stmt := range stmts {
 		if stmt == nil {
 			continue
@@ -2125,7 +2116,7 @@ func scanIdentType(name string, stmts []parse.Statement) string {
 		switch s := stmt.(type) {
 		case *parse.VariableDeclaration:
 			if s.Name == name {
-				return typeFromDecl(s)
+				return typeFromDecl(s, prog, filePath)
 			}
 		case *parse.FunctionDeclaration:
 			if s.Name == name {
@@ -2136,7 +2127,7 @@ func scanIdentType(name string, stmts []parse.Statement) string {
 					return typeDeclString(p.Type)
 				}
 			}
-			if t := scanIdentType(name, s.Body); t != "" {
+			if t := scanIdentType(name, s.Body, prog, filePath); t != "" {
 				return t
 			}
 		case *parse.ImplBlock:
@@ -2144,7 +2135,7 @@ func scanIdentType(name string, stmts []parse.Statement) string {
 				return s.Target.Name
 			}
 			for i := range s.Methods {
-				if t := scanIdentType(name, []parse.Statement{&s.Methods[i]}); t != "" {
+				if t := scanIdentType(name, []parse.Statement{&s.Methods[i]}, prog, filePath); t != "" {
 					return t
 				}
 			}
@@ -2156,7 +2147,7 @@ func scanIdentType(name string, stmts []parse.Statement) string {
 				return s.ForType.Name
 			}
 			for i := range s.Methods {
-				if t := scanIdentType(name, []parse.Statement{&s.Methods[i]}); t != "" {
+				if t := scanIdentType(name, []parse.Statement{&s.Methods[i]}, prog, filePath); t != "" {
 					return t
 				}
 			}
@@ -2165,46 +2156,46 @@ func scanIdentType(name string, stmts []parse.Statement) string {
 				return s.Name.Name
 			}
 			for i := range s.Methods {
-				if t := scanIdentType(name, []parse.Statement{&s.Methods[i]}); t != "" {
+				if t := scanIdentType(name, []parse.Statement{&s.Methods[i]}, prog, filePath); t != "" {
 					return t
 				}
 			}
 		case *parse.IfStatement:
-			if t := scanIdentType(name, s.Body); t != "" {
+			if t := scanIdentType(name, s.Body, prog, filePath); t != "" {
 				return t
 			}
 			if s.Else != nil {
-				if t := scanIdentType(name, []parse.Statement{s.Else}); t != "" {
+				if t := scanIdentType(name, []parse.Statement{s.Else}, prog, filePath); t != "" {
 					return t
 				}
 			}
 		case *parse.WhileLoop:
-			if t := scanIdentType(name, s.Body); t != "" {
+			if t := scanIdentType(name, s.Body, prog, filePath); t != "" {
 				return t
 			}
 		case *parse.ForInLoop:
 			if s.Cursor.Name == name {
-				return inferLoopCursorType(s.Iterable, false)
+				return inferLoopCursorType(s.Iterable, false, prog, filePath)
 			}
 			if s.Cursor2.Name == name {
-				return inferLoopCursorType(s.Iterable, true)
+				return inferLoopCursorType(s.Iterable, true, prog, filePath)
 			}
-			if t := scanIdentType(name, s.Body); t != "" {
+			if t := scanIdentType(name, s.Body, prog, filePath); t != "" {
 				return t
 			}
 		case *parse.RangeLoop:
 			if s.Cursor.Name == name || s.Cursor2.Name == name {
 				return "Int"
 			}
-			if t := scanIdentType(name, s.Body); t != "" {
+			if t := scanIdentType(name, s.Body, prog, filePath); t != "" {
 				return t
 			}
 		case *parse.ForLoop:
-			if t := scanIdentType(name, s.Body); t != "" {
+			if t := scanIdentType(name, s.Body, prog, filePath); t != "" {
 				return t
 			}
 		case *parse.BlockExpression:
-			if t := scanIdentType(name, s.Statements); t != "" {
+			if t := scanIdentType(name, s.Statements, prog, filePath); t != "" {
 				return t
 			}
 		case *parse.Try:
@@ -2217,8 +2208,8 @@ func scanIdentType(name string, stmts []parse.Statement) string {
 }
 
 // inferLoopCursorType returns the parse-inferred item type for a for-in cursor.
-func inferLoopCursorType(iterable parse.Expression, index bool) string {
-	iterableType := inferExprType(iterable)
+func inferLoopCursorType(iterable parse.Expression, index bool, prog *parse.Program, filePath string) string {
+	iterableType := inferExprType(iterable, prog, filePath)
 	if index {
 		if iterableType == "Map" {
 			return "?"
@@ -2235,19 +2226,19 @@ func inferLoopCursorType(iterable parse.Expression, index bool) string {
 }
 
 // typeFromDecl returns the type string for a variable declaration.
-func typeFromDecl(vd *parse.VariableDeclaration) string {
+func typeFromDecl(vd *parse.VariableDeclaration, prog *parse.Program, filePath string) string {
 	if vd.Type != nil {
 		return typeDeclString(vd.Type)
 	}
 	if vd.Value != nil {
-		return inferExprType(vd.Value)
+		return inferExprType(vd.Value, prog, filePath)
 	}
 	return ""
 }
 
-func resolveStaticFunctionReturnType(sf *parse.StaticFunction, prog *parse.Program) string {
-	if sig := resolveStaticFunctionSignature(sf, prog, lastParseFilepath); sig != nil {
-		return qualifyTypeDisplay(sig.ReturnType, prog, lastParseFilepath)
+func resolveStaticFunctionReturnType(sf *parse.StaticFunction, prog *parse.Program, filePath string) string {
+	if sig := resolveStaticFunctionSignature(sf, prog, filePath); sig != nil {
+		return qualifyTypeDisplay(sig.ReturnType, prog, filePath)
 	}
 	return ""
 }
@@ -2376,11 +2367,11 @@ func parseStaticFunctionSignature(target string, fd *parse.FunctionDeclaration) 
 }
 
 // resolveFunctionReturnType finds a function declaration and returns its return type.
-func resolveFunctionReturnType(name string) string {
-	if lastParseProgram == nil {
+func resolveFunctionReturnType(name string, prog *parse.Program) string {
+	if prog == nil {
 		return "?"
 	}
-	return scanFunctionReturnType(name, lastParseProgram.Statements)
+	return scanFunctionReturnType(name, prog.Statements)
 }
 
 // scanFunctionReturnType searches for a function declaration and returns its return type.
@@ -2429,14 +2420,14 @@ func funcReturnTypeString(fd *parse.FunctionDeclaration) string {
 }
 
 // inferBinaryExprType returns the type of a binary expression.
-func inferBinaryExprType(e *parse.BinaryExpression) string {
+func inferBinaryExprType(e *parse.BinaryExpression, prog *parse.Program, filePath string) string {
 	switch e.Operator {
 	case parse.Equal, parse.NotEqual, parse.GreaterThan, parse.GreaterThanOrEqual,
 		parse.LessThan, parse.LessThanOrEqual, parse.And, parse.Or:
 		return "Bool"
 	case parse.Plus:
-		left := inferExprType(e.Left)
-		right := inferExprType(e.Right)
+		left := inferExprType(e.Left, prog, filePath)
+		right := inferExprType(e.Right, prog, filePath)
 		if left == right {
 			return left
 		}
@@ -2448,12 +2439,12 @@ func inferBinaryExprType(e *parse.BinaryExpression) string {
 		}
 		return "Int"
 	case parse.Minus, parse.Divide, parse.Multiply, parse.Modulo:
-		left := inferExprType(e.Left)
+		left := inferExprType(e.Left, prog, filePath)
 		if left != "" && left != "?" {
 			return left
 		}
 		return "Int"
 	default:
-		return inferExprType(e.Left)
+		return inferExprType(e.Left, prog, filePath)
 	}
 }

--- a/compiler/lsp/references.go
+++ b/compiler/lsp/references.go
@@ -25,22 +25,11 @@ type referenceResolvedTarget struct {
 	def  *definitionTarget
 }
 
-type referenceModulePathEntry struct {
-	path string
-	ok   bool
-}
-
-var referenceModulePathCache map[string]referenceModulePathEntry
-
 func computeReferences(source string, filePath string, position protocol.Position, includeDeclaration bool) []protocol.Location {
 	return computeReferencesWithOverlays(source, filePath, position, includeDeclaration, nil)
 }
 
 func computeReferencesWithOverlays(source string, filePath string, position protocol.Position, includeDeclaration bool, overlays map[string]string) []protocol.Location {
-	previousModulePathCache := referenceModulePathCache
-	referenceModulePathCache = map[string]referenceModulePathEntry{}
-	defer func() { referenceModulePathCache = previousModulePathCache }()
-
 	target := lspPositionToParsePoint(position)
 	prog := parseAndCache(source, filePath)
 	if prog == nil {
@@ -50,7 +39,7 @@ func computeReferencesWithOverlays(source string, filePath string, position prot
 	var def *definitionTarget
 	var targetKind string
 	var targetName string
-	if resolved := findReferenceDeclarationTarget(prog.Statements, target, filePath, prog); resolved != nil {
+	if resolved := findReferenceDeclarationTarget(prog.Statements, target, filePath, source, prog); resolved != nil {
 		def = resolved.def
 		targetKind = resolved.kind
 		targetName = resolved.name
@@ -97,7 +86,7 @@ func computeReferencesWithOverlays(source string, filePath string, position prot
 	return refs
 }
 
-func findReferenceDeclarationTarget(stmts []parse.Statement, target parse.Point, filePath string, prog *parse.Program) *referenceResolvedTarget {
+func findReferenceDeclarationTarget(stmts []parse.Statement, target parse.Point, filePath string, source string, prog *parse.Program) *referenceResolvedTarget {
 	for _, stmt := range stmts {
 		if stmt == nil || !pointInRange(target, stmt.GetLocation()) {
 			continue
@@ -132,7 +121,7 @@ func findReferenceDeclarationTarget(stmts []parse.Statement, target parse.Point,
 				return &referenceResolvedTarget{kind: "type", name: s.Name.Name, def: &definitionTarget{filePath: filePath, loc: nameLoc}}
 			}
 			for i := range s.Methods {
-				if resolved := findReferenceDeclarationTarget([]parse.Statement{&s.Methods[i]}, target, filePath, prog); resolved != nil {
+				if resolved := findReferenceDeclarationTarget([]parse.Statement{&s.Methods[i]}, target, filePath, source, prog); resolved != nil {
 					return resolved
 				}
 			}
@@ -143,7 +132,7 @@ func findReferenceDeclarationTarget(stmts []parse.Statement, target parse.Point,
 				}
 			}
 			for i := range s.Methods {
-				if resolved := findReferenceDeclarationTarget([]parse.Statement{&s.Methods[i]}, target, filePath, prog); resolved != nil {
+				if resolved := findReferenceDeclarationTarget([]parse.Statement{&s.Methods[i]}, target, filePath, source, prog); resolved != nil {
 					return resolved
 				}
 			}
@@ -154,7 +143,7 @@ func findReferenceDeclarationTarget(stmts []parse.Statement, target parse.Point,
 				}
 			}
 			for i := range s.Methods {
-				if resolved := findReferenceDeclarationTarget([]parse.Statement{&s.Methods[i]}, target, filePath, prog); resolved != nil {
+				if resolved := findReferenceDeclarationTarget([]parse.Statement{&s.Methods[i]}, target, filePath, source, prog); resolved != nil {
 					return resolved
 				}
 			}
@@ -167,7 +156,7 @@ func findReferenceDeclarationTarget(stmts []parse.Statement, target parse.Point,
 			if resolved := findReferenceDeclaredTypeTarget(s.ReturnType, target, filePath, prog); resolved != nil {
 				return resolved
 			}
-			if resolved := findReferenceDeclarationTarget(s.Body, target, filePath, prog); resolved != nil {
+			if resolved := findReferenceDeclarationTarget(s.Body, target, filePath, source, prog); resolved != nil {
 				return resolved
 			}
 		case *parse.StaticFunctionDeclaration:
@@ -177,11 +166,11 @@ func findReferenceDeclarationTarget(stmts []parse.Statement, target parse.Point,
 					return &referenceResolvedTarget{kind: "type", name: name, def: def}
 				}
 			}
-			if resolved := findReferenceDeclarationTarget([]parse.Statement{&s.FunctionDeclaration}, target, filePath, prog); resolved != nil {
+			if resolved := findReferenceDeclarationTarget([]parse.Statement{&s.FunctionDeclaration}, target, filePath, source, prog); resolved != nil {
 				return resolved
 			}
 		case *parse.VariableDeclaration:
-			nameLoc := documentHighlightNameLocation(lastParseSource, s.Location, s.Name)
+			nameLoc := documentHighlightNameLocation(source, s.Location, s.Name)
 			if pointInRange(target, nameLoc) {
 				return &referenceResolvedTarget{kind: "name", name: s.Name, def: &definitionTarget{filePath: filePath, loc: s.Location}}
 			}
@@ -198,32 +187,32 @@ func findReferenceDeclarationTarget(stmts []parse.Statement, target parse.Point,
 				return resolved
 			}
 		case *parse.IfStatement:
-			if resolved := findReferenceDeclarationTarget(s.Body, target, filePath, prog); resolved != nil {
+			if resolved := findReferenceDeclarationTarget(s.Body, target, filePath, source, prog); resolved != nil {
 				return resolved
 			}
 			if s.Else != nil {
-				if resolved := findReferenceDeclarationTarget([]parse.Statement{s.Else}, target, filePath, prog); resolved != nil {
+				if resolved := findReferenceDeclarationTarget([]parse.Statement{s.Else}, target, filePath, source, prog); resolved != nil {
 					return resolved
 				}
 			}
 		case *parse.WhileLoop:
-			if resolved := findReferenceDeclarationTarget(s.Body, target, filePath, prog); resolved != nil {
+			if resolved := findReferenceDeclarationTarget(s.Body, target, filePath, source, prog); resolved != nil {
 				return resolved
 			}
 		case *parse.ForInLoop:
-			if resolved := findReferenceDeclarationTarget(s.Body, target, filePath, prog); resolved != nil {
+			if resolved := findReferenceDeclarationTarget(s.Body, target, filePath, source, prog); resolved != nil {
 				return resolved
 			}
 		case *parse.RangeLoop:
-			if resolved := findReferenceDeclarationTarget(s.Body, target, filePath, prog); resolved != nil {
+			if resolved := findReferenceDeclarationTarget(s.Body, target, filePath, source, prog); resolved != nil {
 				return resolved
 			}
 		case *parse.ForLoop:
-			if resolved := findReferenceDeclarationTarget(s.Body, target, filePath, prog); resolved != nil {
+			if resolved := findReferenceDeclarationTarget(s.Body, target, filePath, source, prog); resolved != nil {
 				return resolved
 			}
 		case *parse.BlockExpression:
-			if resolved := findReferenceDeclarationTarget(s.Statements, target, filePath, prog); resolved != nil {
+			if resolved := findReferenceDeclarationTarget(s.Statements, target, filePath, source, prog); resolved != nil {
 				return resolved
 			}
 		}
@@ -429,134 +418,131 @@ func scanReferenceDocument(doc referenceDocument, targetKind string, targetName 
 	if doc.prog == nil {
 		return
 	}
-	lastParseSource = doc.source
-	lastParseProgram = doc.prog
-	lastParseFilepath = doc.filePath
-	visitReferenceStatements(doc.prog.Statements, doc.filePath, doc.prog, doc.filePath, targetKind, targetName, targetDef, add)
+	visitReferenceStatements(doc.prog.Statements, doc.filePath, doc.source, doc.prog, doc.filePath, targetKind, targetName, targetDef, add)
 }
 
-func visitReferenceStatements(stmts []parse.Statement, currentFile string, prog *parse.Program, rootFile string, targetKind string, targetName string, targetDef *definitionTarget, add func(string, parse.Location)) {
+func visitReferenceStatements(stmts []parse.Statement, currentFile string, source string, prog *parse.Program, rootFile string, targetKind string, targetName string, targetDef *definitionTarget, add func(string, parse.Location)) {
 	for _, stmt := range stmts {
 		if stmt == nil {
 			continue
 		}
-		visitReferenceStatement(stmt, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatement(stmt, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	}
 }
 
-func visitReferenceStatement(stmt parse.Statement, currentFile string, prog *parse.Program, rootFile string, targetKind string, targetName string, targetDef *definitionTarget, add func(string, parse.Location)) {
+func visitReferenceStatement(stmt parse.Statement, currentFile string, source string, prog *parse.Program, rootFile string, targetKind string, targetName string, targetDef *definitionTarget, add func(string, parse.Location)) {
 	if expr, ok := stmt.(parse.Expression); ok {
-		visitReferenceExpr(expr, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(expr, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	}
 
 	switch s := stmt.(type) {
 	case *parse.VariableDeclaration:
-		visitReferenceDeclaredType(s.Type, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceExpr(s.Value, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceDeclaredType(s.Type, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(s.Value, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.VariableAssignment:
-		visitReferenceExpr(s.Target, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceExpr(s.Value, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(s.Target, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(s.Value, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.FunctionDeclaration:
 		for i := range s.Parameters {
-			visitReferenceExpr(&s.Parameters[i], currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-			visitReferenceDeclaredType(s.Parameters[i].Type, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(&s.Parameters[i], currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceDeclaredType(s.Parameters[i].Type, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
-		visitReferenceDeclaredType(s.ReturnType, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceStatements(s.Body, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceDeclaredType(s.ReturnType, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatements(s.Body, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.StaticFunctionDeclaration:
-		visitReferenceExpr(s.Path.Target, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceStatement(&s.FunctionDeclaration, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(s.Path.Target, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatement(&s.FunctionDeclaration, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.ImplBlock:
-		visitReferenceExpr(&s.Target, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceExpr(&s.Receiver, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(&s.Target, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(&s.Receiver, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		for i := range s.Methods {
-			visitReferenceStatement(&s.Methods[i], currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceStatement(&s.Methods[i], currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.TraitImplementation:
-		visitReferenceExpr(s.Trait, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceExpr(&s.ForType, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceExpr(&s.Receiver, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(s.Trait, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(&s.ForType, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(&s.Receiver, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		for i := range s.Methods {
-			visitReferenceStatement(&s.Methods[i], currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceStatement(&s.Methods[i], currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.TraitDefinition:
-		visitReferenceExpr(&s.Name, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(&s.Name, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		for i := range s.Methods {
-			visitReferenceStatement(&s.Methods[i], currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceStatement(&s.Methods[i], currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.StructDefinition:
-		visitReferenceExpr(&s.Name, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(&s.Name, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		for _, field := range s.Fields {
-			visitReferenceDeclaredType(field.Type, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceDeclaredType(field.Type, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.TypeDeclaration:
-		visitReferenceExpr(&s.Name, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(&s.Name, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		for _, declared := range s.Type {
-			visitReferenceDeclaredType(declared, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceDeclaredType(declared, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.ExternalFunction:
 		for i := range s.Parameters {
-			visitReferenceExpr(&s.Parameters[i], currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-			visitReferenceDeclaredType(s.Parameters[i].Type, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(&s.Parameters[i], currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceDeclaredType(s.Parameters[i].Type, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
-		visitReferenceDeclaredType(s.ReturnType, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceDeclaredType(s.ReturnType, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.IfStatement:
-		visitReferenceExpr(s.Condition, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceStatements(s.Body, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(s.Condition, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatements(s.Body, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		if s.Else != nil {
-			visitReferenceStatement(s.Else, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceStatement(s.Else, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.WhileLoop:
-		visitReferenceExpr(s.Condition, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceStatements(s.Body, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(s.Condition, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatements(s.Body, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.ForInLoop:
-		visitReferenceExpr(&s.Cursor, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceExpr(&s.Cursor2, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceExpr(s.Iterable, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceStatements(s.Body, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(&s.Cursor, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(&s.Cursor2, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(s.Iterable, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatements(s.Body, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.RangeLoop:
-		visitReferenceExpr(&s.Cursor, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceExpr(&s.Cursor2, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceExpr(s.Start, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceExpr(s.End, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceStatements(s.Body, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(&s.Cursor, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(&s.Cursor2, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(s.Start, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(s.End, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatements(s.Body, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.ForLoop:
 		if s.Init != nil {
-			visitReferenceStatement(s.Init, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceStatement(s.Init, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
-		visitReferenceExpr(s.Condition, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(s.Condition, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		if s.Incrementer != nil {
-			visitReferenceStatement(s.Incrementer, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceStatement(s.Incrementer, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
-		visitReferenceStatements(s.Body, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatements(s.Body, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.MatchExpression:
-		visitReferenceExpr(s.Subject, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(s.Subject, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		for _, matchCase := range s.Cases {
-			visitReferenceExpr(matchCase.Pattern, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-			visitReferenceStatements(matchCase.Body, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(matchCase.Pattern, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceStatements(matchCase.Body, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.ConditionalMatchExpression:
 		for _, matchCase := range s.Cases {
-			visitReferenceExpr(matchCase.Condition, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-			visitReferenceStatements(matchCase.Body, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(matchCase.Condition, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceStatements(matchCase.Body, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.BlockExpression:
-		visitReferenceStatements(s.Statements, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatements(s.Statements, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.Try:
-		visitReferenceExpr(s.Expression, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(s.Expression, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		if s.CatchVar != nil {
-			visitReferenceExpr(s.CatchVar, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(s.CatchVar, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
-		visitReferenceStatements(s.CatchBlock, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatements(s.CatchBlock, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.StructInstance:
-		visitReferenceExpr(&s.Name, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(&s.Name, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		for _, prop := range s.Properties {
-			visitReferenceExpr(prop.Value, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(prop.Value, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	}
 }
 
-func visitReferenceExpr(expr parse.Expression, currentFile string, prog *parse.Program, rootFile string, targetKind string, targetName string, targetDef *definitionTarget, add func(string, parse.Location)) {
+func visitReferenceExpr(expr parse.Expression, currentFile string, source string, prog *parse.Program, rootFile string, targetKind string, targetName string, targetDef *definitionTarget, add func(string, parse.Location)) {
 	if expr == nil {
 		return
 	}
@@ -569,84 +555,84 @@ func visitReferenceExpr(expr parse.Expression, currentFile string, prog *parse.P
 
 	switch e := expr.(type) {
 	case *parse.BinaryExpression:
-		visitReferenceExpr(e.Left, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceExpr(e.Right, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(e.Left, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(e.Right, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.UnaryExpression:
-		visitReferenceExpr(e.Operand, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(e.Operand, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.FunctionCall:
 		for _, arg := range e.Args {
-			visitReferenceExpr(arg.Value, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(arg.Value, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.InstanceProperty:
-		visitReferenceExpr(e.Target, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(e.Target, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.InstanceMethod:
-		visitReferenceExpr(e.Target, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(e.Target, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		for _, arg := range e.Method.Args {
-			visitReferenceExpr(arg.Value, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(arg.Value, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.StaticProperty:
-		visitReferenceExpr(e.Target, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceExpr(e.Property, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(e.Target, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(e.Property, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.StaticFunction:
-		visitReferenceExpr(e.Target, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(e.Target, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		for _, arg := range e.Function.Args {
-			visitReferenceExpr(arg.Value, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(arg.Value, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.ListLiteral:
 		for _, item := range e.Items {
-			visitReferenceExpr(item, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(item, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.MapLiteral:
 		for _, entry := range e.Entries {
-			visitReferenceExpr(entry.Key, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-			visitReferenceExpr(entry.Value, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(entry.Key, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(entry.Value, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.MatchExpression:
-		visitReferenceExpr(e.Subject, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(e.Subject, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		for _, matchCase := range e.Cases {
-			visitReferenceExpr(matchCase.Pattern, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-			visitReferenceStatements(matchCase.Body, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(matchCase.Pattern, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceStatements(matchCase.Body, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.ConditionalMatchExpression:
 		for _, matchCase := range e.Cases {
-			visitReferenceExpr(matchCase.Condition, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-			visitReferenceStatements(matchCase.Body, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(matchCase.Condition, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceStatements(matchCase.Body, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.Try:
-		visitReferenceExpr(e.Expression, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(e.Expression, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		if e.CatchVar != nil {
-			visitReferenceExpr(e.CatchVar, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(e.CatchVar, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
-		visitReferenceStatements(e.CatchBlock, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatements(e.CatchBlock, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.BlockExpression:
-		visitReferenceStatements(e.Statements, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatements(e.Statements, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	case *parse.InterpolatedStr:
 		for _, chunk := range e.Chunks {
-			visitReferenceExpr(chunk, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(chunk, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.IfStatement:
-		visitReferenceExpr(e.Condition, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceStatements(e.Body, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(e.Condition, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatements(e.Body, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		if e.Else != nil {
-			visitReferenceStatement(e.Else, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceStatement(e.Else, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.StructInstance:
-		visitReferenceExpr(&e.Name, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceExpr(&e.Name, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		for _, prop := range e.Properties {
 			if targetKind == "instanceProperty" && referenceNamesMatch(targetName, prop.Name.Name) {
 				if def := definitionForStructValueField(e, prop.Name.Name, prog, rootFile); sameDefinitionTarget(def, targetDef) {
-					add(currentFile, structValueNameLocation(prop))
+					add(currentFile, structValueNameLocation(prop, source))
 				}
 			}
-			visitReferenceExpr(prop.Value, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(prop.Value, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
 	case *parse.AnonymousFunction:
 		for i := range e.Parameters {
-			visitReferenceExpr(&e.Parameters[i], currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-			visitReferenceDeclaredType(e.Parameters[i].Type, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceExpr(&e.Parameters[i], currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+			visitReferenceDeclaredType(e.Parameters[i].Type, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 		}
-		visitReferenceDeclaredType(e.ReturnType, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
-		visitReferenceStatements(e.Body, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceDeclaredType(e.ReturnType, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceStatements(e.Body, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	}
 }
 
@@ -705,18 +691,7 @@ func modulePathForAlias(alias string, prog *parse.Program, filePath string) (str
 }
 
 func modulePathForImport(imp parse.Import, filePath string) (string, bool) {
-	cacheKey := imp.Path
-	if referenceModulePathCache != nil {
-		if cached, ok := referenceModulePathCache[cacheKey]; ok {
-			return cached.path, cached.ok
-		}
-	}
-
-	path, ok := resolveModulePathForImport(imp, filePath)
-	if referenceModulePathCache != nil {
-		referenceModulePathCache[cacheKey] = referenceModulePathEntry{path: path, ok: ok}
-	}
-	return path, ok
+	return resolveModulePathForImport(imp, filePath)
 }
 
 func resolveModulePathForImport(imp parse.Import, filePath string) (string, bool) {
@@ -895,18 +870,18 @@ func isModuleAliasName(name string, prog *parse.Program) bool {
 	return preludeModulePath(name) != ""
 }
 
-func structValueNameLocation(prop parse.StructValue) parse.Location {
+func structValueNameLocation(prop parse.StructValue, source string) parse.Location {
 	if prop.Name.Location.Start.Row != 0 || prop.Name.Location.Start.Col != 0 {
 		return prop.Name.Location
 	}
-	if prop.Value == nil || prop.Name.Name == "" || lastParseSource == "" {
+	if prop.Value == nil || prop.Name.Name == "" || source == "" {
 		return prop.Name.Location
 	}
 	valueLoc := prop.Value.GetLocation()
 	if valueLoc.Start.Row <= 0 || valueLoc.Start.Col <= 0 {
 		return prop.Name.Location
 	}
-	line := sourceLine(lastParseSource, valueLoc.Start.Row)
+	line := sourceLine(source, valueLoc.Start.Row)
 	limit := valueLoc.Start.Col - 1
 	if limit < 0 {
 		return prop.Name.Location
@@ -951,7 +926,7 @@ func sourceLine(source string, row int) string {
 	return ""
 }
 
-func visitReferenceDeclaredType(declared parse.DeclaredType, currentFile string, prog *parse.Program, rootFile string, targetKind string, targetName string, targetDef *definitionTarget, add func(string, parse.Location)) {
+func visitReferenceDeclaredType(declared parse.DeclaredType, currentFile string, source string, prog *parse.Program, rootFile string, targetKind string, targetName string, targetDef *definitionTarget, add func(string, parse.Location)) {
 	if declared == nil {
 		return
 	}
@@ -961,7 +936,7 @@ func visitReferenceDeclaredType(declared parse.DeclaredType, currentFile string,
 		}
 	}
 	for _, child := range declaredTypeChildren(declared) {
-		visitReferenceDeclaredType(child, currentFile, prog, rootFile, targetKind, targetName, targetDef, add)
+		visitReferenceDeclaredType(child, currentFile, source, prog, rootFile, targetKind, targetName, targetDef, add)
 	}
 }
 

--- a/compiler/lsp/rename.go
+++ b/compiler/lsp/rename.go
@@ -89,7 +89,7 @@ func resolveRenameTarget(source string, filePath string, position protocol.Posit
 	if prog == nil {
 		return nil
 	}
-	if resolved := findReferenceDeclarationTarget(prog.Statements, target, filePath, prog); resolved != nil {
+	if resolved := findReferenceDeclarationTarget(prog.Statements, target, filePath, source, prog); resolved != nil {
 		return resolved
 	}
 	expr := findInStmts(prog.Statements, target)

--- a/compiler/lsp/server.go
+++ b/compiler/lsp/server.go
@@ -70,13 +70,48 @@ func (s *Server) Run(ctx context.Context) error {
 	conn := jsonrpc2.NewConn(stream)
 	s.conn = conn
 
-	handler := protocol.Handlers(
-		jsonrpc2.Handler(s.dispatch),
-	)
-
-	conn.Go(ctx, handler)
+	conn.Go(ctx, s.jsonRPCHandler())
 	<-conn.Done()
 	return conn.Err()
+}
+
+func (s *Server) jsonRPCHandler() jsonrpc2.Handler {
+	return protocol.CancelHandler(
+		concurrentRequestHandler(
+			jsonrpc2.ReplyHandler(jsonrpc2.Handler(s.dispatch)),
+		),
+	)
+}
+
+// concurrentRequestHandler runs feature requests concurrently while preserving
+// lifecycle and document-sync ordering on the reader goroutine.
+func concurrentRequestHandler(handler jsonrpc2.Handler) jsonrpc2.Handler {
+	return func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		if handleRequestInline(req.Method()) {
+			return handler(ctx, reply, req)
+		}
+
+		go func() {
+			_ = handler(ctx, reply, req)
+		}()
+		return nil
+	}
+}
+
+func handleRequestInline(method string) bool {
+	switch method {
+	case protocol.MethodInitialize,
+		protocol.MethodInitialized,
+		protocol.MethodShutdown,
+		protocol.MethodExit,
+		protocol.MethodTextDocumentDidOpen,
+		protocol.MethodTextDocumentDidChange,
+		protocol.MethodTextDocumentDidSave,
+		protocol.MethodTextDocumentDidClose:
+		return true
+	default:
+		return false
+	}
 }
 
 // dispatch routes incoming LSP requests and notifications to registered handlers.

--- a/compiler/lsp/server.go
+++ b/compiler/lsp/server.go
@@ -9,9 +9,11 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	"time"
 
 	"go.lsp.dev/jsonrpc2"
 	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
 )
 
 // stdio wraps os.Stdin and os.Stdout into a single io.ReadWriteCloser.
@@ -36,14 +38,23 @@ type Server struct {
 	handlers    map[string]jsonrpc2.Handler
 	conn        jsonrpc2.Conn
 	projectRoot string
+
+	diagnosticsMu        sync.Mutex
+	diagnosticsTimers    map[uri.URI]*time.Timer
+	diagnosticsDelay     time.Duration
+	diagnosticsPublisher func(context.Context, uri.URI)
 }
 
 // NewServer creates a new Ard LSP server.
 func NewServer() *Server {
 	s := &Server{
-		cache:    NewDocumentCache(),
-		handlers: make(map[string]jsonrpc2.Handler),
+		cache:                NewDocumentCache(),
+		handlers:             make(map[string]jsonrpc2.Handler),
+		diagnosticsTimers:    make(map[uri.URI]*time.Timer),
+		diagnosticsDelay:     100 * time.Millisecond,
+		diagnosticsPublisher: nil,
 	}
+	s.diagnosticsPublisher = s.publishDiagnostics
 	s.registerHandlers()
 	return s
 }
@@ -185,6 +196,38 @@ func (s *Server) handleExit(ctx context.Context, reply jsonrpc2.Replier, req jso
 	return reply(ctx, nil, nil)
 }
 
+func (s *Server) scheduleDiagnostics(docURI uri.URI) {
+	if s.diagnosticsDelay <= 0 {
+		go s.runDiagnostics(docURI)
+		return
+	}
+
+	s.diagnosticsMu.Lock()
+	defer s.diagnosticsMu.Unlock()
+	if timer := s.diagnosticsTimers[docURI]; timer != nil {
+		timer.Stop()
+	}
+	s.diagnosticsTimers[docURI] = time.AfterFunc(s.diagnosticsDelay, func() {
+		s.diagnosticsMu.Lock()
+		delete(s.diagnosticsTimers, docURI)
+		s.diagnosticsMu.Unlock()
+		s.runDiagnostics(docURI)
+	})
+}
+
+func (s *Server) runDiagnostics(docURI uri.URI) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, "ard-lsp panic publishing diagnostics for %s: %v\n%s", docURI, r, debug.Stack())
+		}
+	}()
+	publisher := s.diagnosticsPublisher
+	if publisher == nil {
+		publisher = s.publishDiagnostics
+	}
+	publisher(context.Background(), docURI)
+}
+
 //-------------------------------------------------------------------------
 // Document sync handlers
 //-------------------------------------------------------------------------
@@ -198,10 +241,10 @@ func (s *Server) handleDidOpen(ctx context.Context, reply jsonrpc2.Replier, req 
 	s.cache.Open(
 		params.TextDocument.URI,
 		string(params.TextDocument.LanguageID),
-		1,
+		params.TextDocument.Version,
 		params.TextDocument.Text,
 	)
-	s.publishDiagnostics(ctx, params.TextDocument.URI)
+	s.scheduleDiagnostics(params.TextDocument.URI)
 
 	return reply(ctx, nil, nil)
 }
@@ -217,7 +260,7 @@ func (s *Server) handleDidChange(ctx context.Context, reply jsonrpc2.Replier, re
 		s.cache.Update(params.TextDocument.URI, params.TextDocument.Version, change.Text)
 	}
 
-	s.publishDiagnostics(ctx, params.TextDocument.URI)
+	s.scheduleDiagnostics(params.TextDocument.URI)
 
 	return reply(ctx, nil, nil)
 }
@@ -233,7 +276,7 @@ func (s *Server) handleDidClose(ctx context.Context, reply jsonrpc2.Replier, req
 	}
 
 	s.cache.Close(params.TextDocument.URI)
-	s.publishDiagnostics(ctx, params.TextDocument.URI)
+	s.scheduleDiagnostics(params.TextDocument.URI)
 
 	return reply(ctx, nil, nil)
 }

--- a/compiler/lsp/server.go
+++ b/compiler/lsp/server.go
@@ -43,6 +43,7 @@ type Server struct {
 	diagnosticsTimers    map[uri.URI]*time.Timer
 	diagnosticsDelay     time.Duration
 	diagnosticsPublisher func(context.Context, uri.URI)
+	diagnosticsAnalyzer  diagnosticAnalyzer
 }
 
 // NewServer creates a new Ard LSP server.
@@ -53,6 +54,7 @@ func NewServer() *Server {
 		diagnosticsTimers:    make(map[uri.URI]*time.Timer),
 		diagnosticsDelay:     100 * time.Millisecond,
 		diagnosticsPublisher: nil,
+		diagnosticsAnalyzer:  parseAndCheckWithOverlays,
 	}
 	s.diagnosticsPublisher = s.publishDiagnostics
 	s.registerHandlers()

--- a/compiler/lsp/server.go
+++ b/compiler/lsp/server.go
@@ -330,7 +330,11 @@ func (s *Server) handleHover(ctx context.Context, reply jsonrpc2.Replier, req js
 				info = nil
 			}
 		}()
-		info = computeHover(doc.Text, doc.URI.Filename(), params.Position)
+		filePath, ok := docFilePath(doc)
+		if !ok {
+			return
+		}
+		info = computeHover(doc.Text, filePath, params.Position)
 	}()
 
 	if info == nil || info.content == "" {
@@ -365,7 +369,11 @@ func (s *Server) handleDefinition(ctx context.Context, reply jsonrpc2.Replier, r
 				locations = []protocol.Location{}
 			}
 		}()
-		locations = computeDefinition(doc.Text, doc.URI.Filename(), params.Position)
+		filePath, ok := docFilePath(doc)
+		if !ok {
+			return
+		}
+		locations = computeDefinition(doc.Text, filePath, params.Position)
 	}()
 	if locations == nil {
 		locations = []protocol.Location{}
@@ -392,11 +400,12 @@ func (s *Server) handleReferences(ctx context.Context, reply jsonrpc2.Replier, r
 				locations = []protocol.Location{}
 			}
 		}()
-		overlays := map[string]string{}
-		for _, cached := range s.cache.Snapshot() {
-			overlays[cached.URI.Filename()] = cached.Text
+		filePath, ok := docFilePath(doc)
+		if !ok {
+			return
 		}
-		locations = computeReferencesWithOverlays(doc.Text, doc.URI.Filename(), params.Position, params.Context.IncludeDeclaration, overlays)
+		overlays := overlaySources(s.cache.Snapshot())
+		locations = computeReferencesWithOverlays(doc.Text, filePath, params.Position, params.Context.IncludeDeclaration, overlays)
 	}()
 	if locations == nil {
 		locations = []protocol.Location{}
@@ -433,7 +442,11 @@ func (s *Server) handleCompletion(ctx context.Context, reply jsonrpc2.Replier, r
 				items = []protocol.CompletionItem{}
 			}
 		}()
-		items = computeCompletions(doc.Text, doc.URI.Filename(), params.Position)
+		filePath, ok := docFilePath(doc)
+		if !ok {
+			return
+		}
+		items = computeCompletions(doc.Text, filePath, params.Position)
 	}()
 	if items == nil {
 		items = []protocol.CompletionItem{}
@@ -473,7 +486,10 @@ func (s *Server) handleFormatting(ctx context.Context, reply jsonrpc2.Replier, r
 		return reply(ctx, []protocol.TextEdit{}, nil)
 	}
 
-	filePath := doc.URI.Filename()
+	filePath, ok := docFilePath(doc)
+	if !ok {
+		return reply(ctx, []protocol.TextEdit{}, nil)
+	}
 	formatted, err := formatSource(doc.Text, filePath)
 	if err != nil || formatted == doc.Text {
 		return reply(ctx, []protocol.TextEdit{}, nil)
@@ -505,7 +521,11 @@ func (s *Server) handleCodeAction(ctx context.Context, reply jsonrpc2.Replier, r
 	if doc == nil {
 		return reply(ctx, []protocol.CodeAction{}, nil)
 	}
-	formatted, err := formatSource(doc.Text, doc.URI.Filename())
+	filePath, ok := docFilePath(doc)
+	if !ok {
+		return reply(ctx, []protocol.CodeAction{}, nil)
+	}
+	formatted, err := formatSource(doc.Text, filePath)
 	if err != nil || formatted == doc.Text {
 		return reply(ctx, []protocol.CodeAction{}, nil)
 	}
@@ -539,7 +559,11 @@ func (s *Server) handleSignatureHelp(ctx context.Context, reply jsonrpc2.Replier
 				help = nil
 			}
 		}()
-		help = computeSignatureHelp(doc.Text, doc.URI.Filename(), params.Position)
+		filePath, ok := docFilePath(doc)
+		if !ok {
+			return
+		}
+		help = computeSignatureHelp(doc.Text, filePath, params.Position)
 	}()
 
 	return reply(ctx, help, nil)
@@ -556,7 +580,11 @@ func (s *Server) handleDocumentHighlight(ctx context.Context, reply jsonrpc2.Rep
 		return reply(ctx, []protocol.DocumentHighlight{}, nil)
 	}
 
-	highlights := computeDocumentHighlights(doc.Text, doc.URI.Filename(), params.Position)
+	filePath, ok := docFilePath(doc)
+	if !ok {
+		return reply(ctx, []protocol.DocumentHighlight{}, nil)
+	}
+	highlights := computeDocumentHighlights(doc.Text, filePath, params.Position)
 	if highlights == nil {
 		highlights = []protocol.DocumentHighlight{}
 	}
@@ -572,7 +600,11 @@ func (s *Server) handlePrepareRename(ctx context.Context, reply jsonrpc2.Replier
 	if doc == nil {
 		return reply(ctx, nil, nil)
 	}
-	rng := prepareRename(doc.Text, doc.URI.Filename(), params.Position)
+	filePath, ok := docFilePath(doc)
+	if !ok {
+		return reply(ctx, nil, nil)
+	}
+	rng := prepareRename(doc.Text, filePath, params.Position)
 	return reply(ctx, rng, nil)
 }
 
@@ -585,10 +617,11 @@ func (s *Server) handleRename(ctx context.Context, reply jsonrpc2.Replier, req j
 	if doc == nil {
 		return reply(ctx, nil, nil)
 	}
-	overlays := map[string]string{}
-	for _, cached := range s.cache.Snapshot() {
-		overlays[cached.URI.Filename()] = cached.Text
+	filePath, ok := docFilePath(doc)
+	if !ok {
+		return reply(ctx, nil, nil)
 	}
-	edit := computeRename(doc.Text, doc.URI.Filename(), params.Position, params.NewName, overlays)
+	overlays := overlaySources(s.cache.Snapshot())
+	edit := computeRename(doc.Text, filePath, params.Position, params.NewName, overlays)
 	return reply(ctx, edit, nil)
 }

--- a/compiler/lsp/server.go
+++ b/compiler/lsp/server.go
@@ -34,7 +34,6 @@ func (s *stdio) Close() error {
 // Server is the Ard LSP server.
 type Server struct {
 	cache       *DocumentCache
-	mu          sync.Mutex
 	handlers    map[string]jsonrpc2.Handler
 	conn        jsonrpc2.Conn
 	projectRoot string
@@ -99,12 +98,6 @@ func (s *Server) dispatch(ctx context.Context, reply jsonrpc2.Replier, req jsonr
 			err = fmt.Errorf("internal server error after reply handling %s: %v", method, r)
 		}
 	}()
-
-	// LSP clients may send feature requests concurrently. The current hover,
-	// definition, references, and signature-help paths share parse/type-resolution
-	// caches, so serialize handlers until those caches are request-scoped.
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if handler, ok := s.handlers[method]; ok {
 		return handler(ctx, safeReply, req)

--- a/compiler/lsp/server.go
+++ b/compiler/lsp/server.go
@@ -160,7 +160,7 @@ func (s *Server) handleInitialize(ctx context.Context, reply jsonrpc2.Replier, r
 
 	result := &protocol.InitializeResult{
 		Capabilities: protocol.ServerCapabilities{
-			TextDocumentSync:       protocol.TextDocumentSyncKindFull,
+			TextDocumentSync:       protocol.TextDocumentSyncKindIncremental,
 			HoverProvider:          true,
 			DefinitionProvider:     true,
 			ReferencesProvider:     true,
@@ -217,6 +217,12 @@ func (s *Server) scheduleDiagnostics(docURI uri.URI) {
 	})
 }
 
+func (s *Server) scheduleDiagnosticsForOpenDocuments() {
+	for _, doc := range s.cache.Snapshot() {
+		s.scheduleDiagnostics(doc.URI)
+	}
+}
+
 func (s *Server) runDiagnostics(docURI uri.URI) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -234,6 +240,17 @@ func (s *Server) runDiagnostics(docURI uri.URI) {
 // Document sync handlers
 //-------------------------------------------------------------------------
 
+type didChangeParams struct {
+	TextDocument   protocol.VersionedTextDocumentIdentifier `json:"textDocument"`
+	ContentChanges []documentContentChange                  `json:"contentChanges"`
+}
+
+type documentContentChange struct {
+	Range       *protocol.Range `json:"range,omitempty"`
+	RangeLength *uint32         `json:"rangeLength,omitempty"`
+	Text        string          `json:"text"`
+}
+
 func (s *Server) handleDidOpen(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
 	var params protocol.DidOpenTextDocumentParams
 	if err := json.Unmarshal(req.Params(), &params); err != nil {
@@ -246,23 +263,29 @@ func (s *Server) handleDidOpen(ctx context.Context, reply jsonrpc2.Replier, req 
 		params.TextDocument.Version,
 		params.TextDocument.Text,
 	)
-	s.scheduleDiagnostics(params.TextDocument.URI)
+	s.scheduleDiagnosticsForOpenDocuments()
 
 	return reply(ctx, nil, nil)
 }
 
 func (s *Server) handleDidChange(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-	var params protocol.DidChangeTextDocumentParams
+	var params didChangeParams
 	if err := json.Unmarshal(req.Params(), &params); err != nil {
 		return reply(ctx, nil, fmt.Errorf("%s: %w", jsonrpc2.ErrParse, err))
 	}
 
 	if len(params.ContentChanges) > 0 {
-		change := params.ContentChanges[len(params.ContentChanges)-1]
-		s.cache.Update(params.TextDocument.URI, params.TextDocument.Version, change.Text)
+		doc := s.cache.Get(params.TextDocument.URI)
+		if doc != nil {
+			updated, err := applyDocumentChanges(doc.Text, params.ContentChanges)
+			if err != nil {
+				return reply(ctx, nil, fmt.Errorf("invalid document change: %w", err))
+			}
+			s.cache.Update(params.TextDocument.URI, params.TextDocument.Version, updated)
+		}
 	}
 
-	s.scheduleDiagnostics(params.TextDocument.URI)
+	s.scheduleDiagnosticsForOpenDocuments()
 
 	return reply(ctx, nil, nil)
 }
@@ -279,6 +302,7 @@ func (s *Server) handleDidClose(ctx context.Context, reply jsonrpc2.Replier, req
 
 	s.cache.Close(params.TextDocument.URI)
 	s.scheduleDiagnostics(params.TextDocument.URI)
+	s.scheduleDiagnosticsForOpenDocuments()
 
 	return reply(ctx, nil, nil)
 }

--- a/compiler/lsp/server_test.go
+++ b/compiler/lsp/server_test.go
@@ -354,6 +354,45 @@ func assertDocumentSyncRepliesBeforeDiagnostics(t *testing.T, handle func(*Serve
 	}
 }
 
+func TestDispatchDoesNotSerializeIndependentHandlers(t *testing.T) {
+	server := NewServer()
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	server.handlers["ard/block"] = func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		entered <- struct{}{}
+		<-release
+		return reply(ctx, nil, nil)
+	}
+
+	dispatch := func(id int32, done chan<- error) {
+		req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(id), "ard/block", nil)
+		if err != nil {
+			done <- err
+			return
+		}
+		done <- server.dispatch(context.Background(), func(ctx context.Context, result interface{}, replyErr error) error { return replyErr }, req)
+	}
+
+	done := make(chan error, 2)
+	go dispatch(1, done)
+	go dispatch(2, done)
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-entered:
+		case <-time.After(500 * time.Millisecond):
+			close(release)
+			t.Fatal("expected concurrent handlers to enter without waiting for each other")
+		}
+	}
+	close(release)
+	for i := 0; i < 2; i++ {
+		if err := <-done; err != nil {
+			t.Fatalf("dispatch error: %v", err)
+		}
+	}
+}
+
 // TestCheckerDiagnosticsToLSP verifies the diagnostic conversion handles edge cases.
 func TestCheckerDiagnosticsToLSP(t *testing.T) {
 	// Nil input should produce empty slice (not nil) so JSON is [] not null

--- a/compiler/lsp/server_test.go
+++ b/compiler/lsp/server_test.go
@@ -354,7 +354,7 @@ func assertDocumentSyncRepliesBeforeDiagnostics(t *testing.T, handle func(*Serve
 	}
 }
 
-func TestDispatchDoesNotSerializeIndependentHandlers(t *testing.T) {
+func TestJSONRPCHandlerDoesNotSerializeFeatureRequests(t *testing.T) {
 	server := NewServer()
 	entered := make(chan struct{}, 2)
 	release := make(chan struct{})
@@ -364,32 +364,116 @@ func TestDispatchDoesNotSerializeIndependentHandlers(t *testing.T) {
 		return reply(ctx, nil, nil)
 	}
 
-	dispatch := func(id int32, done chan<- error) {
-		req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(id), "ard/block", nil)
-		if err != nil {
-			done <- err
-			return
-		}
-		done <- server.dispatch(context.Background(), func(ctx context.Context, result interface{}, replyErr error) error { return replyErr }, req)
+	handler := server.jsonRPCHandler()
+	replied := make(chan error, 2)
+	reply := func(ctx context.Context, result interface{}, replyErr error) error {
+		replied <- replyErr
+		return nil
 	}
 
-	done := make(chan error, 2)
-	go dispatch(1, done)
-	go dispatch(2, done)
+	for id := int32(1); id <= 2; id++ {
+		req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(id), "ard/block", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := handler(context.Background(), reply, req); err != nil {
+			t.Fatalf("handler returned error: %v", err)
+		}
+	}
 
 	for i := 0; i < 2; i++ {
 		select {
 		case <-entered:
 		case <-time.After(500 * time.Millisecond):
 			close(release)
-			t.Fatal("expected concurrent handlers to enter without waiting for each other")
+			t.Fatal("expected concurrent feature handlers to enter without waiting for each other")
 		}
 	}
 	close(release)
 	for i := 0; i < 2; i++ {
-		if err := <-done; err != nil {
-			t.Fatalf("dispatch error: %v", err)
+		select {
+		case err := <-replied:
+			if err != nil {
+				t.Fatalf("reply error: %v", err)
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("expected feature handler reply")
 		}
+	}
+}
+
+func TestJSONRPCHandlerDoesNotBlockDocumentSyncBehindFeatureRequests(t *testing.T) {
+	server := NewServer()
+	server.diagnosticsDelay = 0
+	server.diagnosticsPublisher = func(context.Context, uri.URI) {}
+	docURI := uri.New("file:///main.ard")
+	server.cache.Open(docURI, "ard", 1, "let x = 1")
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	server.handlers["ard/block"] = func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		close(entered)
+		<-release
+		return reply(ctx, nil, nil)
+	}
+
+	handler := server.jsonRPCHandler()
+	replied := make(chan error, 2)
+	reply := func(ctx context.Context, result interface{}, replyErr error) error {
+		replied <- replyErr
+		return nil
+	}
+
+	blockingReq, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), "ard/block", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handler(context.Background(), reply, blockingReq); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-entered:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("blocking feature request did not start")
+	}
+
+	changeReq, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(2), protocol.MethodTextDocumentDidChange, didChangeParams{
+		TextDocument: protocol.VersionedTextDocumentIdentifier{
+			TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: docURI},
+			Version:                2,
+		},
+		ContentChanges: []documentContentChange{{Text: "let x = 2"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handler(context.Background(), reply, changeReq); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := server.cache.Get(docURI).Text; got != "let x = 2" {
+		close(release)
+		t.Fatalf("didChange was blocked behind feature request; text = %q", got)
+	}
+	select {
+	case err := <-replied:
+		if err != nil {
+			close(release)
+			t.Fatalf("didChange reply error: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		close(release)
+		t.Fatal("didChange did not reply while feature request was blocked")
+	}
+
+	close(release)
+	select {
+	case err := <-replied:
+		if err != nil {
+			t.Fatalf("feature reply error: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("feature request did not finish")
 	}
 }
 

--- a/compiler/lsp/server_test.go
+++ b/compiler/lsp/server_test.go
@@ -94,6 +94,87 @@ func TestDispatchRecoversFromPanic(t *testing.T) {
 	}
 }
 
+func TestDocumentSyncRepliesBeforeDiagnosticsComplete(t *testing.T) {
+	t.Run("didOpen", func(t *testing.T) {
+		assertDocumentSyncRepliesBeforeDiagnostics(t, func(server *Server, docURI uri.URI, reply jsonrpc2.Replier) error {
+			req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), protocol.MethodTextDocumentDidOpen, protocol.DidOpenTextDocumentParams{
+				TextDocument: protocol.TextDocumentItem{
+					URI:        docURI,
+					LanguageID: protocol.LanguageIdentifier("ard"),
+					Version:    7,
+					Text:       "let x = 1",
+				},
+			})
+			if err != nil {
+				return err
+			}
+			return server.handleDidOpen(context.Background(), reply, req)
+		})
+	})
+
+	t.Run("didChange", func(t *testing.T) {
+		assertDocumentSyncRepliesBeforeDiagnostics(t, func(server *Server, docURI uri.URI, reply jsonrpc2.Replier) error {
+			server.cache.Open(docURI, "ard", 1, "let x = 1")
+			req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), protocol.MethodTextDocumentDidChange, protocol.DidChangeTextDocumentParams{
+				TextDocument: protocol.VersionedTextDocumentIdentifier{
+					TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: docURI},
+					Version:                2,
+				},
+				ContentChanges: []protocol.TextDocumentContentChangeEvent{{Text: "let x = 2"}},
+			})
+			if err != nil {
+				return err
+			}
+			return server.handleDidChange(context.Background(), reply, req)
+		})
+	})
+}
+
+func assertDocumentSyncRepliesBeforeDiagnostics(t *testing.T, handle func(*Server, uri.URI, jsonrpc2.Replier) error) {
+	t.Helper()
+	server := NewServer()
+	server.diagnosticsDelay = 0
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	defer close(release)
+	server.diagnosticsPublisher = func(context.Context, uri.URI) {
+		started <- struct{}{}
+		<-release
+	}
+
+	replied := make(chan struct{}, 1)
+	reply := jsonrpc2.Replier(func(ctx context.Context, result interface{}, err error) error {
+		replied <- struct{}{}
+		return nil
+	})
+	done := make(chan error, 1)
+	docURI := uri.New("file:///test.ard")
+	go func() {
+		done <- handle(server, docURI, reply)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("diagnostics were not scheduled")
+	}
+
+	select {
+	case <-replied:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("document sync handler waited for diagnostics before replying")
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("handler returned error: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("document sync handler did not return")
+	}
+}
+
 // TestCheckerDiagnosticsToLSP verifies the diagnostic conversion handles edge cases.
 func TestCheckerDiagnosticsToLSP(t *testing.T) {
 	// Nil input should produce empty slice (not nil) so JSON is [] not null

--- a/compiler/lsp/server_test.go
+++ b/compiler/lsp/server_test.go
@@ -493,6 +493,64 @@ func TestFormatSource(t *testing.T) {
 	}
 }
 
+func TestFeatureHandlersIgnoreNonFileDocuments(t *testing.T) {
+	server := NewServer()
+	docURI := uri.URI("untitled:Untitled-1")
+	server.cache.Open(docURI, "ard", 1, "let   x  =  5")
+
+	formatReq, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), protocol.MethodTextDocumentFormatting, protocol.DocumentFormattingParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var edits []protocol.TextEdit
+	formatReply := jsonrpc2.Replier(func(ctx context.Context, result interface{}, err error) error {
+		if err != nil {
+			return err
+		}
+		var ok bool
+		edits, ok = result.([]protocol.TextEdit)
+		if !ok {
+			t.Fatalf("formatting result = %T, want []protocol.TextEdit", result)
+		}
+		return nil
+	})
+	if err := server.handleFormatting(context.Background(), formatReply, formatReq); err != nil {
+		t.Fatal(err)
+	}
+	if len(edits) != 0 {
+		t.Fatalf("expected no formatting edits for non-file URI, got %#v", edits)
+	}
+
+	hoverReq, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(2), protocol.MethodTextDocumentHover, protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+			Position:     protocol.Position{Line: 0, Character: 1},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	replied := false
+	hoverReply := jsonrpc2.Replier(func(ctx context.Context, result interface{}, err error) error {
+		replied = true
+		if err != nil {
+			return err
+		}
+		if result != nil {
+			t.Fatalf("expected nil hover for non-file URI, got %#v", result)
+		}
+		return nil
+	})
+	if err := server.handleHover(context.Background(), hoverReply, hoverReq); err != nil {
+		t.Fatal(err)
+	}
+	if !replied {
+		t.Fatal("expected hover handler to reply")
+	}
+}
+
 func TestCodeActionRemoveUnusedImports(t *testing.T) {
 	server := NewServer()
 	docURI := uri.New("file:///test.ard")

--- a/compiler/lsp/server_test.go
+++ b/compiler/lsp/server_test.go
@@ -115,12 +115,12 @@ func TestDocumentSyncRepliesBeforeDiagnosticsComplete(t *testing.T) {
 	t.Run("didChange", func(t *testing.T) {
 		assertDocumentSyncRepliesBeforeDiagnostics(t, func(server *Server, docURI uri.URI, reply jsonrpc2.Replier) error {
 			server.cache.Open(docURI, "ard", 1, "let x = 1")
-			req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), protocol.MethodTextDocumentDidChange, protocol.DidChangeTextDocumentParams{
+			req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), protocol.MethodTextDocumentDidChange, didChangeParams{
 				TextDocument: protocol.VersionedTextDocumentIdentifier{
 					TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: docURI},
 					Version:                2,
 				},
-				ContentChanges: []protocol.TextDocumentContentChangeEvent{{Text: "let x = 2"}},
+				ContentChanges: []documentContentChange{{Text: "let x = 2"}},
 			})
 			if err != nil {
 				return err
@@ -128,6 +128,185 @@ func TestDocumentSyncRepliesBeforeDiagnosticsComplete(t *testing.T) {
 			return server.handleDidChange(context.Background(), reply, req)
 		})
 	})
+}
+
+func TestDidChangeAppliesFullAndIncrementalChanges(t *testing.T) {
+	t.Run("full document change", func(t *testing.T) {
+		server := NewServer()
+		server.diagnosticsDelay = 0
+		server.diagnosticsPublisher = func(context.Context, uri.URI) {}
+		docURI := uri.New("file:///main.ard")
+		server.cache.Open(docURI, "ard", 1, "let x = 1")
+
+		req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), protocol.MethodTextDocumentDidChange, didChangeParams{
+			TextDocument: protocol.VersionedTextDocumentIdentifier{
+				TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: docURI},
+				Version:                2,
+			},
+			ContentChanges: []documentContentChange{{Text: "let x = 2"}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		reply := jsonrpc2.Replier(func(ctx context.Context, result interface{}, err error) error { return err })
+		if err := server.handleDidChange(context.Background(), reply, req); err != nil {
+			t.Fatal(err)
+		}
+		if got := server.cache.Get(docURI).Text; got != "let x = 2" {
+			t.Fatalf("text = %q, want full replacement", got)
+		}
+	})
+
+	t.Run("incremental range change", func(t *testing.T) {
+		server := NewServer()
+		server.diagnosticsDelay = 0
+		server.diagnosticsPublisher = func(context.Context, uri.URI) {}
+		docURI := uri.New("file:///main.ard")
+		server.cache.Open(docURI, "ard", 1, "let x = 1\nlet y = 2\n")
+
+		req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), protocol.MethodTextDocumentDidChange, didChangeParams{
+			TextDocument: protocol.VersionedTextDocumentIdentifier{
+				TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: docURI},
+				Version:                2,
+			},
+			ContentChanges: []documentContentChange{{
+				Range: &protocol.Range{
+					Start: protocol.Position{Line: 0, Character: 8},
+					End:   protocol.Position{Line: 0, Character: 9},
+				},
+				Text: "3",
+			}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		reply := jsonrpc2.Replier(func(ctx context.Context, result interface{}, err error) error { return err })
+		if err := server.handleDidChange(context.Background(), reply, req); err != nil {
+			t.Fatal(err)
+		}
+		if got := server.cache.Get(docURI).Text; got != "let x = 3\nlet y = 2\n" {
+			t.Fatalf("text = %q, want incremental replacement", got)
+		}
+	})
+}
+
+func TestApplyDocumentChangesHandlesUTF16AndClamping(t *testing.T) {
+	updated, err := applyDocumentChanges("a😀b", []documentContentChange{{
+		Range: &protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 3},
+			End:   protocol.Position{Line: 0, Character: 4},
+		},
+		Text: "c",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != "a😀c" {
+		t.Fatalf("updated = %q, want UTF-16 range replacement", updated)
+	}
+
+	updated, err = applyDocumentChanges("abc\n", []documentContentChange{{
+		Range: &protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 99},
+			End:   protocol.Position{Line: 0, Character: 99},
+		},
+		Text: "!",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != "abc!\n" {
+		t.Fatalf("updated = %q, want line-end clamped insertion", updated)
+	}
+
+	updated, err = applyDocumentChanges("abc", []documentContentChange{{
+		Range: &protocol.Range{
+			Start: protocol.Position{Line: 99, Character: 0},
+			End:   protocol.Position{Line: 99, Character: 0},
+		},
+		Text: "!",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != "abc!" {
+		t.Fatalf("updated = %q, want EOF clamped insertion", updated)
+	}
+}
+
+func TestDocumentSyncSchedulesDiagnosticsForAllOpenDocuments(t *testing.T) {
+	t.Run("didChange", func(t *testing.T) {
+		server := NewServer()
+		server.diagnosticsDelay = 0
+		scheduled := make(chan uri.URI, 4)
+		server.diagnosticsPublisher = func(ctx context.Context, docURI uri.URI) {
+			scheduled <- docURI
+		}
+		mainURI := uri.New("file:///main.ard")
+		toolsURI := uri.New("file:///tools.ard")
+		server.cache.Open(mainURI, "ard", 1, "use app/tools\nlet x = tools::value()")
+		server.cache.Open(toolsURI, "ard", 1, "fn value() Int { 1 }")
+
+		req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), protocol.MethodTextDocumentDidChange, didChangeParams{
+			TextDocument: protocol.VersionedTextDocumentIdentifier{
+				TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: toolsURI},
+				Version:                2,
+			},
+			ContentChanges: []documentContentChange{{Text: "fn value() Int { 2 }"}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		reply := jsonrpc2.Replier(func(ctx context.Context, result interface{}, err error) error { return err })
+		if err := server.handleDidChange(context.Background(), reply, req); err != nil {
+			t.Fatal(err)
+		}
+
+		assertScheduledDiagnostics(t, scheduled, mainURI, toolsURI)
+	})
+
+	t.Run("didClose", func(t *testing.T) {
+		server := NewServer()
+		server.diagnosticsDelay = 0
+		scheduled := make(chan uri.URI, 4)
+		server.diagnosticsPublisher = func(ctx context.Context, docURI uri.URI) {
+			scheduled <- docURI
+		}
+		mainURI := uri.New("file:///main.ard")
+		toolsURI := uri.New("file:///tools.ard")
+		server.cache.Open(mainURI, "ard", 1, "use app/tools\nlet x = tools::value()")
+		server.cache.Open(toolsURI, "ard", 1, "fn value() Int { 1 }")
+
+		req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), protocol.MethodTextDocumentDidClose, protocol.DidCloseTextDocumentParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: toolsURI},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		reply := jsonrpc2.Replier(func(ctx context.Context, result interface{}, err error) error { return err })
+		if err := server.handleDidClose(context.Background(), reply, req); err != nil {
+			t.Fatal(err)
+		}
+
+		assertScheduledDiagnostics(t, scheduled, mainURI, toolsURI)
+	})
+}
+
+func assertScheduledDiagnostics(t *testing.T, scheduled <-chan uri.URI, expected ...uri.URI) {
+	t.Helper()
+	remaining := map[uri.URI]bool{}
+	for _, docURI := range expected {
+		remaining[docURI] = true
+	}
+	deadline := time.After(time.Second)
+	for len(remaining) > 0 {
+		select {
+		case got := <-scheduled:
+			delete(remaining, got)
+		case <-deadline:
+			t.Fatalf("missing scheduled diagnostics for %#v", remaining)
+		}
+	}
 }
 
 func assertDocumentSyncRepliesBeforeDiagnostics(t *testing.T, handle func(*Server, uri.URI, jsonrpc2.Replier) error) {

--- a/compiler/lsp/uris.go
+++ b/compiler/lsp/uris.go
@@ -1,0 +1,45 @@
+package lsp
+
+import (
+	"fmt"
+	"net/url"
+
+	"go.lsp.dev/uri"
+)
+
+func filePathFromURI(u uri.URI) (path string, err error) {
+	parsed, err := url.ParseRequestURI(string(u))
+	if err != nil {
+		return "", fmt.Errorf("unsupported document URI %q: %w", u, err)
+	}
+	if parsed.Scheme != uri.FileScheme {
+		return "", fmt.Errorf("unsupported document URI %q: only file:// URIs are supported", u)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			path = ""
+			err = fmt.Errorf("unsupported document URI %q: %v", u, r)
+		}
+	}()
+	return u.Filename(), nil
+}
+
+func docFilePath(doc *Doc) (string, bool) {
+	if doc == nil {
+		return "", false
+	}
+	path, err := filePathFromURI(doc.URI)
+	return path, err == nil
+}
+
+func overlaySources(docs []Doc) map[string]string {
+	overlays := map[string]string{}
+	for i := range docs {
+		path, ok := docFilePath(&docs[i])
+		if !ok {
+			continue
+		}
+		overlays[path] = docs[i].Text
+	}
+	return overlays
+}


### PR DESCRIPTION
## Summary
- Run LSP feature handlers concurrently while keeping lifecycle/document-sync handlers ordered
- Publish diagnostics asynchronously with stale-result/version protections and panic recovery
- Avoid panics for non-file document URIs and remove package-global parse/reference state

## Tests
- cd compiler && go test ./lsp -count=1
- cd compiler && go test -race ./lsp -count=1
- cd compiler && go generate ./std_lib/ffi && go test ./...
