### PR TITLE
fix(checker): preserve module identity for named types

### DIFF
--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -1318,10 +1318,19 @@ func (l *lowerer) typeOwnerPath(t checker.Type) string {
 	var name string
 	switch typ := t.(type) {
 	case *checker.StructDef:
+		if typ.ModulePath != "" {
+			return typ.ModulePath
+		}
 		name = typ.Name
 	case *checker.Enum:
+		if typ.ModulePath != "" {
+			return typ.ModulePath
+		}
 		name = typ.Name
 	case *checker.Union:
+		if typ.ModulePath != "" {
+			return typ.ModulePath
+		}
 		name = typ.Name
 	case *checker.ExternType:
 		name = typ.Name_
@@ -1599,7 +1608,7 @@ func airTypeKeySeen(t checker.Type, seen map[checker.Type]struct{}) string {
 			}
 		}
 		if hasSelfReference(typ) {
-			return "recursive struct " + typ.Name
+			return "recursive struct " + typ.ModulePath + "::" + typ.Name
 		}
 		return airStructKeySeen(typ, seen)
 	case *checker.Enum:
@@ -1630,7 +1639,7 @@ func airStructKey(typ *checker.StructDef) string {
 
 func airStructKeySeen(typ *checker.StructDef, seen map[checker.Type]struct{}) string {
 	fields := sortedFieldNames(typ.Fields)
-	key := "struct " + typ.Name + "{"
+	key := "struct " + typ.ModulePath + "::" + typ.Name + "{"
 	for i, name := range fields {
 		if i > 0 {
 			key += ","
@@ -1659,7 +1668,7 @@ func airStructKeySeen(typ *checker.StructDef, seen map[checker.Type]struct{}) st
 }
 
 func airEnumKey(typ *checker.Enum) string {
-	key := "enum " + typ.Name + "{"
+	key := "enum " + typ.ModulePath + "::" + typ.Name + "{"
 	for i, variant := range typ.Values {
 		if i > 0 {
 			key += ","
@@ -1676,7 +1685,7 @@ func airUnionKey(typ *checker.Union) string {
 		parts[i] = airTypeKey(member)
 	}
 	sort.Strings(parts)
-	key := "union " + typ.Name + "{"
+	key := "union " + typ.ModulePath + "::" + typ.Name + "{"
 	for i, part := range parts {
 		if i > 0 {
 			key += "|"
@@ -4547,13 +4556,19 @@ func (l *lowerer) moduleForInstanceMethod(method *checker.InstanceMethod, fallba
 		return fallback
 	}
 	ownerName := ""
+	ownerModulePath := ""
 	switch {
 	case method.StructType != nil:
 		ownerName = method.StructType.Name
+		ownerModulePath = method.StructType.ModulePath
 	case method.EnumType != nil:
 		ownerName = method.EnumType.Name
+		ownerModulePath = method.EnumType.ModulePath
 	default:
 		return fallback
+	}
+	if ownerModulePath != "" {
+		return l.internModule(ownerModulePath)
 	}
 	for modulePath, mod := range l.moduleByName {
 		if mod.Program() == nil {

--- a/compiler/air/lower_test.go
+++ b/compiler/air/lower_test.go
@@ -718,6 +718,84 @@ func TestLowerImportedModuleFunctionCall(t *testing.T) {
 	}
 }
 
+func TestLowerKeepsSameNamedStructsFromDifferentModulesDistinct(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"app\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	modelsDir := filepath.Join(tempDir, "models")
+	if err := os.MkdirAll(modelsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modelsDir, "inbox.ard"), []byte(`
+struct Store {
+  item: Str,
+}
+
+fn new() Store {
+  Store{item: "inbox"}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modelsDir, "issues.ard"), []byte(`
+struct Store {
+  column: Str,
+}
+
+fn new() Store {
+  Store{column: "issues"}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(tempDir, "main.ard")
+	result := parse.Parse([]byte(`
+use app/models/inbox
+use app/models/issues
+
+fn main() Str {
+  let inbox_store = inbox::new()
+  let issues_store = issues::new()
+  inbox_store.item + issues_store.column
+}
+`), mainPath)
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	resolver, err := checker.NewModuleResolver(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := checker.New(mainPath, result.Program, resolver)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+
+	program, err := Lower(c.Module())
+	if err != nil {
+		t.Fatalf("lower error: %v", err)
+	}
+
+	var stores []TypeInfo
+	for _, typ := range program.Types {
+		if typ.Name == "Store" {
+			stores = append(stores, typ)
+		}
+	}
+	if len(stores) != 2 {
+		t.Fatalf("Store type count = %d, want 2: %#v", len(stores), program.Types)
+	}
+	paths := map[string]bool{}
+	for _, typ := range stores {
+		paths[typ.ModulePath] = true
+	}
+	if !paths["app/models/inbox"] || !paths["app/models/issues"] {
+		t.Fatalf("Store module paths = %#v, want inbox and issues", paths)
+	}
+}
+
 func TestLowerImportedModuleFunctionCanReadModuleLevelLet(t *testing.T) {
 	tempDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"app\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {

--- a/compiler/air/recursive_types.go
+++ b/compiler/air/recursive_types.go
@@ -8,7 +8,7 @@ func isRecursiveNullableStructField(owner *checker.StructDef, field checker.Type
 		return false
 	}
 	structType, ok := maybe.Of().(*checker.StructDef)
-	return ok && structType.Name == owner.Name
+	return ok && sameStructIdentity(structType, owner)
 }
 
 func hasSelfReference(owner *checker.StructDef) bool {
@@ -30,7 +30,7 @@ func typeReferencesStruct(t checker.Type, owner *checker.StructDef, seen map[che
 	seen[t] = struct{}{}
 	switch typ := t.(type) {
 	case *checker.StructDef:
-		return typ == owner || typ.Name == owner.Name
+		return sameStructIdentity(typ, owner)
 	case *checker.List:
 		return typeReferencesStruct(typ.Of(), owner, seen)
 	case *checker.Map:
@@ -47,4 +47,17 @@ func typeReferencesStruct(t checker.Type, owner *checker.StructDef, seen map[che
 		}
 	}
 	return false
+}
+
+func sameStructIdentity(left *checker.StructDef, right *checker.StructDef) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	if left == right {
+		return true
+	}
+	if left.ModulePath != "" && right.ModulePath != "" {
+		return left.ModulePath == right.ModulePath && left.Name == right.Name
+	}
+	return left.Name == right.Name
 }

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -143,8 +143,9 @@ func derefTypeSeen(t Type, seen map[Type]bool) Type {
 			return typ // No change, return original
 		}
 		return &Union{
-			Name:  typ.Name,
-			Types: newTypes,
+			Name:       typ.Name,
+			ModulePath: typ.ModulePath,
+			Types:      newTypes,
 		}
 	case *StructDef:
 		fieldsChanged := false
@@ -173,6 +174,7 @@ func derefTypeSeen(t Type, seen map[Type]bool) Type {
 		}
 		return &StructDef{
 			Name:          typ.Name,
+			ModulePath:    typ.ModulePath,
 			Fields:        newFields,
 			Methods:       newMethods,
 			Self:          typ.Self,
@@ -265,6 +267,7 @@ type Checker struct {
 	input          *parse.Program
 	scope          *SymbolTable
 	filePath       string
+	modulePath     string
 	program        *Program
 	halted         bool
 	moduleResolver *ModuleResolver
@@ -278,6 +281,7 @@ func New(filePath string, input *parse.Program, moduleResolver *ModuleResolver, 
 		diagnostics:    []Diagnostic{},
 		input:          input,
 		filePath:       filePath,
+		modulePath:     filePath,
 		moduleResolver: moduleResolver,
 		options:        normalizeCheckOptions(moduleResolver, options),
 		program: &Program{
@@ -288,6 +292,13 @@ func New(filePath string, input *parse.Program, moduleResolver *ModuleResolver, 
 	}
 
 	return c
+}
+
+func (c *Checker) typeOwnerPath() string {
+	if c.moduleResolver == nil && !strings.HasPrefix(c.modulePath, "ard/") {
+		return ""
+	}
+	return c.modulePath
 }
 
 func (c *Checker) HasErrors() bool {
@@ -346,7 +357,7 @@ func (c *Checker) Check() {
 			}
 
 			// Type-check the imported module
-			userModule, diagnostics := check(ast, c.moduleResolver, imp.Path+".ard", c.options)
+			userModule, diagnostics := check(ast, c.moduleResolver, imp.Path+".ard", imp.Path, c.options)
 			if len(diagnostics) > 0 {
 				// Add all diagnostics from the imported module
 				for _, diag := range diagnostics {
@@ -425,13 +436,14 @@ func (c *Checker) scanForUnresolvedGenerics() {
 // This should only be called after .Check()
 // The returned module could be problematic if there are diagnostic errors.
 func (c *Checker) Module() Module {
-	return NewUserModule(c.filePath, c.program, c.scope)
+	return NewUserModule(c.modulePath, c.program, c.scope)
 }
 
 // check is an internal helper for recursive module checking.
 // Use New() + Check() + Module() for the public API.
-func check(input *parse.Program, moduleResolver *ModuleResolver, filePath string, options CheckOptions) (Module, []Diagnostic) {
+func check(input *parse.Program, moduleResolver *ModuleResolver, filePath string, modulePath string, options CheckOptions) (Module, []Diagnostic) {
 	c := New(filePath, input, moduleResolver, options)
+	c.modulePath = modulePath
 
 	c.Check()
 
@@ -1018,8 +1030,9 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 
 			// Create a union type (even if it only contains one type)
 			unionType := &Union{
-				Name:  s.Name.Name,
-				Types: types,
+				Name:       s.Name.Name,
+				ModulePath: c.typeOwnerPath(),
+				Types:      types,
 			}
 
 			// Register the type in the scope with the given name
@@ -1434,10 +1447,11 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 			}
 
 			enum := &Enum{
-				Private: s.Private,
-				Name:    s.Name,
-				Values:  computedValues,
-				Methods: make(map[string]*FunctionDef),
+				Private:    s.Private,
+				Name:       s.Name,
+				ModulePath: c.typeOwnerPath(),
+				Values:     computedValues,
+				Methods:    make(map[string]*FunctionDef),
 			}
 
 			c.scope.add(enum.name(), enum, false)
@@ -1446,10 +1460,11 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 	case *parse.StructDefinition:
 		{
 			def := &StructDef{
-				Name:    s.Name.Name,
-				Fields:  make(map[string]Type),
-				Methods: make(map[string]*FunctionDef),
-				Private: s.Private,
+				Name:       s.Name.Name,
+				ModulePath: c.typeOwnerPath(),
+				Fields:     make(map[string]Type),
+				Methods:    make(map[string]*FunctionDef),
+				Private:    s.Private,
 			}
 			c.scope.add(def.name(), def, false)
 			seenGenerics := make(map[string]bool)
@@ -1977,6 +1992,7 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 	// Store the refined struct definition (with resolved generics) as the instance's type
 	instance._type = &StructDef{
 		Name:          structDefCopy.Name,
+		ModulePath:    structDefCopy.ModulePath,
 		Fields:        fieldTypes,
 		Methods:       structDefCopy.Methods,
 		Self:          structDefCopy.Self,
@@ -4437,7 +4453,7 @@ func bindInferredTypeVars(expected Type, actual Type) {
 			bindInferredTypeVars(exp.Value(), act.Value())
 		}
 	case *StructDef:
-		if act, ok := actual.(*StructDef); ok && exp.Name == act.Name {
+		if act, ok := actual.(*StructDef); ok && exp.Name == act.Name && !namedTypeOwnersDiffer(exp.ModulePath, act.ModulePath) {
 			for fieldName, expectedField := range exp.Fields {
 				if actualField, ok := act.Fields[fieldName]; ok {
 					bindInferredTypeVars(expectedField, actualField)
@@ -4911,7 +4927,7 @@ func substituteType(t Type, typeMap map[string]Type) Type {
 		for i, member := range typ.Types {
 			types[i] = substituteType(member, typeMap)
 		}
-		return &Union{Name: typ.Name, Types: types}
+		return &Union{Name: typ.Name, ModulePath: typ.ModulePath, Types: types}
 	case *StructDef:
 		var out Type = typ
 		for genericName, concrete := range typeMap {
@@ -5380,7 +5396,7 @@ func (c *Checker) unifyTypes(expected Type, actual Type, genericScope *SymbolTab
 		return fmt.Errorf("expected list type, got %T", actual)
 	case *StructDef:
 		actualStruct, ok := actual.(*StructDef)
-		if !ok || expectedType.Name != actualStruct.Name {
+		if !ok || expectedType.Name != actualStruct.Name || namedTypeOwnersDiffer(expectedType.ModulePath, actualStruct.ModulePath) {
 			return fmt.Errorf("type mismatch: expected %s, got %s", expected.String(), actual.String())
 		}
 		for fieldName, expectedField := range expectedType.Fields {

--- a/compiler/checker/embedded_module.go
+++ b/compiler/checker/embedded_module.go
@@ -41,7 +41,7 @@ func FindEmbeddedModuleForTarget(path string, target string) (Module, bool) {
 
 	// Type check the program to create a Program with symbols
 	// Use the check function which returns a Module and diagnostics
-	module, diagnostics := check(program, nil, path, CheckOptions{Target: target})
+	module, diagnostics := check(program, nil, path, path, CheckOptions{Target: target})
 	if len(diagnostics) > 0 {
 		// For now, we'll continue even with diagnostics
 		// In a production system, you might want to handle this differently

--- a/compiler/checker/functions.go
+++ b/compiler/checker/functions.go
@@ -174,6 +174,7 @@ func (c *Checker) validateAsyncEval(fnNode parse.Expression) *FiberEval {
 
 				fiberCopy := &StructDef{
 					Name:          fiberStructDef.Name,
+					ModulePath:    fiberStructDef.ModulePath,
 					Fields:        make(map[string]Type),
 					Methods:       make(map[string]*FunctionDef),
 					GenericParams: append([]string(nil), fiberStructDef.GenericParams...),

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -1140,12 +1140,13 @@ type EnumValue struct {
 }
 
 type Enum struct {
-	Name     string
-	Private  bool
-	Values   []EnumValue // The discriminant values for each variant
-	Methods  map[string]*FunctionDef
-	Traits   []*Trait
-	Location parse.Location
+	Name       string
+	ModulePath string
+	Private    bool
+	Values     []EnumValue // The discriminant values for each variant
+	Methods    map[string]*FunctionDef
+	Traits     []*Trait
+	Location   parse.Location
 }
 
 func (e Enum) NonProducing() {}
@@ -1171,7 +1172,7 @@ func (e Enum) equal(other Type) bool {
 		}
 		return false
 	}
-	if e.Name != o.Name {
+	if e.Name != o.Name || namedTypeOwnersDiffer(e.ModulePath, o.ModulePath) {
 		return false
 	}
 	if len(e.Values) != len(o.Values) {
@@ -1228,8 +1229,9 @@ func (ev EnumVariant) String() string {
 }
 
 type Union struct {
-	Name  string
-	Types []Type
+	Name       string
+	ModulePath string
+	Types      []Type
 }
 
 func (u Union) NonProducing() {}
@@ -1264,6 +1266,7 @@ func (u Union) hasTrait(trait *Trait) bool {
 
 type StructDef struct {
 	Name          string
+	ModulePath    string
 	Fields        map[string]Type
 	Methods       map[string]*FunctionDef
 	Self          string

--- a/compiler/checker/scope.go
+++ b/compiler/checker/scope.go
@@ -356,12 +356,13 @@ func replaceGeneric(t Type, genericName string, concreteType Type) Type {
 			return t
 		}
 		return &StructDef{
-			Name:    t.Name,
-			Fields:  newFields,
-			Methods: newMethods,
-			Self:    t.Self,
-			Traits:  t.Traits,
-			Private: t.Private,
+			Name:       t.Name,
+			ModulePath: t.ModulePath,
+			Fields:     newFields,
+			Methods:    newMethods,
+			Self:       t.Self,
+			Traits:     t.Traits,
+			Private:    t.Private,
 		}
 	case *ExternType:
 		if len(t.TypeArgs) == 0 {
@@ -442,6 +443,7 @@ func copyStructWithTypeVarMap(structDef *StructDef, typeVarMap map[string]*TypeV
 
 	return &StructDef{
 		Name:          structDef.Name,
+		ModulePath:    structDef.ModulePath,
 		Fields:        newFields,
 		Methods:       structDef.Methods, // Methods are not copied; they're shared
 		Self:          structDef.Self,
@@ -479,8 +481,9 @@ func copyTypeWithTypeVarMap(t Type, typeVarMap map[string]*TypeVar) Type {
 			newTypes[i] = copyTypeWithTypeVarMap(t, typeVarMap)
 		}
 		return &Union{
-			Name:  typ.Name,
-			Types: newTypes,
+			Name:       typ.Name,
+			ModulePath: typ.ModulePath,
+			Types:      newTypes,
 		}
 	case *StructDef:
 		return copyStructWithTypeVarMap(typ, typeVarMap)

--- a/compiler/checker/type_equal.go
+++ b/compiler/checker/type_equal.go
@@ -192,7 +192,7 @@ func equalExternalFunctionDefSeen(left ExternalFunctionDef, right Type, seen map
 
 func equalStructDefSeen(left StructDef, right Type, seen map[typeEqualKey]struct{}) bool {
 	r, ok := right.(*StructDef)
-	if !ok || left.Name != r.Name || len(left.Fields) != len(r.Fields) || len(left.Methods) != len(r.Methods) {
+	if !ok || left.Name != r.Name || namedTypeOwnersDiffer(left.ModulePath, r.ModulePath) || len(left.Fields) != len(r.Fields) || len(left.Methods) != len(r.Methods) {
 		return false
 	}
 	for name, fieldType := range left.Fields {
@@ -210,9 +210,13 @@ func equalStructDefSeen(left StructDef, right Type, seen map[typeEqualKey]struct
 	return true
 }
 
+func namedTypeOwnersDiffer(left string, right string) bool {
+	return left != "" && right != "" && left != right
+}
+
 func equalUnionSeen(left Union, right Type, seen map[typeEqualKey]struct{}) bool {
 	if r, ok := right.(*Union); ok {
-		if len(left.Types) != len(r.Types) {
+		if namedTypeOwnersDiffer(left.ModulePath, r.ModulePath) || len(left.Types) != len(r.Types) {
 			return false
 		}
 		for _, leftType := range left.Types {
@@ -263,17 +267,24 @@ func typeEqualID(t Type) string {
 		return fmt.Sprintf("Function:%s", v.Name)
 	case *ExternalFunctionDef:
 		return fmt.Sprintf("ExternalFunction:%p", v)
+	case *Enum:
+		return fmt.Sprintf("Enum:%s:%s", v.ModulePath, v.Name)
+	case Enum:
+		return fmt.Sprintf("Enum:%s:%s", v.ModulePath, v.Name)
 	case *StructDef:
 		if v.Name != "" {
-			return fmt.Sprintf("Struct:%s", v.Name)
+			return fmt.Sprintf("Struct:%s:%s", v.ModulePath, v.Name)
 		}
 		return fmt.Sprintf("Struct:%p", v)
 	case StructDef:
-		return fmt.Sprintf("Struct:%s", v.Name)
+		return fmt.Sprintf("Struct:%s:%s", v.ModulePath, v.Name)
 	case *Union:
+		if v.Name != "" {
+			return fmt.Sprintf("Union:%s:%s", v.ModulePath, v.Name)
+		}
 		return fmt.Sprintf("Union:%p", v)
 	case Union:
-		return fmt.Sprintf("Union:%s", v.Name)
+		return fmt.Sprintf("Union:%s:%s", v.ModulePath, v.Name)
 	default:
 		return fmt.Sprintf("%T:%s", t, t.String())
 	}

--- a/compiler/checker/user_modules_test.go
+++ b/compiler/checker/user_modules_test.go
@@ -146,6 +146,115 @@ fn main() Int {
 	}
 }
 
+func TestSameNamedGenericStructsFromDifferentModulesAreNominallyDistinct(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"app\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, module := range []string{"left", "right"} {
+		if err := os.WriteFile(filepath.Join(tempDir, module+".ard"), []byte(`
+struct Box {
+  value: $T,
+}
+
+fn boxed() Box<Int> {
+  Box{value: 1}
+}
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result := parse.Parse([]byte(`
+use app/left
+use app/right
+
+fn needs_left(box: left::Box<Int>) {}
+
+fn main() {
+  needs_left(right::boxed())
+}
+`), filepath.Join(tempDir, "main.ard"))
+	if len(result.Errors) > 0 {
+		t.Fatal(result.Errors[0].Message)
+	}
+	resolver, err := checker.NewModuleResolver(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := checker.New("main.ard", result.Program, resolver)
+	c.Check()
+	if !c.HasErrors() {
+		t.Fatal("expected same-named generic structs from different modules to be incompatible")
+	}
+	if !strings.Contains(strings.ToLower(diagnosticsString(c.Diagnostics())), "type mismatch") {
+		t.Fatalf("diagnostics = %v, want type mismatch", c.Diagnostics())
+	}
+}
+
+func TestSameNamedStructsFromDifferentModulesAreNominallyDistinct(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"app\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "left.ard"), []byte(`
+struct Store {
+  id: Int,
+}
+
+fn new() Store {
+  Store{id: 1}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "right.ard"), []byte(`
+struct Store {
+  id: Int,
+}
+
+fn new() Store {
+  Store{id: 2}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := parse.Parse([]byte(`
+use app/left
+use app/right
+
+fn needs_left(store: left::Store) {}
+
+fn main() {
+  needs_left(right::new())
+}
+`), filepath.Join(tempDir, "main.ard"))
+	if len(result.Errors) > 0 {
+		t.Fatal(result.Errors[0].Message)
+	}
+	resolver, err := checker.NewModuleResolver(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := checker.New("main.ard", result.Program, resolver)
+	c.Check()
+	if !c.HasErrors() {
+		t.Fatal("expected same-named structs from different modules to be incompatible")
+	}
+	if !strings.Contains(strings.ToLower(diagnosticsString(c.Diagnostics())), "type mismatch") {
+		t.Fatalf("diagnostics = %v, want type mismatch", c.Diagnostics())
+	}
+}
+
+func diagnosticsString(diags []checker.Diagnostic) string {
+	parts := make([]string, len(diags))
+	for i, diag := range diags {
+		parts[i] = diag.String()
+	}
+	return strings.Join(parts, "\n")
+}
+
 func TestUserModuleSymbolResolution(t *testing.T) {
 	// Create temporary directory structure
 	tempDir, err := os.MkdirTemp("", "ard_symbol_resolution_")

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -1,6 +1,7 @@
 package gotarget
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -299,6 +300,216 @@ func TestRunProgramSupportsModuleLevelLetCapturedByClosure(t *testing.T) {
 	`)
 
 	if err := RunProgram(program, []string{"ard", "run", "sample.ard"}); err != nil {
+		t.Fatalf("RunProgram error = %v", err)
+	}
+}
+
+func TestRunProgramSupportsTransitiveSameNamedStructsFromDifferentModules(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"app\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range []string{"models", "tui"} {
+		if err := os.MkdirAll(filepath.Join(tempDir, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files := map[string]string{
+		"models/inbox.ard": `
+struct Store {
+  item: Str,
+}
+
+fn new() Store {
+  Store{item: "inbox"}
+}
+`,
+		"models/issues.ard": `
+struct Store {
+  column: Str,
+}
+
+fn new() Store {
+  Store{column: "issues"}
+}
+`,
+		"tui/inbox_screen.ard": `
+use app/models/inbox
+
+struct Screen {
+  store: inbox::Store,
+}
+
+fn new() Screen {
+  Screen{store: inbox::new()}
+}
+
+impl Screen {
+  fn item() Str { self.store.item }
+}
+`,
+		"tui/issues_screen.ard": `
+use app/models/issues
+
+struct Screen {
+  store: issues::Store,
+}
+
+fn new() Screen {
+  Screen{store: issues::new()}
+}
+
+impl Screen {
+  fn column() Str { self.store.column }
+}
+`,
+	}
+	for name, source := range files {
+		if err := os.WriteFile(filepath.Join(tempDir, name), []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mainPath := filepath.Join(tempDir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`
+use app/tui/inbox_screen
+use app/tui/issues_screen
+
+fn main() {
+  let inbox = inbox_screen::new()
+  let issues = issues_screen::new()
+  if not inbox.item() == "inbox" {
+    panic("wrong inbox screen")
+  }
+  if not issues.column() == "issues" {
+    panic("wrong issues screen")
+  }
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetGo)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower error: %v", err)
+	}
+	if err := RunProgram(program, []string{"ard", "run", mainPath}); err != nil {
+		t.Fatalf("RunProgram error = %v", err)
+	}
+}
+
+func TestRunProgramSupportsSameNamedStructMethodsFromDifferentModules(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"app\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, module := range []struct{ name, label string }{{"left", "left"}, {"right", "right"}} {
+		source := fmt.Sprintf(`
+struct Store {
+  label: Str,
+}
+
+fn new() Store {
+  Store{label: %q}
+}
+
+impl Store {
+  fn value() Str { self.label }
+}
+`, module.label)
+		if err := os.WriteFile(filepath.Join(tempDir, module.name+".ard"), []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mainPath := filepath.Join(tempDir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`
+use app/left
+use app/right
+
+fn main() {
+  if not left::new().value() == "left" {
+    panic("wrong left value")
+  }
+  if not right::new().value() == "right" {
+    panic("wrong right value")
+  }
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetGo)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower error: %v", err)
+	}
+	if err := RunProgram(program, []string{"ard", "run", mainPath}); err != nil {
+		t.Fatalf("RunProgram error = %v", err)
+	}
+}
+
+func TestRunProgramSupportsSameNamedStructsFromDifferentModules(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"app\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	modelsDir := filepath.Join(tempDir, "models")
+	if err := os.MkdirAll(modelsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modelsDir, "inbox.ard"), []byte(`
+struct Store {
+  item: Str,
+}
+
+fn new() Store {
+  Store{item: "inbox"}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modelsDir, "issues.ard"), []byte(`
+struct Store {
+  column: Str,
+}
+
+fn new() Store {
+  Store{column: "issues"}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(tempDir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`
+use app/models/inbox
+use app/models/issues
+
+fn main() {
+  let inbox_store = inbox::new()
+  let issues_store = issues::new()
+  if not inbox_store.item == "inbox" {
+    panic("wrong inbox store")
+  }
+  if not issues_store.column == "issues" {
+    panic("wrong issues store")
+  }
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetGo)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower error: %v", err)
+	}
+	if err := RunProgram(program, []string{"ard", "run", mainPath}); err != nil {
 		t.Fatalf("RunProgram error = %v", err)
 	}
 }
@@ -651,16 +862,16 @@ func TestGenerateSourcesSupportsStructsAndEnums(t *testing.T) {
 	for _, source := range sources {
 		combined += string(source)
 	}
-	if !regexp.MustCompile(`type type_\d+__Direction int`).MatchString(combined) {
+	if !strings.Contains(combined, `type test_ard__Direction int`) {
 		t.Fatalf("generated source missing enum type:\n%s", combined)
 	}
-	if !regexp.MustCompile(`type_\d+__Direction__Down`).MatchString(combined) {
+	if !strings.Contains(combined, `test_ard__Direction__Down`) {
 		t.Fatalf("generated source missing enum constants:\n%s", combined)
 	}
-	if !regexp.MustCompile(`type type_\d+__User struct`).MatchString(combined) {
+	if !strings.Contains(combined, `type test_ard__User struct`) {
 		t.Fatalf("generated source missing struct type:\n%s", combined)
 	}
-	if !regexp.MustCompile(`type_\d+__User\{age: 41, name: "Ada"\}`).MatchString(combined) {
+	if !strings.Contains(combined, `test_ard__User{age: 41, name: "Ada"}`) {
 		t.Fatalf("generated source missing struct literal lowering:\n%s", combined)
 	}
 	if !strings.Contains(combined, ".age + 1") {
@@ -1355,10 +1566,16 @@ func TestRunProgramSupportsVoidFiberFunctions(t *testing.T) {
 	}
 }
 
-func TestTypeNameUsesUniqueFallbackWhenModuleOwnershipIsMissing(t *testing.T) {
+func TestTypeNameUsesModulePathAndUniqueFallback(t *testing.T) {
 	program := &air.Program{}
-	left := typeName(program, air.TypeInfo{ID: 1, Name: "Request"})
-	right := typeName(program, air.TypeInfo{ID: 2, Name: "Request"})
+	inbox := typeName(program, air.TypeInfo{ID: 1, Name: "Store", ModulePath: "app/models/inbox"})
+	issues := typeName(program, air.TypeInfo{ID: 2, Name: "Store", ModulePath: "app/models/issues"})
+	if inbox != "app_models_inbox__Store" || issues != "app_models_issues__Store" {
+		t.Fatalf("module type names = %q, %q", inbox, issues)
+	}
+
+	left := typeName(program, air.TypeInfo{ID: 3, Name: "Request"})
+	right := typeName(program, air.TypeInfo{ID: 4, Name: "Request"})
 	if left == right {
 		t.Fatalf("fallback type names should be unique, got %q", left)
 	}
@@ -1452,7 +1669,7 @@ func TestGenerateSourcesUsesPointersForMutableStructParams(t *testing.T) {
 		t.Fatalf("GenerateSources error = %v", err)
 	}
 	source := string(sources["test.go"])
-	if !regexp.MustCompile(`func test_ard__set_body\(res \*type_\d+__Response\)`).MatchString(source) {
+	if !strings.Contains(source, `func test_ard__set_body(res *test_ard__Response)`) {
 		t.Fatalf("generated source missing pointer mutable param lowering:\n%s", source)
 	}
 	if !strings.Contains(source, "test_ard__set_body(&res_0)") {

--- a/compiler/go/names.go
+++ b/compiler/go/names.go
@@ -59,16 +59,26 @@ func functionName(program *air.Program, fn air.Function) string {
 }
 
 func typeName(program *air.Program, typ air.TypeInfo) string {
-	moduleName := ""
-	for _, module := range program.Modules {
-		for _, typeID := range module.Types {
-			if typeID == typ.ID {
-				moduleName = sanitizeName(module.Path)
+	base := typeNameBase(program, typ)
+	if typeNameCollides(program, typ, base) {
+		return fmt.Sprintf("%s_%d", base, typ.ID)
+	}
+	return base
+}
+
+func typeNameBase(program *air.Program, typ air.TypeInfo) string {
+	moduleName := sanitizeName(typ.ModulePath)
+	if moduleName == "" {
+		for _, module := range program.Modules {
+			for _, typeID := range module.Types {
+				if typeID == typ.ID {
+					moduleName = sanitizeName(module.Path)
+					break
+				}
+			}
+			if moduleName != "" {
 				break
 			}
-		}
-		if moduleName != "" {
-			break
 		}
 	}
 	name := sanitizeName(typ.Name)
@@ -79,6 +89,15 @@ func typeName(program *air.Program, typ air.TypeInfo) string {
 		name = fmt.Sprintf("type_%d", typ.ID)
 	}
 	return moduleName + "__" + name
+}
+
+func typeNameCollides(program *air.Program, typ air.TypeInfo, base string) bool {
+	for _, other := range program.Types {
+		if other.ID != typ.ID && typeNameBase(program, other) == base {
+			return true
+		}
+	}
+	return false
 }
 
 func enumVariantName(program *air.Program, typ air.TypeInfo, variant air.VariantInfo) string {

--- a/compiler/javascript/air_backend.go
+++ b/compiler/javascript/air_backend.go
@@ -312,10 +312,10 @@ func (l *airJSLowerer) lowerModule(module air.Module, invokeRoot bool) (string, 
 	}
 	b.WriteString(renderJSDoc(jsModulePreambleDoc(imports, l.target)))
 	b.WriteByte('\n')
-	for _, typ := range l.program.Types {
-		decl, err := l.lowerTypeDecl(typ.ID)
+	for _, typeID := range l.moduleTypeIDs(module) {
+		decl, err := l.lowerTypeDecl(typeID)
 		if err != nil {
-			return "", fmt.Errorf("module %s type %d: %w", module.Path, typ.ID, err)
+			return "", fmt.Errorf("module %s type %d: %w", module.Path, typeID, err)
 		}
 		if strings.TrimSpace(decl) != "" {
 			b.WriteString(decl)
@@ -370,6 +370,32 @@ func (l *airJSLowerer) lowerModule(module air.Module, invokeRoot bool) (string, 
 	return b.String(), nil
 }
 
+func (l *airJSLowerer) moduleTypeIDs(module air.Module) []air.TypeID {
+	ids := []air.TypeID{}
+	for _, typ := range l.program.Types {
+		if typ.Kind != air.TypeStruct && typ.Kind != air.TypeEnum {
+			continue
+		}
+		if l.typeOwnedByModule(typ, module) {
+			ids = append(ids, typ.ID)
+		}
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+func (l *airJSLowerer) typeOwnedByModule(typ air.TypeInfo, module air.Module) bool {
+	if typ.ModulePath != "" {
+		return typ.ModulePath == module.Path
+	}
+	for _, typeID := range module.Types {
+		if typeID == typ.ID {
+			return true
+		}
+	}
+	return false
+}
+
 func (l *airJSLowerer) moduleDependencyIDs(module air.Module) []air.ModuleID {
 	seen := map[air.ModuleID]bool{}
 	add := func(id air.ModuleID) {
@@ -382,6 +408,41 @@ func (l *airJSLowerer) moduleDependencyIDs(module air.Module) []air.ModuleID {
 	}
 	var visitBlock func(air.Block)
 	var visitExpr func(air.Expr)
+	seenTypes := map[air.TypeID]bool{}
+	var visitType func(air.TypeID)
+	visitType = func(typeID air.TypeID) {
+		info, ok := l.typeInfo(typeID)
+		if !ok || seenTypes[typeID] {
+			return
+		}
+		seenTypes[typeID] = true
+		if owner, ok := l.typeModule(typeID); ok {
+			add(owner)
+		}
+		switch info.Kind {
+		case air.TypeList, air.TypeMaybe, air.TypeFiber:
+			visitType(info.Elem)
+		case air.TypeMap:
+			visitType(info.Key)
+			visitType(info.Value)
+		case air.TypeResult:
+			visitType(info.Value)
+			visitType(info.Error)
+		case air.TypeStruct:
+			for _, field := range info.Fields {
+				visitType(field.Type)
+			}
+		case air.TypeUnion:
+			for _, member := range info.Members {
+				visitType(member.Type)
+			}
+		case air.TypeFunction:
+			for _, param := range info.Params {
+				visitType(param)
+			}
+			visitType(info.Return)
+		}
+	}
 	visitBlock = func(block air.Block) {
 		for _, stmt := range block.Stmts {
 			if stmt.Value != nil {
@@ -403,6 +464,7 @@ func (l *airJSLowerer) moduleDependencyIDs(module air.Module) []air.ModuleID {
 		}
 	}
 	visitExpr = func(expr air.Expr) {
+		visitType(expr.Type)
 		if expr.Kind == air.ExprCall && int(expr.Function) >= 0 && int(expr.Function) < len(l.program.Functions) {
 			add(l.program.Functions[expr.Function].Module)
 		}
@@ -791,7 +853,7 @@ func (l *airJSLowerer) lowerExpr(fn air.Function, expr air.Expr) (string, error)
 		if err != nil {
 			return "", err
 		}
-		return l.adaptExternReturn(call, expr.Type)
+		return l.adaptExternReturn(fn.Module, call, expr.Type)
 	case air.ExprSpawnFiber:
 		return l.lowerSpawnFiber(fn, expr)
 	case air.ExprFiberGet:
@@ -1034,40 +1096,40 @@ func (l *airJSLowerer) lowerExternCallRaw(fn air.Function, expr air.Expr) (strin
 	return renderJSExpr(jsCallExprIR{Callee: callee, Args: args}), nil
 }
 
-func (l *airJSLowerer) adaptExternReturn(call string, typeID air.TypeID) (string, error) {
+func (l *airJSLowerer) adaptExternReturn(from air.ModuleID, call string, typeID air.TypeID) (string, error) {
 	t, ok := l.typeInfo(typeID)
 	if !ok {
 		return call, nil
 	}
 	switch t.Kind {
 	case air.TypeMaybe:
-		adapted, err := l.adaptExternValue("__extern", t.Elem)
+		adapted, err := l.adaptExternValue(from, "__extern", t.Elem)
 		if err != nil {
 			return "", err
 		}
 		body := "const __extern = " + call + ";\nreturn !isVoid(__extern) ? Maybe.some(" + adapted + ") : Maybe.none();"
 		return renderJSDoc(jsIIFEDoc(body)), nil
 	case air.TypeResult:
-		adaptedOk, err := l.adaptExternValue("__extern.ok", t.Value)
+		adaptedOk, err := l.adaptExternValue(from, "__extern.ok", t.Value)
 		if err != nil {
 			return "", err
 		}
-		adaptedErr, err := l.adaptExternValue("__extern.error", t.Error)
+		adaptedErr, err := l.adaptExternValue(from, "__extern.error", t.Error)
 		if err != nil {
 			return "", err
 		}
-		adaptedAltErr, err := l.adaptExternValue("__extern.err", t.Error)
+		adaptedAltErr, err := l.adaptExternValue(from, "__extern.err", t.Error)
 		if err != nil {
 			return "", err
 		}
 		body := "const __extern = " + call + ";\nif (__extern && Object.prototype.hasOwnProperty.call(__extern, \"ok\")) return Result.ok(" + adaptedOk + ");\nif (__extern && Object.prototype.hasOwnProperty.call(__extern, \"error\")) return Result.err(" + adaptedErr + ");\nif (__extern && Object.prototype.hasOwnProperty.call(__extern, \"err\")) return Result.err(" + adaptedAltErr + ");\nreturn __extern;"
 		return renderJSDoc(jsIIFEDoc(body)), nil
 	default:
-		return l.adaptExternValue(call, typeID)
+		return l.adaptExternValue(from, call, typeID)
 	}
 }
 
-func (l *airJSLowerer) adaptExternValue(value string, typeID air.TypeID) (string, error) {
+func (l *airJSLowerer) adaptExternValue(from air.ModuleID, value string, typeID air.TypeID) (string, error) {
 	t, ok := l.typeInfo(typeID)
 	if !ok {
 		return value, nil
@@ -1076,32 +1138,33 @@ func (l *airJSLowerer) adaptExternValue(value string, typeID air.TypeID) (string
 	case air.TypeStruct:
 		args := make([]string, len(t.Fields))
 		for i, field := range t.Fields {
-			adapted, err := l.adaptExternValue(value+"["+strconv.Quote(field.Name)+"]", field.Type)
+			adapted, err := l.adaptExternValue(from, value+"["+strconv.Quote(field.Name)+"]", field.Type)
 			if err != nil {
 				return "", err
 			}
 			args[i] = adapted
 		}
-		return "(" + value + " instanceof " + jsName(t.Name) + " ? " + value + " : new " + jsName(t.Name) + "(" + strings.Join(args, ", ") + "))", nil
+		ctor := l.typeRef(from, typeID)
+		return "(" + value + " instanceof " + ctor + " ? " + value + " : new " + ctor + "(" + strings.Join(args, ", ") + "))", nil
 	case air.TypeList:
-		adapted, err := l.adaptExternValue("__item", t.Elem)
+		adapted, err := l.adaptExternValue(from, "__item", t.Elem)
 		if err != nil {
 			return "", err
 		}
 		return "Array.isArray(" + value + ") ? " + value + ".map((__item) => " + adapted + ") : []", nil
 	case air.TypeMap:
-		adaptedKey, err := l.adaptExternValue("__key", t.Key)
+		adaptedKey, err := l.adaptExternValue(from, "__key", t.Key)
 		if err != nil {
 			return "", err
 		}
-		adaptedValue, err := l.adaptExternValue("__value", t.Value)
+		adaptedValue, err := l.adaptExternValue(from, "__value", t.Value)
 		if err != nil {
 			return "", err
 		}
 		body := "const __map = " + value + ";\nif (__map instanceof Map) return new Map(Array.from(__map.entries(), ([__key, __value]) => [" + adaptedKey + ", " + adaptedValue + "]));\nreturn new Map(Object.entries(__map ?? {}).map(([__key, __value]) => [" + adaptedKey + ", " + adaptedValue + "]));"
 		return renderJSDoc(jsIIFEDoc(body)), nil
 	case air.TypeMaybe:
-		adapted, err := l.adaptExternValue("__maybe", t.Elem)
+		adapted, err := l.adaptExternValue(from, "__maybe", t.Elem)
 		if err != nil {
 			return "", err
 		}
@@ -1539,7 +1602,7 @@ func (l *airJSLowerer) lowerMaybeExpectLines(fn air.Function, expr air.Expr) ([]
 		if !ok || maybeType.Kind != air.TypeMaybe {
 			return nil, "", fmt.Errorf("maybe expect lowered with non-Maybe extern target %d", expr.Target.Type)
 		}
-		adapted, err := l.adaptExternValue(expectVar, maybeType.Elem)
+		adapted, err := l.adaptExternValue(fn.Module, expectVar, maybeType.Elem)
 		if err != nil {
 			return nil, "", err
 		}
@@ -1875,12 +1938,8 @@ func isAIRJSPreludeExtern(binding string) bool {
 
 func (l *airJSLowerer) moduleExports(module air.Module) []string {
 	exports := []string{}
-	// lowerModule currently emits all struct/enum declarations into every generated
-	// module so imported constructors are available even when AIR does not retain
-	// a precise type-owner mapping. Keep exports aligned with the emitted
-	// declarations so browser/server integration code can import enum values too.
-	for _, typ := range l.program.Types {
-		if typ.Kind == air.TypeStruct || typ.Kind == air.TypeEnum {
+	for _, typeID := range l.moduleTypeIDs(module) {
+		if typ, ok := l.typeInfo(typeID); ok {
 			exports = append(exports, jsName(typ.Name))
 		}
 	}

--- a/compiler/javascript/javascript_test.go
+++ b/compiler/javascript/javascript_test.go
@@ -1399,6 +1399,145 @@ let answer = value()
 	}
 }
 
+func TestGenerateSourcesFromAIRExternAdapterImportsNestedStructRefs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write ard.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "left.ard"), []byte(`
+struct Store { item: Str }
+`), 0o644); err != nil {
+		t.Fatalf("failed to write left module: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "wrapper.ard"), []byte(`
+use demo/left
+struct Wrapper { store: left::Store }
+`), 0o644); err != nil {
+		t.Fatalf("failed to write wrapper module: %v", err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`
+use demo/wrapper
+
+extern fn get_wrapper() wrapper::Wrapper = {
+  js-server = "getWrapper"
+}
+
+let wrapper_value = get_wrapper()
+`), 0o644); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetJSServer)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower AIR: %v", err)
+	}
+	files, _, err := GenerateSources(program, Options{Target: backend.TargetJSServer, RootFileName: "main.mjs"})
+	if err != nil {
+		t.Fatalf("generate AIR JS sources: %v", err)
+	}
+	source := string(files["main.mjs"])
+	if !strings.Contains(source, `import * as demo_left from "./demo/left.mjs";`) || !strings.Contains(source, "new demo_left.Store") {
+		t.Fatalf("expected nested imported struct adapter dependency, got:\n%s", source)
+	}
+}
+
+func TestGenerateSourcesFromAIRExternAdapterUsesImportedStructRef(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write ard.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "models.ard"), []byte(`
+struct Person { age: Int }
+`), 0o644); err != nil {
+		t.Fatalf("failed to write models module: %v", err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`
+use demo/models
+
+extern fn get_person() models::Person = {
+  js-server = "getPerson"
+}
+
+let person = get_person()
+`), 0o644); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetJSServer)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower AIR: %v", err)
+	}
+	files, _, err := GenerateSources(program, Options{Target: backend.TargetJSServer, RootFileName: "main.mjs"})
+	if err != nil {
+		t.Fatalf("generate AIR JS sources: %v", err)
+	}
+	source := string(files["main.mjs"])
+	if !strings.Contains(source, "new demo_models.Person") || !strings.Contains(source, "instanceof demo_models.Person") {
+		t.Fatalf("expected imported struct adapter to use qualified type ref, got:\n%s", source)
+	}
+}
+
+func TestGenerateSourcesFromAIRSameNamedImportedStructs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write ard.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "left.ard"), []byte(`
+struct Store { item: Str }
+fn new() Store { Store{item: "left"} }
+`), 0o644); err != nil {
+		t.Fatalf("failed to write left module: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "right.ard"), []byte(`
+struct Store { column: Str }
+fn new() Store { Store{column: "right"} }
+`), 0o644); err != nil {
+		t.Fatalf("failed to write right module: %v", err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`
+use demo/left
+use demo/right
+
+let left_store = left::new()
+let right_store = right::new()
+`), 0o644); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetJSServer)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower AIR: %v", err)
+	}
+	files, _, err := GenerateSources(program, Options{Target: backend.TargetJSServer, RootFileName: "main.mjs"})
+	if err != nil {
+		t.Fatalf("generate AIR JS sources: %v", err)
+	}
+	mainSource := string(files["main.mjs"])
+	leftSource := string(files["demo/left.mjs"])
+	rightSource := string(files["demo/right.mjs"])
+	if strings.Contains(mainSource, "class Store") {
+		t.Fatalf("root module should import same-named structs instead of redeclaring them:\n%s", mainSource)
+	}
+	if !strings.Contains(leftSource, "class Store") || !strings.Contains(leftSource, "constructor(item)") {
+		t.Fatalf("expected left Store declaration, got:\n%s", leftSource)
+	}
+	if !strings.Contains(rightSource, "class Store") || !strings.Contains(rightSource, "constructor(column)") {
+		t.Fatalf("expected right Store declaration, got:\n%s", rightSource)
+	}
+}
+
 func TestGenerateSourcesFromAIRImportedStructConstruction(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
@@ -1430,8 +1569,9 @@ let person = models::Person{age: 42}
 		t.Fatalf("generate AIR JS sources: %v", err)
 	}
 	source := string(files["main.mjs"])
-	if !strings.Contains(source, "class Person") || !strings.Contains(source, "new demo_models.Person(42)") {
-		t.Fatalf("expected imported struct type declaration and qualified constructor, got:\n%s", source)
+	modelSource := string(files["demo/models.mjs"])
+	if !strings.Contains(modelSource, "class Person") || !strings.Contains(source, "new demo_models.Person(42)") {
+		t.Fatalf("expected imported struct type declaration and qualified constructor, got main:\n%s\nmodels:\n%s", source, modelSource)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Track module ownership on named structs/enums/unions so same-named types from different modules stay nominally distinct
- Include module identity in AIR type keys and Go generated type names
- Emit/import JS type declarations from owner modules, including nested extern adapter dependencies

## Tests
- cd compiler && go test ./checker ./air ./go ./javascript -count=1
- cd compiler && go generate ./std_lib/ffi && go test ./...
