### PR TITLE
fix(air): lower module-level let bindings

### DIFF
--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -41,6 +41,7 @@ type lowerer struct {
 	impls        map[string]ImplID
 	functions    map[string]FunctionID
 	externs      map[string]ExternID
+	globals      map[string]GlobalID
 
 	loweringModules map[string]bool
 	loweredModules  map[string]bool
@@ -72,6 +73,7 @@ func newLowerer(options LowerOptions) *lowerer {
 		impls:        map[string]ImplID{},
 		functions:    map[string]FunctionID{},
 		externs:      map[string]ExternID{},
+		globals:      map[string]GlobalID{},
 
 		loweringModules: map[string]bool{},
 		loweredModules:  map[string]bool{},
@@ -154,6 +156,15 @@ func (l *lowerer) lowerModule(module checker.Module) error {
 			mod.Types = appendUniqueType(mod.Types, typeID)
 		}
 
+		switch node := stmt.Stmt.(type) {
+		case *checker.VariableDef:
+			if !node.Mutable {
+				if _, err := l.declareGlobal(modID, node); err != nil {
+					return err
+				}
+			}
+		}
+
 		switch expr := stmt.Expr.(type) {
 		case *checker.FunctionDef:
 			if functionHasUnresolvedTypeVar(expr) || (!l.includeTests && expr.IsTest) {
@@ -185,6 +196,15 @@ func (l *lowerer) lowerModule(module checker.Module) error {
 		case *checker.Enum:
 			if err := l.declareTraitImplsForType(modID, node); err != nil {
 				return err
+			}
+		}
+	}
+
+	for i := range prog.Statements {
+		stmt := prog.Statements[i]
+		if def, ok := stmt.Stmt.(*checker.VariableDef); ok && !def.Mutable {
+			if err := l.lowerGlobal(modID, def); err != nil {
+				return fmt.Errorf("lower global %s: %w", def.Name, err)
 			}
 		}
 	}
@@ -234,6 +254,46 @@ func (l *lowerer) internModule(path string) ModuleID {
 		Path: path,
 	})
 	return id
+}
+
+func (l *lowerer) declareGlobal(module ModuleID, def *checker.VariableDef) (GlobalID, error) {
+	key := globalKey(module, def.Name)
+	if id, ok := l.globals[key]; ok {
+		return id, nil
+	}
+	typeID, err := l.internType(def.Type())
+	if err != nil {
+		return NoGlobal, err
+	}
+	id := GlobalID(len(l.program.Globals))
+	l.globals[key] = id
+	l.program.Globals = append(l.program.Globals, Global{
+		ID:      id,
+		Module:  module,
+		Name:    def.Name,
+		Type:    typeID,
+		Mutable: def.Mutable,
+	})
+	l.program.Modules[module].Globals = appendUniqueGlobal(l.program.Modules[module].Globals, id)
+	return id, nil
+}
+
+func (l *lowerer) lowerGlobal(module ModuleID, def *checker.VariableDef) error {
+	id, ok := l.globals[globalKey(module, def.Name)]
+	if !ok {
+		return fmt.Errorf("global was not declared before lowering: %s", def.Name)
+	}
+	global := l.program.Globals[id]
+	fn := Function{Module: module, Name: "<global>"}
+	fl := l.newFunctionLowerer(&fn, nil, nil)
+	value, actualType, err := fl.lowerContextualExpr(def.Value, global.Type)
+	if err != nil {
+		return err
+	}
+	global.Type = actualType
+	global.Value = *value
+	l.program.Globals[id] = global
+	return nil
 }
 
 func (l *lowerer) declareFunction(module ModuleID, def *checker.FunctionDef) (FunctionID, error) {
@@ -2502,6 +2562,21 @@ func (fl *functionLowerer) lowerForLoop(loop *checker.ForLoop) ([]Stmt, error) {
 	return []Stmt{*init, Stmt{Kind: StmtWhile, Condition: condition, Body: body}}, nil
 }
 
+func (fl *functionLowerer) lowerFunctionTypeCall(name string, args []checker.Expression, target *Expr) (*Expr, error) {
+	if target == nil {
+		return nil, fmt.Errorf("function value call %s missing target", name)
+	}
+	loweredArgs, err := fl.lowerArgsForFunctionType(args, target.Type)
+	if err != nil {
+		return nil, err
+	}
+	typeInfo, ok := fl.l.typeInfo(target.Type)
+	if !ok || typeInfo.Kind != TypeFunction {
+		return nil, fmt.Errorf("%s is not a function", name)
+	}
+	return &Expr{Kind: ExprCallClosure, Type: typeInfo.Return, Target: target, Args: loweredArgs}, nil
+}
+
 func (fl *functionLowerer) lowerNonProducingBlock(stmts []checker.Statement) (Block, error) {
 	var block Block
 	for _, stmt := range stmts {
@@ -2521,6 +2596,9 @@ func (fl *functionLowerer) lowerExpr(expr checker.Expression) (*Expr, error) {
 			return nil, err
 		}
 		if !ok {
+			if global, ok := fl.l.lookupGlobalInModule(fl.fn.Module, e.Name); ok {
+				return &Expr{Kind: ExprLoadGlobal, Type: fl.l.program.Globals[global].Type, Global: global}, nil
+			}
 			return nil, fmt.Errorf("unknown local %s", e.Name)
 		}
 		return &Expr{Kind: ExprLoadLocal, Type: fl.fn.Locals[local].Type, Local: local}, nil
@@ -2531,6 +2609,9 @@ func (fl *functionLowerer) lowerExpr(expr checker.Expression) (*Expr, error) {
 			return nil, err
 		}
 		if !ok {
+			if global, ok := fl.l.lookupGlobalInModule(fl.fn.Module, e.Name()); ok {
+				return &Expr{Kind: ExprLoadGlobal, Type: fl.l.program.Globals[global].Type, Global: global}, nil
+			}
 			if def, ok := e.Type().(*checker.FunctionDef); ok {
 				functionType, err := fl.internType(e.Type())
 				if err != nil {
@@ -2553,15 +2634,14 @@ func (fl *functionLowerer) lowerExpr(expr checker.Expression) (*Expr, error) {
 		}
 		if ok && fl.localKind(local) == TypeFunction {
 			target := &Expr{Kind: ExprLoadLocal, Type: fl.fn.Locals[local].Type, Local: local}
-			args, err := fl.lowerArgsForFunctionType(e.Args, target.Type)
-			if err != nil {
-				return nil, err
+			return fl.lowerFunctionTypeCall(e.Name, e.Args, target)
+		}
+		if global, ok := fl.l.lookupGlobalInModule(fl.fn.Module, e.Name); ok {
+			globalType := fl.l.program.Globals[global].Type
+			if typeInfo, ok := fl.l.typeInfo(globalType); ok && typeInfo.Kind == TypeFunction {
+				target := &Expr{Kind: ExprLoadGlobal, Type: globalType, Global: global}
+				return fl.lowerFunctionTypeCall(e.Name, e.Args, target)
 			}
-			typeInfo, ok := fl.l.typeInfo(target.Type)
-			if !ok || typeInfo.Kind != TypeFunction {
-				return nil, fmt.Errorf("local %s is not a function", e.Name)
-			}
-			return &Expr{Kind: ExprCallClosure, Type: typeInfo.Return, Target: target, Args: args}, nil
 		}
 	}
 	typeID, err := fl.internType(expr.Type())
@@ -2604,15 +2684,14 @@ func (fl *functionLowerer) lowerExpr(expr checker.Expression) (*Expr, error) {
 	case *checker.FunctionCall:
 		if local, ok := fl.locals[e.Name]; ok && fl.localKind(local) == TypeFunction {
 			target := &Expr{Kind: ExprLoadLocal, Type: fl.fn.Locals[local].Type, Local: local}
-			args, err := fl.lowerArgsForFunctionType(e.Args, target.Type)
-			if err != nil {
-				return nil, err
+			return fl.lowerFunctionTypeCall(e.Name, e.Args, target)
+		}
+		if global, ok := fl.l.lookupGlobalInModule(fl.fn.Module, e.Name); ok {
+			globalType := fl.l.program.Globals[global].Type
+			if typeInfo, ok := fl.l.typeInfo(globalType); ok && typeInfo.Kind == TypeFunction {
+				target := &Expr{Kind: ExprLoadGlobal, Type: globalType, Global: global}
+				return fl.lowerFunctionTypeCall(e.Name, e.Args, target)
 			}
-			returnType := typeID
-			if typeInfo, ok := fl.l.typeInfo(target.Type); ok && typeInfo.Kind == TypeFunction {
-				returnType = typeInfo.Return
-			}
-			return &Expr{Kind: ExprCallClosure, Type: returnType, Target: target, Args: args}, nil
 		}
 		if e.ExternalBinding != "" {
 			signature, err := fl.signatureForCall(e)
@@ -3837,6 +3916,12 @@ func (fl *functionLowerer) lowerModuleSymbol(typeID TypeID, symbol *checker.Modu
 		return &Expr{Kind: ExprMakeClosure, Type: typeID, Function: id}, nil
 	}
 
+	if global, ok, err := fl.l.resolveModuleGlobal(symbol.Module, symbol.Symbol.Name); err != nil {
+		return nil, err
+	} else if ok {
+		return &Expr{Kind: ExprLoadGlobal, Type: fl.l.program.Globals[global].Type, Global: global}, nil
+	}
+
 	return nil, fmt.Errorf("unsupported AIR module symbol %s::%s of type %s", symbol.Module, symbol.Symbol.Name, symbol.Type().String())
 }
 
@@ -4112,6 +4197,11 @@ func (l *lowerer) lookupFunction(name string) (FunctionID, bool) {
 	return NoFunction, false
 }
 
+func (l *lowerer) lookupGlobalInModule(module ModuleID, name string) (GlobalID, bool) {
+	id, ok := l.globals[globalKey(module, name)]
+	return id, ok
+}
+
 func (l *lowerer) lookupFunctionInModule(modulePath, name string) (FunctionID, bool) {
 	moduleID, ok := l.moduleByPath[modulePath]
 	if !ok {
@@ -4215,6 +4305,32 @@ func (l *lowerer) ensureModuleTraitImplsDeclared(modulePath string) error {
 		}
 	}
 	return nil
+}
+
+func (l *lowerer) resolveModuleGlobal(modulePath, name string) (GlobalID, bool, error) {
+	moduleID, ok := l.moduleByPath[modulePath]
+	if ok {
+		if id, ok := l.lookupGlobalInModule(moduleID, name); ok {
+			return id, true, nil
+		}
+	}
+
+	mod, ok := l.moduleByName[modulePath]
+	if !ok {
+		return NoGlobal, false, nil
+	}
+	if mod.Program() == nil {
+		return NoGlobal, false, nil
+	}
+	if err := l.lowerModule(mod); err != nil {
+		return NoGlobal, false, err
+	}
+	moduleID, ok = l.moduleByPath[modulePath]
+	if !ok {
+		return NoGlobal, false, nil
+	}
+	id, ok := l.lookupGlobalInModule(moduleID, name)
+	return id, ok, nil
 }
 
 func (l *lowerer) resolveModuleFunction(modulePath, name string) (FunctionID, bool, error) {
@@ -4387,9 +4503,13 @@ func topLevelExecutableStatements(stmts []checker.Statement) []checker.Statement
 			continue
 		}
 		if stmt.Stmt != nil {
-			switch stmt.Stmt.(type) {
+			switch node := stmt.Stmt.(type) {
 			case *checker.StructDef, *checker.Enum, *checker.Union, *checker.ExternType:
 				continue
+			case *checker.VariableDef:
+				if !node.Mutable {
+					continue
+				}
 			}
 		}
 		filtered = append(filtered, stmt)
@@ -4407,6 +4527,15 @@ func sortedFieldNames(fields map[string]checker.Type) []string {
 }
 
 func appendUniqueType(items []TypeID, id TypeID) []TypeID {
+	for _, item := range items {
+		if item == id {
+			return items
+		}
+	}
+	return append(items, id)
+}
+
+func appendUniqueGlobal(items []GlobalID, id GlobalID) []GlobalID {
 	for _, item := range items {
 		if item == id {
 			return items
@@ -4435,6 +4564,10 @@ func appendUniqueModule(items []ModuleID, id ModuleID) []ModuleID {
 
 func functionKey(module ModuleID, name string) string {
 	return fmt.Sprintf("%d:%s", module, name)
+}
+
+func globalKey(module ModuleID, name string) string {
+	return fmt.Sprintf("%d:global:%s", module, name)
 }
 
 func concreteFunctionKey(module ModuleID, name string, signature Signature) string {

--- a/compiler/air/lower_test.go
+++ b/compiler/air/lower_test.go
@@ -51,6 +51,30 @@ func TestLowerTinyProgram(t *testing.T) {
 	}
 }
 
+func TestLowerFunctionCanReadModuleLevelLet(t *testing.T) {
+	program := lowerSource(t, `
+		let refresh_event = "inbox.refresh"
+
+		fn event_name() Str {
+			refresh_event
+		}
+	`)
+
+	if len(program.Globals) != 1 {
+		t.Fatalf("global count = %d, want 1", len(program.Globals))
+	}
+	if program.Globals[0].Name != "refresh_event" {
+		t.Fatalf("global name = %q, want refresh_event", program.Globals[0].Name)
+	}
+	eventName := findFunction(t, program, "event_name")
+	if eventName.Body.Result == nil || eventName.Body.Result.Kind != ExprLoadGlobal {
+		t.Fatalf("event_name result = %#v, want ExprLoadGlobal", eventName.Body.Result)
+	}
+	if eventName.Body.Result.Global != program.Globals[0].ID {
+		t.Fatalf("event_name loads global %d, want %d", eventName.Body.Result.Global, program.Globals[0].ID)
+	}
+}
+
 func TestLowerOmitsTestsByDefault(t *testing.T) {
 	result := parse.Parse([]byte(`
 		fn main() Int { 1 }

--- a/compiler/air/nodes.go
+++ b/compiler/air/nodes.go
@@ -41,6 +41,7 @@ const (
 	ExprConstStr
 	ExprPanic
 	ExprLoadLocal
+	ExprLoadGlobal
 	ExprCall
 	ExprCallExtern
 	ExprMakeClosure
@@ -146,7 +147,8 @@ type Expr struct {
 	Discriminant int
 	Tag          uint32
 
-	Local LocalID
+	Local  LocalID
+	Global GlobalID
 
 	Function      FunctionID
 	Extern        ExternID

--- a/compiler/air/types.go
+++ b/compiler/air/types.go
@@ -4,6 +4,7 @@ type ModuleID int
 type TypeID int
 type FunctionID int
 type ExternID int
+type GlobalID int
 type LocalID int
 type TraitID int
 type ImplID int
@@ -11,6 +12,7 @@ type ImplID int
 const (
 	NoType     TypeID     = 0
 	NoFunction FunctionID = -1
+	NoGlobal   GlobalID   = -1
 )
 
 type Program struct {
@@ -19,6 +21,7 @@ type Program struct {
 	Traits    []Trait
 	Impls     []Impl
 	Externs   []Extern
+	Globals   []Global
 	Tests     []Test
 	Functions []Function
 	Entry     FunctionID
@@ -30,7 +33,17 @@ type Module struct {
 	Path      string
 	Imports   []ModuleID
 	Types     []TypeID
+	Globals   []GlobalID
 	Functions []FunctionID
+}
+
+type Global struct {
+	ID      GlobalID
+	Module  ModuleID
+	Name    string
+	Type    TypeID
+	Mutable bool
+	Value   Expr
 }
 
 type Function struct {

--- a/compiler/air/validate.go
+++ b/compiler/air/validate.go
@@ -22,6 +22,14 @@ func Validate(program *Program) error {
 			return err
 		}
 	}
+	for i, global := range program.Globals {
+		if global.ID != GlobalID(i) {
+			return fmt.Errorf("global table entry %d has id %d", i, global.ID)
+		}
+		if err := validateGlobal(program, global); err != nil {
+			return err
+		}
+	}
 	for i, fn := range program.Functions {
 		if fn.ID != FunctionID(i) {
 			return fmt.Errorf("function table entry %d has id %d", i, fn.ID)
@@ -157,6 +165,25 @@ func validateImpl(program *Program, impl Impl) error {
 	return nil
 }
 
+func validateGlobal(program *Program, global Global) error {
+	if int(global.Module) < 0 || int(global.Module) >= len(program.Modules) {
+		return fmt.Errorf("global %s has invalid module id %d", global.Name, global.Module)
+	}
+	if !validTypeID(program, global.Type) {
+		return fmt.Errorf("global %s has invalid type %d", global.Name, global.Type)
+	}
+	if global.Value.Type == NoType {
+		return fmt.Errorf("global %s has no initializer", global.Name)
+	}
+	if global.Value.Type != global.Type {
+		return fmt.Errorf("global %s initializer type %d does not match global type %d", global.Name, global.Value.Type, global.Type)
+	}
+	if err := validateExpr(program, Function{Module: global.Module, Name: "<global>"}, global.Value); err != nil {
+		return fmt.Errorf("global %s: %w", global.Name, err)
+	}
+	return nil
+}
+
 func validateFunction(program *Program, fn Function) error {
 	if int(fn.Module) < 0 || int(fn.Module) >= len(program.Modules) {
 		return fmt.Errorf("function %s has invalid module id %d", fn.Name, fn.Module)
@@ -264,6 +291,9 @@ func validateExpr(program *Program, fn Function, expr Expr) error {
 	}
 	if expr.Kind == ExprLoadLocal && (expr.Local < 0 || int(expr.Local) >= len(fn.Locals)) {
 		return fmt.Errorf("expression loads invalid local %d", expr.Local)
+	}
+	if expr.Kind == ExprLoadGlobal && !validGlobalID(program, expr.Global) {
+		return fmt.Errorf("expression loads invalid global %d", expr.Global)
 	}
 	if expr.Kind == ExprCall && !validFunctionID(program, expr.Function) {
 		return fmt.Errorf("expression calls invalid function %d", expr.Function)
@@ -593,6 +623,10 @@ func validTypeID(program *Program, id TypeID) bool {
 
 func validFunctionID(program *Program, id FunctionID) bool {
 	return id >= 0 && int(id) < len(program.Functions)
+}
+
+func validGlobalID(program *Program, id GlobalID) bool {
+	return id >= 0 && int(id) < len(program.Globals)
 }
 
 func validTraitID(program *Program, id TraitID) bool {

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -285,6 +285,24 @@ func TestRunProgramExecutesSimpleMain(t *testing.T) {
 	}
 }
 
+func TestRunProgramSupportsModuleLevelLetCapturedByClosure(t *testing.T) {
+	program := lowerSource(t, `
+		let refresh_event = "inbox.refresh"
+
+		fn main() {
+			let event = refresh_event
+			let read: fn() Str = fn() { event }
+			if not read() == "inbox.refresh" {
+				panic("wrong event")
+			}
+		}
+	`)
+
+	if err := RunProgram(program, []string{"ard", "run", "sample.ard"}); err != nil {
+		t.Fatalf("RunProgram error = %v", err)
+	}
+}
+
 func TestRunProgramSpecializesGenericEmptyListLocal(t *testing.T) {
 	program := lowerSource(t, `
 		fn drop(from: [$T], till: Int) [$T] {

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -207,6 +207,16 @@ func (l *lowerer) lowerModule(module air.Module) (*ast.File, error) {
 			decls = append(decls, typeDecls...)
 		}
 	}
+	globalIDs := append([]air.GlobalID(nil), module.Globals...)
+	sort.Slice(globalIDs, func(i, j int) bool { return globalIDs[i] < globalIDs[j] })
+	for _, globalID := range globalIDs {
+		global := l.program.Globals[globalID]
+		decl, err := l.lowerGlobal(global)
+		if err != nil {
+			return nil, fmt.Errorf("module %s global %s: %w", module.Path, global.Name, err)
+		}
+		decls = append(decls, decl)
+	}
 	functionIDs := append([]air.FunctionID(nil), module.Functions...)
 	sort.Slice(functionIDs, func(i, j int) bool { return functionIDs[i] < functionIDs[j] })
 	for _, functionID := range functionIDs {
@@ -555,6 +565,25 @@ func (l *lowerer) lowerMainWrapper(root air.FunctionID) (ast.Decl, error) {
 	}, nil
 }
 
+func (l *lowerer) lowerGlobal(global air.Global) (ast.Decl, error) {
+	globalType, err := l.goType(global.Type)
+	if err != nil {
+		return nil, err
+	}
+	value, err := l.lowerExprWithExpectedType(air.Function{Module: global.Module, Name: "<global>"}, global.Value, global.Type)
+	if err != nil {
+		return nil, err
+	}
+	if len(value.stmts) != 0 {
+		return nil, fmt.Errorf("global initializers with setup statements are not supported")
+	}
+	return &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{
+		Names:  []*ast.Ident{ast.NewIdent(globalName(l.program, global))},
+		Type:   globalType,
+		Values: []ast.Expr{value.expr},
+	}}}, nil
+}
+
 func (l *lowerer) lowerFunction(fn air.Function) (ast.Decl, error) {
 	l.declaredLocals = map[air.LocalID]bool{}
 	params := []*ast.Field{}
@@ -800,6 +829,11 @@ func (l *lowerer) lowerExpr(fn air.Function, expr air.Expr) (loweredExpr, error)
 		return loweredExpr{stmts: stmts, expr: zero}, nil
 	case air.ExprLoadLocal:
 		return loweredExpr{expr: ast.NewIdent(localName(fn, expr.Local))}, nil
+	case air.ExprLoadGlobal:
+		if expr.Global < 0 || int(expr.Global) >= len(l.program.Globals) {
+			return loweredExpr{}, fmt.Errorf("unknown global %d", expr.Global)
+		}
+		return loweredExpr{expr: ast.NewIdent(globalName(l.program, l.program.Globals[expr.Global]))}, nil
 	case air.ExprUnionWrap:
 		return l.lowerUnionWrap(fn, expr)
 	case air.ExprMatchUnion:

--- a/compiler/go/names.go
+++ b/compiler/go/names.go
@@ -21,6 +21,18 @@ func moduleFileName(module air.Module) string {
 	return name + ".go"
 }
 
+func globalName(program *air.Program, global air.Global) string {
+	moduleName := sanitizeName(program.Modules[global.Module].Path)
+	name := sanitizeName(global.Name)
+	if moduleName == "" {
+		moduleName = fmt.Sprintf("module_%d", global.Module)
+	}
+	if name == "" {
+		name = fmt.Sprintf("global_%d", global.ID)
+	}
+	return moduleName + "__global_" + name
+}
+
 func functionName(program *air.Program, fn air.Function) string {
 	moduleName := sanitizeName(program.Modules[fn.Module].Path)
 	suffix := sanitizeName(fn.Name)

--- a/compiler/javascript/air_backend.go
+++ b/compiler/javascript/air_backend.go
@@ -276,7 +276,7 @@ func (l *airJSLowerer) planModuleFiles() {
 	if rootID, ok := airJSRootModuleFunction(l.program); ok {
 		rootModule = l.program.Functions[rootID].Module
 	} else if len(l.program.Modules) > 0 {
-		rootModule = l.program.Modules[len(l.program.Modules)-1].ID
+		rootModule = l.program.Modules[0].ID
 	}
 	for _, module := range l.program.Modules {
 		if module.ID == rootModule {
@@ -318,6 +318,17 @@ func (l *airJSLowerer) lowerModule(module air.Module, invokeRoot bool) (string, 
 			b.WriteString(decl)
 			b.WriteString("\n\n")
 		}
+	}
+	globalIDs := append([]air.GlobalID(nil), module.Globals...)
+	sort.Slice(globalIDs, func(i, j int) bool { return globalIDs[i] < globalIDs[j] })
+	for _, globalID := range globalIDs {
+		global := l.program.Globals[globalID]
+		decl, err := l.lowerGlobal(global)
+		if err != nil {
+			return "", fmt.Errorf("module %s global %s: %w", module.Path, global.Name, err)
+		}
+		b.WriteString(decl)
+		b.WriteString("\n\n")
 	}
 	functionIDs := append([]air.FunctionID(nil), module.Functions...)
 	sort.Slice(functionIDs, func(i, j int) bool { return functionIDs[i] < functionIDs[j] })
@@ -392,6 +403,9 @@ func (l *airJSLowerer) moduleDependencyIDs(module air.Module) []air.ModuleID {
 		if expr.Kind == air.ExprCall && int(expr.Function) >= 0 && int(expr.Function) < len(l.program.Functions) {
 			add(l.program.Functions[expr.Function].Module)
 		}
+		if expr.Kind == air.ExprLoadGlobal && int(expr.Global) >= 0 && int(expr.Global) < len(l.program.Globals) {
+			add(l.program.Globals[expr.Global].Module)
+		}
 		if expr.Kind == air.ExprMakeStruct || expr.Kind == air.ExprEnumVariant {
 			if owner, ok := l.typeModule(expr.Type); ok {
 				add(owner)
@@ -440,6 +454,11 @@ func (l *airJSLowerer) moduleDependencyIDs(module air.Module) []air.ModuleID {
 		visitBlock(expr.Ok)
 		visitBlock(expr.Err)
 		visitBlock(expr.Catch)
+	}
+	for _, globalID := range module.Globals {
+		if int(globalID) >= 0 && int(globalID) < len(l.program.Globals) {
+			visitExpr(l.program.Globals[globalID].Value)
+		}
 	}
 	for _, functionID := range module.Functions {
 		if int(functionID) >= 0 && int(functionID) < len(l.program.Functions) {
@@ -519,6 +538,18 @@ func (l *airJSLowerer) lowerClassMethod(fn air.Function) (string, error) {
 	}
 	_ = info
 	return renderJSDoc(jsBlockDoc(jsName(info.Method)+"("+strings.Join(params, ", ")+")", body)), nil
+}
+
+func (l *airJSLowerer) lowerGlobal(global air.Global) (string, error) {
+	value, err := l.lowerExpr(air.Function{Module: global.Module, Name: "<global>"}, global.Value)
+	if err != nil {
+		return "", err
+	}
+	keyword := "const"
+	if global.Mutable {
+		keyword = "let"
+	}
+	return keyword + " " + l.globalName(global.ID) + " = " + value + ";", nil
 }
 
 func (l *airJSLowerer) lowerFunction(fn air.Function) (string, error) {
@@ -721,6 +752,8 @@ func (l *airJSLowerer) lowerExpr(fn air.Function, expr air.Expr) (string, error)
 		return strconv.Quote(expr.Str), nil
 	case air.ExprLoadLocal:
 		return l.localName(fn, expr.Local), nil
+	case air.ExprLoadGlobal:
+		return l.globalRef(fn.Module, expr.Global), nil
 	case air.ExprUnionWrap:
 		return l.lowerUnionWrap(fn, expr)
 	case air.ExprMatchUnion:
@@ -1719,6 +1752,13 @@ func (l *airJSLowerer) typeRef(from air.ModuleID, typeID air.TypeID) string {
 	return name
 }
 
+func (l *airJSLowerer) globalName(id air.GlobalID) string {
+	if id == air.NoGlobal || int(id) < 0 || int(id) >= len(l.program.Globals) {
+		return "__missing_global"
+	}
+	return jsName(l.program.Globals[id].Name)
+}
+
 func (l *airJSLowerer) functionName(id air.FunctionID) string {
 	if id == air.NoFunction || int(id) < 0 || int(id) >= len(l.program.Functions) {
 		return "__missing_function"
@@ -1742,6 +1782,21 @@ func (l *airJSLowerer) functionNameIsAmbiguous(fn air.Function) bool {
 		}
 	}
 	return count > 1
+}
+
+func (l *airJSLowerer) globalRef(from air.ModuleID, id air.GlobalID) string {
+	name := l.globalName(id)
+	if id == air.NoGlobal || int(id) < 0 || int(id) >= len(l.program.Globals) {
+		return name
+	}
+	global := l.program.Globals[id]
+	if global.Module == from {
+		return name
+	}
+	if int(global.Module) >= 0 && int(global.Module) < len(l.program.Modules) {
+		return moduleAlias(l.program.Modules[global.Module].Path) + "." + name
+	}
+	return name
 }
 
 func (l *airJSLowerer) functionRef(from air.ModuleID, id air.FunctionID) string {
@@ -1813,6 +1868,9 @@ func (l *airJSLowerer) moduleExports(module air.Module) []string {
 		if typ.Kind == air.TypeStruct || typ.Kind == air.TypeEnum {
 			exports = append(exports, jsName(typ.Name))
 		}
+	}
+	for _, globalID := range module.Globals {
+		exports = append(exports, l.globalName(globalID))
 	}
 	for _, functionID := range module.Functions {
 		fn := l.program.Functions[functionID]

--- a/compiler/javascript/javascript_test.go
+++ b/compiler/javascript/javascript_test.go
@@ -812,8 +812,8 @@ let result = add(1, 2)
 	if strings.Contains(source, "__ard_script") {
 		t.Fatalf("expected top-level script statements to emit directly, got:\n%s", source)
 	}
-	if !strings.Contains(source, "export { add };") {
-		t.Fatalf("expected function export in AIR JS output, got:\n%s", source)
+	if !strings.Contains(source, "export { add, result };") {
+		t.Fatalf("expected function and global exports in AIR JS output, got:\n%s", source)
 	}
 }
 

--- a/tinear-top-level-let-lowering-bug.md
+++ b/tinear-top-level-let-lowering-bug.md
@@ -1,0 +1,87 @@
+# Ard lowering bug: module-level `let` visible to checker but not lowerer
+
+## Summary
+
+A module-level `let` binding can pass `ard check`, but `ard build` fails during
+lowering when a function references that binding, especially when the value is
+captured for use in a closure.
+
+This was encountered in `tinear` while trying to replace a zero-argument helper
+function with a module-level string binding for a static custom event name.
+
+## Expected
+
+A module-level binding should be usable from functions in the same module and
+capturable into closures.
+
+## Actual
+
+`ard check main.ard` succeeds, but `ard build main.ard --out ...` fails with:
+
+```text
+lower function main: lower function run: lower function init: lower method init: lower function init: lower function register_refresh_timer: unknown local refresh_event
+```
+
+## Repro
+
+```ard
+use ard/async
+use ard/duration
+
+let refresh_event = "inbox.refresh"
+
+struct Context {}
+
+impl Context {
+  fn post(event: Str) {}
+}
+
+fn register_refresh_timer(ctx: Context) {
+  let event = refresh_event
+  async::start(fn() {
+    while {
+      async::sleep(duration::from_minutes(5))
+      ctx.post(event)
+    }
+  })
+}
+
+fn main() {
+  register_refresh_timer(Context{})
+}
+```
+
+A typed binding behaves the same:
+
+```ard
+let refresh_event: Str = "inbox.refresh"
+```
+
+## Workaround
+
+Use a zero-argument function instead of a module-level binding:
+
+```ard
+fn refresh_event() Str { "inbox.refresh" }
+
+fn register_refresh_timer(ctx: Context) {
+  let event = refresh_event()
+  async::start(fn() {
+    while {
+      async::sleep(duration::from_minutes(5))
+      ctx.post(event)
+    }
+  })
+}
+```
+
+## Related note
+
+Trying `const refresh_event = "inbox.refresh"` instead caused the checker to
+panic with:
+
+```text
+panic: Cannot look up symbols in unrefined $unknown
+```
+
+So `const` was not a viable workaround here.


### PR DESCRIPTION
## Summary
- Represent immutable module-level let bindings as AIR globals
- Resolve same-module and imported module globals during lowering
- Emit module globals in Go and AIR JavaScript backends

## Tests
- cd compiler && go test ./air ./go ./javascript -count=1
- cd compiler && go generate ./std_lib/ffi && go test ./...
