### PR TITLE
feat(compiler)!: use mutable reference semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ let alice = Person { name: "Alice", age: 30 }
 update_person(alice) // Error: expected a mutable Person
 ```
 
+Struct fields can also hold mutable references:
+
+```ard
+struct Context {
+    tree: mut ViewTree,
+}
+
+let ctx = Context { tree: tree }
+ctx.tree.add_child(child)
+```
+
+The `ctx` binding is immutable, but `ctx.tree` is mutable access to the referenced `ViewTree`. Field assignment writes through the reference; it does not rebind the field slot.
+
 Explicit copy support belongs in the standard library as `ard/core::copy(value)`. Use that when an independent deep copy is intended. Generic deep-copy coverage is still being defined.
 
 #### Increment/Decrement short hand

--- a/README.md
+++ b/README.md
@@ -36,32 +36,28 @@ let name: Str = "Alice"
 mut age = 30
 ```
 
-#### Copy Semantics
+#### Mutable References and Explicit Copies
 
-Ard uses explicit copy semantics to ensure data safety:
+Ard uses `mut` for mutable access. A mutable function parameter receives a mutable reference to caller-owned storage, so the caller must pass an addressable mutable value:
 
-**Function Parameters**: When a function parameter is mutable, you must use the `mut` keyword to create a copy:
 ```ard
 fn update_person(mut person: Person) {
-    person.age = 99  // Only affects the copy
+    person.age = 99  // Mutates the caller's value
 }
 
-let alice = Person { name: "Alice", age: 30 }
-update_person(mut alice)  // Explicitly request a copy with `mut`
-// alice.age is still 30 (original unchanged)
+mut alice = Person { name: "Alice", age: 30 }
+update_person(alice)
+// alice.age is now 99
 ```
 
-**Variable Assignment**: When assigning complex types (structs, lists, maps) to mutable variables, Ard creates copies:
+Immutable values cannot be passed where mutable access is required:
+
 ```ard
-let original = Person { name: "Alice", age: 30 }
-mut copy = original  // Creates a deep copy
-copy.age = 31
-// original.age is still 30, copy.age is 31
+let alice = Person { name: "Alice", age: 30 }
+update_person(alice) // Error: expected a mutable Person
 ```
 
-**Identity vs Equality**: Copied values are equal in content but not identical in memory. This prevents accidental mutation of shared data while maintaining value semantics.
-
-**Note**: Primitives (Int, Str, Bool, etc.) and functions are immutable, so they don't trigger copying for simple assignments. When passed to mutable parameters with the `mut` keyword, they are copied for consistency.
+Explicit copy support belongs in the standard library as `ard/core::copy(value)`. Use that when an independent deep copy is intended. Generic deep-copy coverage is still being defined.
 
 #### Increment/Decrement short hand
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ let name: Str = "Alice"
 mut age = 30
 ```
 
-#### Mutable References and Explicit Copies
+#### Mutable References
 
 Ard uses `mut` for mutable access. A mutable function parameter receives a mutable reference to caller-owned storage, so the caller must pass an addressable mutable value:
 
@@ -69,8 +69,6 @@ ctx.tree.add_child(child)
 ```
 
 The `ctx` binding is immutable, but `ctx.tree` is mutable access to the referenced `ViewTree`. Field assignment writes through the reference; it does not rebind the field slot.
-
-Explicit copy support belongs in the standard library as `ard/core::copy(value)`. Use that when an independent deep copy is intended. Generic deep-copy coverage is still being defined.
 
 #### Increment/Decrement short hand
 

--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -2753,12 +2753,6 @@ func (fl *functionLowerer) lowerExpr(expr checker.Expression) (*Expr, error) {
 		return &Expr{Kind: ExprPanic, Type: typeID, Target: message}, nil
 	case *checker.TemplateStr:
 		return fl.lowerTemplateStr(typeID, e)
-	case *checker.CopyExpression:
-		value, err := fl.lowerExprWithExpected(e.Expr, typeID)
-		if err != nil {
-			return nil, err
-		}
-		return &Expr{Kind: ExprCopy, Type: typeID, Target: value}, nil
 	case *checker.FunctionDef:
 		return fl.lowerClosure(typeID, e)
 	case *checker.FiberStart:

--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -1419,15 +1419,19 @@ func signatureForFunctionWithInterner(params []checker.Parameter, returnType che
 }
 
 func functionHasUnresolvedTypeVar(def *checker.FunctionDef) bool {
+	return typeHasUnresolvedTypeVarSeen(def, map[checker.Type]struct{}{})
+}
+
+func functionSignatureHasUnresolvedTypeVarSeen(def *checker.FunctionDef, seen map[checker.Type]struct{}) bool {
 	if def == nil {
 		return false
 	}
 	for _, param := range def.Parameters {
-		if typeHasUnresolvedTypeVar(param.Type) {
+		if typeHasUnresolvedTypeVarSeen(param.Type, seen) {
 			return true
 		}
 	}
-	return typeHasUnresolvedTypeVar(def.ReturnType)
+	return typeHasUnresolvedTypeVarSeen(def.ReturnType, seen)
 }
 
 func functionHasTypeVar(def *checker.FunctionDef) bool {
@@ -1443,15 +1447,19 @@ func functionHasTypeVar(def *checker.FunctionDef) bool {
 }
 
 func externalFunctionHasUnresolvedTypeVar(def *checker.ExternalFunctionDef) bool {
+	return typeHasUnresolvedTypeVarSeen(def, map[checker.Type]struct{}{})
+}
+
+func externalFunctionSignatureHasUnresolvedTypeVarSeen(def *checker.ExternalFunctionDef, seen map[checker.Type]struct{}) bool {
 	if def == nil {
 		return false
 	}
 	for _, param := range def.Parameters {
-		if typeHasUnresolvedTypeVar(param.Type) {
+		if typeHasUnresolvedTypeVarSeen(param.Type, seen) {
 			return true
 		}
 	}
-	return typeHasUnresolvedTypeVar(def.ReturnType)
+	return typeHasUnresolvedTypeVarSeen(def.ReturnType, seen)
 }
 
 func typeContainsTypeVar(t checker.Type) bool {
@@ -1562,9 +1570,9 @@ func typeHasUnresolvedTypeVarSeen(t checker.Type, seen map[checker.Type]struct{}
 		}
 		return false
 	case *checker.FunctionDef:
-		return functionHasUnresolvedTypeVar(typ)
+		return functionSignatureHasUnresolvedTypeVarSeen(typ, seen)
 	case *checker.ExternalFunctionDef:
-		return externalFunctionHasUnresolvedTypeVar(typ)
+		return externalFunctionSignatureHasUnresolvedTypeVarSeen(typ, seen)
 	case *checker.ExternType:
 		for _, typeArg := range typ.TypeArgs {
 			if typeHasUnresolvedTypeVarSeen(typeArg, seen) {
@@ -1646,11 +1654,11 @@ func airTypeKeySeen(t checker.Type, seen map[checker.Type]struct{}) string {
 	case *checker.Enum:
 		return airEnumKey(typ)
 	case *checker.Union:
-		return airUnionKey(typ)
+		return airUnionKeySeen(typ, seen)
 	case *checker.FunctionDef:
-		return airFunctionTypeKey(typ.Parameters, typ.ReturnType)
+		return airFunctionTypeKeySeen(typ.Parameters, typ.ReturnType, seen)
 	case *checker.ExternalFunctionDef:
-		return airFunctionTypeKey(typ.Parameters, typ.ReturnType)
+		return airFunctionTypeKeySeen(typ.Parameters, typ.ReturnType, seen)
 	case *checker.ExternType:
 		if len(typ.TypeArgs) == 0 {
 			return "extern " + typ.Name_
@@ -1693,7 +1701,7 @@ func airStructKeySeen(typ *checker.StructDef, seen map[checker.Type]struct{}) st
 			key += ","
 		}
 		method := typ.Methods[name]
-		key += name + ":" + airFunctionTypeKey(method.Parameters, method.ReturnType)
+		key += name + ":" + airFunctionTypeKeySeen(method.Parameters, method.ReturnType, seen)
 	}
 	key += "}"
 	return key
@@ -1712,9 +1720,13 @@ func airEnumKey(typ *checker.Enum) string {
 }
 
 func airUnionKey(typ *checker.Union) string {
+	return airUnionKeySeen(typ, map[checker.Type]struct{}{})
+}
+
+func airUnionKeySeen(typ *checker.Union, seen map[checker.Type]struct{}) string {
 	parts := make([]string, len(typ.Types))
 	for i, member := range typ.Types {
-		parts[i] = airTypeKey(member)
+		parts[i] = airTypeKeySeen(member, seen)
 	}
 	sort.Strings(parts)
 	key := "union " + typ.ModulePath + "::" + typ.Name + "{"
@@ -1729,6 +1741,10 @@ func airUnionKey(typ *checker.Union) string {
 }
 
 func airFunctionTypeKey(params []checker.Parameter, returnType checker.Type) string {
+	return airFunctionTypeKeySeen(params, returnType, map[checker.Type]struct{}{})
+}
+
+func airFunctionTypeKeySeen(params []checker.Parameter, returnType checker.Type, seen map[checker.Type]struct{}) string {
 	key := "fn("
 	for i, param := range params {
 		if i > 0 {
@@ -1737,9 +1753,9 @@ func airFunctionTypeKey(params []checker.Parameter, returnType checker.Type) str
 		if param.Mutable {
 			key += "mut "
 		}
-		key += airTypeKey(param.Type)
+		key += airTypeKeySeen(param.Type, seen)
 	}
-	key += ")->" + airTypeKey(returnType)
+	key += ")->" + airTypeKeySeen(returnType, seen)
 	return key
 }
 

--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -557,6 +557,8 @@ func (fl *functionLowerer) bindTypeVars(pattern checker.Type, actual TypeID) {
 		if actualInfo.Kind == TypeMaybe {
 			fl.bindTypeVars(typ.Of(), actualInfo.Elem)
 		}
+	case *checker.MutableRef:
+		fl.bindTypeVars(typ.Of(), actual)
 	case *checker.Result:
 		if actualInfo.Kind == TypeResult {
 			fl.bindTypeVars(typ.Val(), actualInfo.Value)
@@ -1178,6 +1180,8 @@ func (l *lowerer) internType(t checker.Type) (TypeID, error) {
 		}
 		info.Kind = TypeMaybe
 		info.Elem = elem
+	case *checker.MutableRef:
+		return l.internType(typ.Of())
 	case *checker.Result:
 		value, err := l.internType(typ.Val())
 		if err != nil {
@@ -1209,11 +1213,16 @@ func (l *lowerer) internType(t checker.Type) (TypeID, error) {
 		info.Fields = make([]FieldInfo, len(fields))
 		for i, name := range fields {
 			fieldTypeValue := typ.Fields[name]
+			fieldMutable := false
+			if ref, ok := fieldTypeValue.(*checker.MutableRef); ok {
+				fieldTypeValue = ref.Of()
+				fieldMutable = true
+			}
 			fieldType, err := l.internType(fieldTypeValue)
 			if err != nil {
 				return NoType, err
 			}
-			info.Fields[i] = FieldInfo{Name: name, Type: fieldType, Index: i, RecursiveNullable: isRecursiveNullableStructField(typ, fieldTypeValue)}
+			info.Fields[i] = FieldInfo{Name: name, Type: fieldType, Index: i, Mutable: fieldMutable, RecursiveNullable: !fieldMutable && isRecursiveNullableStructField(typ, fieldTypeValue)}
 		}
 	case *checker.Enum:
 		info.Kind = TypeEnum
@@ -1315,6 +1324,9 @@ func (l *lowerer) internSyntheticType(name string, info TypeInfo) (TypeID, error
 }
 
 func (l *lowerer) typeOwnerPath(t checker.Type) string {
+	if ref, ok := t.(*checker.MutableRef); ok {
+		return l.typeOwnerPath(ref.Of())
+	}
 	var name string
 	switch typ := t.(type) {
 	case *checker.StructDef:
@@ -1443,45 +1455,61 @@ func externalFunctionHasUnresolvedTypeVar(def *checker.ExternalFunctionDef) bool
 }
 
 func typeContainsTypeVar(t checker.Type) bool {
-	switch typ := t.(type) {
-	case nil:
+	return typeContainsTypeVarSeen(t, map[checker.Type]struct{}{})
+}
+
+func typeContainsTypeVarSeen(t checker.Type, seen map[checker.Type]struct{}) bool {
+	if t == nil {
 		return false
+	}
+	if _, ok := seen[t]; ok {
+		return false
+	}
+	seen[t] = struct{}{}
+	switch typ := t.(type) {
 	case *checker.TypeVar:
 		return true
 	case *checker.List:
-		return typeContainsTypeVar(typ.Of())
+		return typeContainsTypeVarSeen(typ.Of(), seen)
 	case *checker.Map:
-		return typeContainsTypeVar(typ.Key()) || typeContainsTypeVar(typ.Value())
+		return typeContainsTypeVarSeen(typ.Key(), seen) || typeContainsTypeVarSeen(typ.Value(), seen)
 	case *checker.Maybe:
-		return typeContainsTypeVar(typ.Of())
+		return typeContainsTypeVarSeen(typ.Of(), seen)
 	case *checker.Result:
-		return typeContainsTypeVar(typ.Val()) || typeContainsTypeVar(typ.Err())
+		return typeContainsTypeVarSeen(typ.Val(), seen) || typeContainsTypeVarSeen(typ.Err(), seen)
+	case *checker.MutableRef:
+		return typeContainsTypeVarSeen(typ.Of(), seen)
 	case *checker.Union:
 		for _, member := range typ.Types {
-			if typeContainsTypeVar(member) {
+			if typeContainsTypeVarSeen(member, seen) {
 				return true
 			}
 		}
 		return false
 	case *checker.StructDef:
 		for _, fieldType := range typ.Fields {
-			if typeContainsTypeVar(fieldType) {
+			if typeContainsTypeVarSeen(fieldType, seen) {
 				return true
 			}
 		}
 		return false
 	case *checker.FunctionDef:
-		return functionHasTypeVar(typ)
-	case *checker.ExternalFunctionDef:
 		for _, param := range typ.Parameters {
-			if typeContainsTypeVar(param.Type) {
+			if typeContainsTypeVarSeen(param.Type, seen) {
 				return true
 			}
 		}
-		return typeContainsTypeVar(typ.ReturnType)
+		return typeContainsTypeVarSeen(typ.ReturnType, seen)
+	case *checker.ExternalFunctionDef:
+		for _, param := range typ.Parameters {
+			if typeContainsTypeVarSeen(param.Type, seen) {
+				return true
+			}
+		}
+		return typeContainsTypeVarSeen(typ.ReturnType, seen)
 	case *checker.ExternType:
 		for _, typeArg := range typ.TypeArgs {
-			if typeContainsTypeVar(typeArg) {
+			if typeContainsTypeVarSeen(typeArg, seen) {
 				return true
 			}
 		}
@@ -1517,6 +1545,8 @@ func typeHasUnresolvedTypeVarSeen(t checker.Type, seen map[checker.Type]struct{}
 		return typeHasUnresolvedTypeVarSeen(typ.Of(), seen)
 	case *checker.Result:
 		return typeHasUnresolvedTypeVarSeen(typ.Val(), seen) || typeHasUnresolvedTypeVarSeen(typ.Err(), seen)
+	case *checker.MutableRef:
+		return typeHasUnresolvedTypeVarSeen(typ.Of(), seen)
 	case *checker.Union:
 		for _, member := range typ.Types {
 			if typeHasUnresolvedTypeVarSeen(member, seen) {
@@ -1601,6 +1631,8 @@ func airTypeKeySeen(t checker.Type, seen map[checker.Type]struct{}) string {
 		return "maybe<" + airTypeKeySeen(typ.Of(), seen) + ">"
 	case *checker.Result:
 		return "result<" + airTypeKeySeen(typ.Val(), seen) + "," + airTypeKeySeen(typ.Err(), seen) + ">"
+	case *checker.MutableRef:
+		return "mut<" + airTypeKeySeen(typ.Of(), seen) + ">"
 	case *checker.StructDef:
 		if typ.Name == "Fiber" {
 			if elem, ok := typ.Fields["result"]; ok {

--- a/compiler/air/nodes.go
+++ b/compiler/air/nodes.go
@@ -54,7 +54,6 @@ const (
 	ExprMatchUnion
 	ExprTraitUpcast
 	ExprCallTrait
-	ExprCopy
 	ExprMakeList
 	ExprListAt
 	ExprListPrepend

--- a/compiler/air/recursive_types.go
+++ b/compiler/air/recursive_types.go
@@ -39,6 +39,8 @@ func typeReferencesStruct(t checker.Type, owner *checker.StructDef, seen map[che
 		return typeReferencesStruct(typ.Of(), owner, seen)
 	case *checker.Result:
 		return typeReferencesStruct(typ.Val(), owner, seen) || typeReferencesStruct(typ.Err(), owner, seen)
+	case *checker.MutableRef:
+		return typeReferencesStruct(typ.Of(), owner, seen)
 	case *checker.Union:
 		for _, member := range typ.Types {
 			if typeReferencesStruct(member, owner, seen) {

--- a/compiler/air/recursive_types.go
+++ b/compiler/air/recursive_types.go
@@ -7,8 +7,47 @@ func isRecursiveNullableStructField(owner *checker.StructDef, field checker.Type
 	if !ok {
 		return false
 	}
-	structType, ok := maybe.Of().(*checker.StructDef)
-	return ok && sameStructIdentity(structType, owner)
+	return nullablePayloadReferencesStruct(maybe.Of(), owner, map[checker.Type]struct{}{})
+}
+
+func nullablePayloadReferencesStruct(t checker.Type, owner *checker.StructDef, seen map[checker.Type]struct{}) bool {
+	if t == nil {
+		return false
+	}
+	if typeVar, ok := t.(*checker.TypeVar); ok && typeVar.Actual() != nil {
+		t = typeVar.Actual()
+	}
+	if _, ok := seen[t]; ok {
+		return false
+	}
+	seen[t] = struct{}{}
+	switch typ := t.(type) {
+	case *checker.StructDef:
+		if sameStructIdentity(typ, owner) {
+			return true
+		}
+		for _, field := range typ.Fields {
+			if nullablePayloadReferencesStruct(field, owner, seen) {
+				return true
+			}
+		}
+		return false
+	case *checker.Result:
+		return nullablePayloadReferencesStruct(typ.Val(), owner, seen) || nullablePayloadReferencesStruct(typ.Err(), owner, seen)
+	case *checker.Union:
+		for _, member := range typ.Types {
+			if nullablePayloadReferencesStruct(member, owner, seen) {
+				return true
+			}
+		}
+		return false
+	case *checker.Maybe:
+		return nullablePayloadReferencesStruct(typ.Of(), owner, seen)
+	case *checker.MutableRef, *checker.List, *checker.Map, *checker.Trait, *checker.ExternType, *checker.FunctionDef, *checker.ExternalFunctionDef:
+		return false
+	default:
+		return false
+	}
 }
 
 func hasSelfReference(owner *checker.StructDef) bool {
@@ -24,13 +63,24 @@ func typeReferencesStruct(t checker.Type, owner *checker.StructDef, seen map[che
 	if t == nil {
 		return false
 	}
+	if typeVar, ok := t.(*checker.TypeVar); ok && typeVar.Actual() != nil {
+		t = typeVar.Actual()
+	}
 	if _, ok := seen[t]; ok {
 		return false
 	}
 	seen[t] = struct{}{}
 	switch typ := t.(type) {
 	case *checker.StructDef:
-		return sameStructIdentity(typ, owner)
+		if sameStructIdentity(typ, owner) {
+			return true
+		}
+		for _, field := range typ.Fields {
+			if typeReferencesStruct(field, owner, seen) {
+				return true
+			}
+		}
+		return false
 	case *checker.List:
 		return typeReferencesStruct(typ.Of(), owner, seen)
 	case *checker.Map:

--- a/compiler/air/types.go
+++ b/compiler/air/types.go
@@ -136,6 +136,7 @@ type FieldInfo struct {
 	Name              string
 	Type              TypeID
 	Index             int
+	Mutable           bool
 	RecursiveNullable bool
 }
 

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -130,6 +130,12 @@ func derefTypeSeen(t Type, seen map[Type]bool) Type {
 			val: derefVal,
 			err: derefErr,
 		}
+	case *MutableRef:
+		derefInner := derefTypeSeen(typ.of, seen)
+		if derefInner == typ.of {
+			return typ
+		}
+		return MakeMutableRef(derefInner)
 	case *Union:
 		newTypes := make([]Type, len(typ.Types))
 		changed := false
@@ -237,6 +243,9 @@ func (c Checker) isMutable(expr Expression) bool {
 	case *Variable:
 		return e.sym.mutable
 	case *InstanceProperty:
+		if _, ok := mutableRefBase(e._type); ok {
+			return true
+		}
 		return c.isMutable(e.Subject)
 	}
 	return false
@@ -582,6 +591,10 @@ func (c *Checker) resolveType(t parse.DeclaredType) Type {
 	case *parse.VoidType:
 		baseType = Void
 
+	case *parse.MutableType:
+		baseType = MakeMutableRef(c.resolveType(ty.Inner))
+	case parse.MutableType:
+		baseType = MakeMutableRef(c.resolveType(ty.Inner))
 	case *parse.FunctionType:
 		// Convert each parameter type and return type
 		params := make([]Parameter, len(ty.Params))
@@ -1849,6 +1862,7 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 	instance := &StructInstance{Name: structName, _type: structType}
 	fields := make(map[string]Expression)
 	fieldTypes := make(map[string]Type)
+	providedFields := make(map[string]bool)
 
 	// For generic structs, infer generics from provided field values
 	var structDefCopy *StructDef
@@ -1888,6 +1902,15 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 		if !ok {
 			c.addError(fmt.Sprintf("Unknown field: %s", fieldName), property.GetLocation())
 		} else {
+			providedFields[fieldName] = true
+
+			fieldExpected := field
+			fieldIsMutableRef := false
+			if base, ok := mutableRefBase(field); ok {
+				fieldExpected = base
+				fieldIsMutableRef = true
+			}
+
 			// For generic structs, unify types to resolve generics
 			if genericScope != nil {
 				// Check expression without type context first (let it infer if possible)
@@ -1897,27 +1920,37 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 				}
 
 				// Implicit Maybe wrapping: if field is Maybe<T> and value is T, wrap in maybe::some()
-				if maybeField, isMaybe := field.(*Maybe); isMaybe {
-					if valType := checkVal.Type(); !valType.equal(field) {
+				if maybeField, isMaybe := fieldExpected.(*Maybe); isMaybe {
+					if valType := checkVal.Type(); !valType.equal(fieldExpected) {
 						if areCompatible(maybeField.Of(), valType) {
-							checkVal = c.synthesizeMaybeSome(checkVal, field)
+							checkVal = c.synthesizeMaybeSome(checkVal, fieldExpected)
 						}
 					}
 				}
 
-				if err := c.unifyTypes(field, checkVal.Type(), genericScope); err != nil {
+				if fieldIsMutableRef && !c.isMutable(checkVal) {
+					c.addError(fmt.Sprintf("Type mismatch: Expected a mutable %s", fieldExpected.String()), property.GetLocation())
+					continue
+				}
+
+				if err := c.unifyTypes(fieldExpected, checkVal.Type(), genericScope); err != nil {
 					c.addError(err.Error(), property.GetLocation())
 					continue
 				}
 				// After unification, dereference to get the actual type
-				field = derefType(field)
+				fieldExpected = derefType(fieldExpected)
+				if fieldIsMutableRef {
+					field = MakeMutableRef(fieldExpected)
+				} else {
+					field = fieldExpected
+				}
 
 				fields[fieldName] = checkVal
 				fieldTypes[fieldName] = field
 			} else {
 				// For non-generic structs, handle nullable fields with implicit wrapping
 				var val Expression
-				if maybeField, isMaybe := field.(*Maybe); isMaybe {
+				if maybeField, isMaybe := fieldExpected.(*Maybe); isMaybe {
 					// Preserve full Maybe<T> type context for expressions like maybe::some(...)
 					// and maybe::none(), but use the inner type for literals and anonymous
 					// functions so they can still infer their element/parameter types.
@@ -1929,15 +1962,15 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 						}
 					default:
 						diagnosticCount := len(c.diagnostics)
-						val = c.checkExprAs(property.Value, field)
+						val = c.checkExprAs(property.Value, fieldExpected)
 						if val == nil {
 							c.diagnostics = c.diagnostics[:diagnosticCount]
 							val = c.checkExpr(property.Value)
-							if val != nil && !val.Type().equal(field) {
+							if val != nil && !val.Type().equal(fieldExpected) {
 								if areCompatible(maybeField.Of(), val.Type()) {
-									val = c.synthesizeMaybeSome(val, field)
+									val = c.synthesizeMaybeSome(val, fieldExpected)
 								} else {
-									c.addError(typeMismatch(field, val.Type()), property.GetLocation())
+									c.addError(typeMismatch(fieldExpected, val.Type()), property.GetLocation())
 									val = nil
 								}
 							}
@@ -1945,9 +1978,13 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 					}
 				} else {
 					// Non-nullable fields use checkExprAs which provides type context
-					val = c.checkExprAs(property.Value, field)
+					val = c.checkExprAs(property.Value, fieldExpected)
 				}
 				if val != nil {
+					if fieldIsMutableRef && !c.isMutable(val) {
+						c.addError(fmt.Sprintf("Type mismatch: Expected a mutable %s", fieldExpected.String()), property.GetLocation())
+						continue
+					}
 					fields[fieldName] = val
 					fieldTypes[fieldName] = field
 				}
@@ -1965,9 +2002,9 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 	for name, t := range checkFieldsMap {
 		if _, exists := fields[name]; !exists {
 			if _, isMaybe := t.(*Maybe); !isMaybe {
-				// todo: distinguish between provided w/ error + missing to avoid creating 2 errors:
-				// missing field + invalid expression for field
-				missing = append(missing, name)
+				if !providedFields[name] {
+					missing = append(missing, name)
+				}
 			} else {
 				// For optional fields, include their type
 				fieldTypes[name] = t

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -266,16 +266,23 @@ func (c Checker) shouldCopyForMutableAssignment(t Type) bool {
 }
 
 type Checker struct {
-	diagnostics    []Diagnostic
-	input          *parse.Program
-	scope          *SymbolTable
-	filePath       string
-	modulePath     string
-	program        *Program
-	halted         bool
-	moduleResolver *ModuleResolver
-	options        CheckOptions
-	expectedExpr   Type
+	diagnostics                       []Diagnostic
+	input                             *parse.Program
+	scope                             *SymbolTable
+	filePath                          string
+	modulePath                        string
+	program                           *Program
+	halted                            bool
+	moduleResolver                    *ModuleResolver
+	options                           CheckOptions
+	expectedExpr                      Type
+	duplicateTopLevelTypeDeclarations map[parse.Statement]bool
+	topLevelStructDeclarations        map[string]*parse.StructDefinition
+	topLevelTypeAliases               map[string]*parse.TypeDeclaration
+	resolvingTopLevelStructs          map[string]bool
+	resolvedTopLevelStructs           map[string]bool
+	resolvingTopLevelAliases          map[string]bool
+	resolvedTopLevelAliases           map[string]bool
 }
 
 func New(filePath string, input *parse.Program, moduleResolver *ModuleResolver, options ...CheckOptions) *Checker {
@@ -402,7 +409,18 @@ func (c *Checker) Check() {
 		}
 	}
 
+	c.hoistTopLevelTypeDeclarations()
+	c.predeclareTopLevelTypeAliases()
+	c.populateTopLevelTypeDefinitions()
+
 	for i := range c.input.Statements {
+		if stmt := c.checkedTopLevelTypeStatement(c.input.Statements[i]); stmt != nil {
+			c.program.Statements = append(c.program.Statements, *stmt)
+			continue
+		}
+		if isTopLevelTypeDeclaration(c.input.Statements[i]) {
+			continue
+		}
 		if stmt := c.checkStmt(&c.input.Statements[i]); stmt != nil {
 			c.program.Statements = append(c.program.Statements, *stmt)
 		}
@@ -410,6 +428,9 @@ func (c *Checker) Check() {
 			break
 		}
 	}
+
+	c.validateTopLevelTypeAliases()
+	c.checkRecursiveStructLayouts()
 
 	// now that we're done with the aliases, use module paths for the import keys
 	for alias, mod := range c.program.Imports {
@@ -493,6 +514,17 @@ func (c *Checker) findModuleByPath(path string) Module {
 	return nil
 }
 
+func namedTypeRequiresTypeArguments(t Type) bool {
+	switch typ := t.(type) {
+	case *StructDef:
+		return len(typ.GenericParams) > 0 || hasGenericsInType(typ)
+	case *ExternType:
+		return len(typ.GenericParams) > 0 || hasGenericsInType(typ)
+	default:
+		return hasGenericsInType(typ)
+	}
+}
+
 func collectGenericsFromType(t Type, params *[]string, seen map[string]bool) {
 	switch t := t.(type) {
 	case *TypeVar:
@@ -554,6 +586,21 @@ func (c *Checker) specializeAliasedType(originalType Type, typeArgs []parse.Decl
 	}
 
 	if structDef, ok := originalType.(*StructDef); ok {
+		if c.isResolvingStructDefinition(structDef) {
+			c.addError(fmt.Sprintf("Recursive generic self-reference %s is not supported yet", structDef.Name), loc)
+			return structDef
+		}
+		c.ensureStructDefinitionResolved(structDef)
+		genericParams = []string{}
+		seenGenerics = make(map[string]bool)
+		collectGenericsFromType(originalType, &genericParams, seenGenerics)
+		if len(genericParams) == 0 && len(structDef.GenericParams) > 0 {
+			genericParams = append(genericParams, structDef.GenericParams...)
+		}
+		if len(typeArgs) != len(genericParams) {
+			c.addError(fmt.Sprintf("Incorrect number of type arguments: expected %d, got %d", len(genericParams), len(typeArgs)), loc)
+			return originalType
+		}
 		typeVarMap := make(map[string]*TypeVar, len(genericParams))
 		for i, typeArg := range typeArgs {
 			resolvedArgType := c.resolveType(typeArg)
@@ -637,12 +684,17 @@ func (c *Checker) resolveType(t parse.DeclaredType) Type {
 			baseType = Dynamic
 			break
 		}
+		if ty.Type.Target == nil && c.topLevelTypeAliases != nil {
+			if _, ok := c.topLevelTypeAliases[t.GetName()]; ok {
+				c.resolveTopLevelTypeAlias(t.GetName())
+			}
+		}
 
 		if sym, ok := c.scope.get(t.GetName()); ok {
 			if len(ty.TypeArgs) > 0 {
 				baseType = c.specializeAliasedType(sym.Type, ty.TypeArgs, ty.GetLocation())
 			} else {
-				if hasGenericsInType(sym.Type) {
+				if namedTypeRequiresTypeArguments(sym.Type) {
 					c.addError(fmt.Sprintf("Generic type %s requires type arguments", t.GetName()), ty.GetLocation())
 				}
 				baseType = sym.Type
@@ -658,7 +710,7 @@ func (c *Checker) resolveType(t parse.DeclaredType) Type {
 					if len(ty.TypeArgs) > 0 {
 						baseType = c.specializeAliasedType(sym.Type, ty.TypeArgs, ty.GetLocation())
 					} else {
-						if hasGenericsInType(sym.Type) {
+						if namedTypeRequiresTypeArguments(sym.Type) {
 							c.addError(fmt.Sprintf("Generic type %s::%s requires type arguments", ty.Type.Target, ty.Type.Property), ty.GetLocation())
 						}
 						baseType = sym.Type
@@ -739,6 +791,9 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 	if c.halted {
 		return nil
 	}
+	if c.isDuplicateTopLevelTypeDeclaration(*stmt) {
+		return nil
+	}
 	switch s := (*stmt).(type) {
 	case *parse.Comment:
 		return nil
@@ -746,6 +801,10 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 		return &Statement{Break: true}
 	case *parse.TraitDefinition:
 		{
+			trait, ok := c.hoistedTrait(s.Name.Name)
+			if !ok {
+				return nil
+			}
 			methods := make([]FunctionDef, len(s.Methods))
 			for i, method := range s.Methods {
 				params := make([]Parameter, len(method.Parameters))
@@ -775,13 +834,9 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 				}
 			}
 
-			trait := Trait{
-				private: s.Private,
-				Name:    s.Name.Name,
-				methods: methods,
-			}
-
-			c.scope.add(trait.name(), &trait, false)
+			trait.private = s.Private
+			trait.Name = s.Name.Name
+			trait.methods = methods
 			return nil
 		}
 	case *parse.TraitImplementation:
@@ -995,8 +1050,8 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 		}
 	case *parse.ExternTypeDeclaration:
 		{
-			if _, dup := c.scope.get(s.Name); dup {
-				c.addError(fmt.Sprintf("Duplicate declaration: %s", s.Name), s.GetLocation())
+			externType, ok := c.hoistedExternType(s.Name)
+			if !ok {
 				return nil
 			}
 			typeArgs := make([]Type, len(s.TypeParams))
@@ -1012,12 +1067,22 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 				return nil
 			}
 			resolvedTarget, resolvedBinding := resolveExternalBindingForTarget(c.options.Target, bindings)
-			externType := &ExternType{Name_: s.Name, GenericParams: append([]string(nil), s.TypeParams...), TypeArgs: typeArgs, ExternalBinding: resolvedBinding, ExternalBindingTarget: resolvedTarget, ExternalBindings: bindings, private: s.Private}
-			c.scope.add(s.Name, externType, false)
+			externType.Name_ = s.Name
+			externType.GenericParams = append([]string(nil), s.TypeParams...)
+			externType.TypeArgs = typeArgs
+			externType.ExternalBinding = resolvedBinding
+			externType.ExternalBindingTarget = resolvedTarget
+			externType.ExternalBindings = bindings
+			externType.private = s.Private
 			return &Statement{Stmt: externType}
 		}
 	case *parse.TypeDeclaration:
 		{
+			if len(s.Type) == 1 {
+				if _, exists := c.scope.get(s.Name.Name); exists {
+					return nil
+				}
+			}
 			// Handle type declaration (type unions/aliases)
 			types := make([]Type, len(s.Type))
 			for i, declType := range s.Type {
@@ -1035,16 +1100,14 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 				return nil
 			}
 
-			// Create a union type (even if it only contains one type)
-			unionType := &Union{
-				Name:       s.Name.Name,
-				ModulePath: c.typeOwnerPath(),
-				Types:      types,
+			unionType, ok := c.hoistedUnion(s.Name.Name)
+			if !ok {
+				return nil
 			}
-
-			// Register the type in the scope with the given name
-			c.scope.add(unionType.name(), unionType, false)
-			return nil
+			unionType.Name = s.Name.Name
+			unionType.ModulePath = c.typeOwnerPath()
+			unionType.Types = types
+			return &Statement{Stmt: unionType}
 		}
 	case *parse.VariableDeclaration:
 		{
@@ -1396,6 +1459,10 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 		}
 	case *parse.EnumDefinition:
 		{
+			enum, ok := c.hoistedEnum(s.Name)
+			if !ok {
+				return nil
+			}
 			if len(s.Variants) == 0 {
 				c.addError("Enums must have at least one variant", s.GetLocation())
 				return nil
@@ -1453,44 +1520,22 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 				})
 			}
 
-			enum := &Enum{
-				Private:    s.Private,
-				Name:       s.Name,
-				ModulePath: c.typeOwnerPath(),
-				Values:     computedValues,
-				Methods:    make(map[string]*FunctionDef),
+			enum.Private = s.Private
+			enum.Name = s.Name
+			enum.ModulePath = c.typeOwnerPath()
+			enum.Values = computedValues
+			if enum.Methods == nil {
+				enum.Methods = make(map[string]*FunctionDef)
 			}
-
-			c.scope.add(enum.name(), enum, false)
 			return nil
 		}
 	case *parse.StructDefinition:
 		{
-			def := &StructDef{
-				Name:       s.Name.Name,
-				ModulePath: c.typeOwnerPath(),
-				Fields:     make(map[string]Type),
-				Methods:    make(map[string]*FunctionDef),
-				Private:    s.Private,
+			def, ok := c.hoistedStruct(s.Name.Name)
+			if !ok {
+				return nil
 			}
-			c.scope.add(def.name(), def, false)
-			seenGenerics := make(map[string]bool)
-			for _, field := range s.Fields {
-				fieldType := c.resolveType(field.Type)
-				if fieldType == nil {
-					return nil
-				}
-
-				if _, dup := def.Fields[field.Name.Name]; dup {
-					c.addError(fmt.Sprintf("Duplicate field: %s", field.Name.Name), field.Name.GetLocation())
-					return nil
-				}
-				if recursiveFieldHasInfiniteSize(field.Type, def.Name, false) {
-					c.addError(fmt.Sprintf("Recursive field %s.%s has infinite size. Put the recursive reference behind a list, map, or nullable type.", def.Name, field.Name.Name), field.Name.GetLocation())
-				}
-				def.Fields[field.Name.Name] = fieldType
-				collectGenericsFromType(fieldType, &def.GenericParams, seenGenerics)
-			}
+			c.populateStructDefinition(def, s)
 			return &Statement{Stmt: def}
 		}
 	case *parse.ImplBlock:

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -251,20 +251,6 @@ func (c Checker) isMutable(expr Expression) bool {
 	return false
 }
 
-// shouldCopyForMutableAssignment determines if we should copy for mut variable assignments.
-// TODO: replace implicit copies with explicit ard/core::copy once generic deep-copy
-// semantics are implemented.
-func (c Checker) shouldCopyForMutableAssignment(t Type) bool {
-	switch t.(type) {
-	case *StructDef, *List, *Map:
-		// Complex types that benefit from copy semantics
-		return true
-	default:
-		// Primitives (Int, Str, Bool, etc.) are immutable anyway, no need to copy
-		return false
-	}
-}
-
 type Checker struct {
 	diagnostics                       []Diagnostic
 	input                             *parse.Program
@@ -1161,15 +1147,6 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 						return nil
 					}
 					__type = expected
-				}
-			}
-
-			// Apply copy semantics for mutable variable assignments
-			if s.Mutable && c.shouldCopyForMutableAssignment(val.Type()) {
-				// Always wrap in copy expression for mutable assignment of copyable types
-				val = &CopyExpression{
-					Expr:  val,
-					Type_: val.Type(),
 				}
 			}
 

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -242,15 +242,9 @@ func (c Checker) isMutable(expr Expression) bool {
 	return false
 }
 
-// isCopyable returns true if the type can be copied for mut parameters
-func (c Checker) isCopyable(_ Type) bool {
-	// In Ard, all types are copyable by default
-	// Future: might exclude external resources like file handles
-	return true
-}
-
-// shouldCopyForMutableAssignment determines if we should copy for mut variable assignments
-// This is more conservative than isCopyable to avoid unnecessary copying of primitives
+// shouldCopyForMutableAssignment determines if we should copy for mut variable assignments.
+// TODO: replace implicit copies with explicit ard/core::copy once generic deep-copy
+// semantics are implemented.
 func (c Checker) shouldCopyForMutableAssignment(t Type) bool {
 	switch t.(type) {
 	case *StructDef, *List, *Map:
@@ -2542,14 +2536,11 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				resolvedExprs = resolvedExprs[:len(fnDef.Parameters)]
 			}
 
-			// Align mutability information with parameters
-			resolvedArgs := c.alignArgumentsWithParameters(s.Args, fnDef.Parameters)
-
 			// Setup generics if function has them
 			fnDefCopy, genericScope := c.setupFunctionGenerics(fnDef)
 
 			// Check and process arguments (handles both generics and mutability)
-			args, fnToUse := c.checkAndProcessArguments(fnDef, resolvedArgs, resolvedExprs, fnDefCopy, genericScope, numOmittedArgs)
+			args, fnToUse := c.checkAndProcessArguments(fnDef, resolvedExprs, fnDefCopy, genericScope, numOmittedArgs)
 			if args == nil {
 				return nil
 			}
@@ -2657,9 +2648,6 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				resolvedExprs = resolvedExprs[:len(fnDef.Parameters)]
 			}
 
-			// Align mutability information with parameters
-			resolvedArgs := c.alignArgumentsWithParameters(s.Method.Args, fnDef.Parameters)
-
 			// For methods on generic struct instances, bind struct generics to method parameters.
 			// When calling a method on a generic struct instance, the method's generic parameters
 			// should use the types that were resolved during struct instantiation.
@@ -2727,7 +2715,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 			}
 
 			// Check and process arguments (handles both generics and mutability)
-			args, fnToUse := c.checkAndProcessArguments(fnDef, resolvedArgs, resolvedExprs, fnDefCopy, genericScope, numOmittedArgs)
+			args, fnToUse := c.checkAndProcessArguments(fnDef, resolvedExprs, fnDefCopy, genericScope, numOmittedArgs)
 			if args == nil {
 				return nil
 			}
@@ -3214,14 +3202,11 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 				resolvedExprs = resolvedExprs[:len(fnDef.Parameters)]
 			}
 
-			// Align mutability information with parameters
-			resolvedArgs := c.alignArgumentsWithParameters(s.Function.Args, fnDef.Parameters)
-
 			// Setup generics if function has them
 			fnDefCopy, genericScope := c.setupFunctionGenerics(fnDef)
 
 			// Check and process arguments (handles both generics and mutability)
-			args, fnToUse := c.checkAndProcessArguments(fnDef, resolvedArgs, resolvedExprs, fnDefCopy, genericScope, numOmittedArgs)
+			args, fnToUse := c.checkAndProcessArguments(fnDef, resolvedExprs, fnDefCopy, genericScope, numOmittedArgs)
 			if args == nil {
 				return nil
 			}
@@ -4966,39 +4951,6 @@ func substituteType(t Type, typeMap map[string]Type) Type {
 	}
 }
 
-// alignArgumentsWithParameters converts a list of (possibly named) arguments to positional form,
-// aligned with function parameters and preserving mutability information.
-func (c *Checker) alignArgumentsWithParameters(args []parse.Argument, params []Parameter) []parse.Argument {
-	resolvedArgs := make([]parse.Argument, len(params))
-
-	if len(args) == 0 {
-		return resolvedArgs
-	}
-
-	// If arguments have names, reorder them to match parameter positions
-	if args[0].Name != "" {
-		paramMap := make(map[string]int)
-		for i, param := range params {
-			paramMap[param.Name] = i
-		}
-		for _, arg := range args {
-			if index, exists := paramMap[arg.Name]; exists {
-				resolvedArgs[index] = parse.Argument{
-					Location: arg.Location,
-					Name:     "",
-					Value:    arg.Value,
-					Mutable:  arg.Mutable,
-				}
-			}
-		}
-	} else {
-		// Positional arguments - direct copy
-		copy(resolvedArgs, args)
-	}
-
-	return resolvedArgs
-}
-
 // setupFunctionGenerics sets up generic scope and function copy for generic functions.
 // Returns the function copy (with fresh TypeVar instances for generics) and the generic scope.
 // For non-generic functions, returns the original function and a nil scope.
@@ -5084,10 +5036,10 @@ func (c *Checker) synthesizeMaybeSome(value Expression, maybeType Type) Expressi
 
 // checkAndProcessArguments validates and type-checks function arguments with generic support.
 // Returns the processed arguments and the specialized function (with generics resolved if applicable).
-// Handles the `mut` keyword for explicit copy semantics on mutable parameters.
+// Mutable parameters require addressable mutable arguments.
 // Synthesizes maybe::none() calls for omitted nullable arguments.
 // If any error occurs, it's added to the checker's diagnostics.
-func (c *Checker) checkAndProcessArguments(fnDef *FunctionDef, resolvedArgs []parse.Argument, resolvedExprs []parse.Expression, fnDefCopy *FunctionDef, genericScope *SymbolTable, numOmittedArgs int) ([]Expression, *FunctionDef) {
+func (c *Checker) checkAndProcessArguments(fnDef *FunctionDef, resolvedExprs []parse.Expression, fnDefCopy *FunctionDef, genericScope *SymbolTable, numOmittedArgs int) ([]Expression, *FunctionDef) {
 	// Create the full argument list including synthesized maybe::none() calls for omitted arguments
 	// Need to maintain parameter order, so use indexed assignment instead of appending
 	totalArgs := len(fnDefCopy.Parameters)
@@ -5174,23 +5126,15 @@ func (c *Checker) checkAndProcessArguments(fnDef *FunctionDef, resolvedArgs []pa
 			}
 		}
 
-		// Check mutability constraints if needed
+		// Check mutable-reference constraints if needed. A mutable parameter
+		// requires an addressable mutable place; a call-site `mut` marker no longer
+		// requests a defensive copy.
 		if fnDefCopy.Parameters[i].Mutable {
-			if c.isMutable(checkedArg) {
-				// Argument is already mutable - use it directly
-				allExprs[i] = checkedArg
-			} else if i < len(resolvedArgs) && resolvedArgs[i].Mutable {
-				// User provided `mut` keyword - create a copy
-				// (omitted arguments won't have a resolvedArgs entry)
-				allExprs[i] = &CopyExpression{
-					Expr:  checkedArg,
-					Type_: checkedArg.Type(),
-				}
-			} else {
-				// Argument is not mutable and no `mut` keyword - error
+			if !c.isMutable(checkedArg) {
 				c.addError(fmt.Sprintf("Type mismatch: Expected a mutable %s", fnDefCopy.Parameters[i].Type.String()), resolvedExprs[i].GetLocation())
 				return nil, nil
 			}
+			allExprs[i] = checkedArg
 		} else {
 			allExprs[i] = checkedArg
 		}

--- a/compiler/checker/copying_test.go
+++ b/compiler/checker/copying_test.go
@@ -6,6 +6,63 @@ import (
 	"github.com/akonwi/ard/checker"
 )
 
+func TestMutableReferenceFields(t *testing.T) {
+	run(t, []test{
+		{
+			name: "immutable struct can expose mutable reference field",
+			input: `
+				struct Tree { count: Int }
+				struct Context { tree: mut Tree }
+
+				fn bump(mut tree: Tree) {
+					tree.count =+ 1
+				}
+
+				mut tree = Tree{count: 0}
+				let ctx = Context{tree: tree}
+				bump(ctx.tree)
+			`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "mutable reference field requires mutable value",
+			input: `
+				struct Tree { count: Int }
+				struct Context { tree: mut Tree }
+
+				let tree = Tree{count: 0}
+				let ctx = Context{tree: tree}
+			`,
+			diagnostics: []checker.Diagnostic{{Kind: checker.Error, Message: "Type mismatch: Expected a mutable Tree"}},
+		},
+		{
+			name: "assignment to mutable reference field is allowed through immutable holder",
+			input: `
+				struct Tree { count: Int }
+				struct Context { tree: mut Tree }
+
+				mut tree = Tree{count: 0}
+				mut other = Tree{count: 1}
+				let ctx = Context{tree: tree}
+				ctx.tree = other
+			`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "nested field assignment through mutable reference field is allowed",
+			input: `
+				struct Tree { count: Int }
+				struct Context { tree: mut Tree }
+
+				mut tree = Tree{count: 0}
+				let ctx = Context{tree: tree}
+				ctx.tree.count = 2
+			`,
+			diagnostics: []checker.Diagnostic{},
+		},
+	})
+}
+
 func TestMutableReferenceParameters(t *testing.T) {
 	run(t, []test{
 		{

--- a/compiler/checker/copying_test.go
+++ b/compiler/checker/copying_test.go
@@ -6,10 +6,23 @@ import (
 	"github.com/akonwi/ard/checker"
 )
 
-func TestCallingMutatingFunctions(t *testing.T) {
+func TestMutableReferenceParameters(t *testing.T) {
 	run(t, []test{
 		{
-			name: "providing a read-only reference as a mutable parameter",
+			name: "mutable parameter accepts mutable binding without call-site mut",
+			input: `
+				struct Person { age: Int }
+
+				fn grow(mut p: Person) {
+					p.age =+ 1
+				}
+				mut joe = Person{age: 20}
+				grow(joe)
+			`,
+			diagnostics: []checker.Diagnostic{},
+		},
+		{
+			name: "immutable binding cannot be passed to mutable parameter",
 			input: `
 				struct Person { age: Int }
 
@@ -18,7 +31,24 @@ func TestCallingMutatingFunctions(t *testing.T) {
 				}
 				let joe = Person{age: 20}
 				grow(joe)
-				joe.age == 20
+			`,
+			diagnostics: []checker.Diagnostic{
+				{
+					Kind:    checker.Error,
+					Message: "Type mismatch: Expected a mutable Person",
+				},
+			},
+		},
+		{
+			name: "call-site mut no longer copies immutable argument",
+			input: `
+				struct Person { age: Int }
+
+				fn grow(mut p: Person) {
+					p.age =+ 1
+				}
+				let joe = Person{age: 20}
+				grow(mut joe)
 			`,
 			diagnostics: []checker.Diagnostic{
 				{

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -1386,12 +1386,3 @@ func (t TryOp) Expr() Expression {
 func (t TryOp) Type() Type {
 	return t.ok
 }
-
-type CopyExpression struct {
-	Expr  Expression
-	Type_ Type
-}
-
-func (c *CopyExpression) Type() Type {
-	return c.Type_
-}

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -175,7 +175,7 @@ type InstanceProperty struct {
 }
 
 func (i *InstanceProperty) Type() Type {
-	return i._type
+	return derefMutableRef(i._type)
 }
 
 // String returns a string representation of the instance property

--- a/compiler/checker/recursive_types.go
+++ b/compiler/checker/recursive_types.go
@@ -10,6 +10,10 @@ func recursiveFieldHasInfiniteSize(t parse.DeclaredType, self string, indirect b
 		indirect = true
 	}
 	switch typ := t.(type) {
+	case *parse.MutableType:
+		return recursiveFieldHasInfiniteSize(typ.Inner, self, true)
+	case parse.MutableType:
+		return recursiveFieldHasInfiniteSize(typ.Inner, self, true)
 	case *parse.CustomType:
 		return typ.GetName() == self && !indirect
 	case parse.CustomType:

--- a/compiler/checker/recursive_types.go
+++ b/compiler/checker/recursive_types.go
@@ -1,56 +1,215 @@
 package checker
 
-import "github.com/akonwi/ard/parse"
+import (
+	"sort"
+	"strings"
 
-func recursiveFieldHasInfiniteSize(t parse.DeclaredType, self string, indirect bool) bool {
+	"github.com/akonwi/ard/parse"
+)
+
+const recursiveLayoutDiagnostic = "Put the recursive reference behind mut, list, map, nullable, trait, extern, or function indirection."
+
+type recursiveStructEdge struct {
+	from      *StructDef
+	to        *StructDef
+	fieldName string
+	location  parse.Location
+}
+
+func (c *Checker) checkRecursiveStructLayouts() {
+	structs := []*StructDef{}
+	structSet := map[*StructDef]bool{}
+	for i := range c.input.Statements {
+		decl, ok := c.input.Statements[i].(*parse.StructDefinition)
+		if !ok {
+			continue
+		}
+		def, ok := c.hoistedStruct(decl.Name.Name)
+		if !ok || def == nil {
+			continue
+		}
+		structs = append(structs, def)
+		structSet[def] = true
+	}
+	if len(structs) == 0 {
+		return
+	}
+
+	edges := map[*StructDef][]recursiveStructEdge{}
+	for i := range c.input.Statements {
+		decl, ok := c.input.Statements[i].(*parse.StructDefinition)
+		if !ok {
+			continue
+		}
+		owner, ok := c.hoistedStruct(decl.Name.Name)
+		if !ok || owner == nil {
+			continue
+		}
+		for _, field := range decl.Fields {
+			fieldType, ok := owner.Fields[field.Name.Name]
+			if !ok {
+				continue
+			}
+			refs := inlineStructReferences(fieldType, map[Type]bool{})
+			refs = append(refs, recursiveMapKeyReferences(fieldType, map[Type]bool{})...)
+			for _, ref := range refs {
+				if ref == nil || !structSet[ref] {
+					continue
+				}
+				edges[owner] = append(edges[owner], recursiveStructEdge{
+					from:      owner,
+					to:        ref,
+					fieldName: field.Name.Name,
+					location:  field.Name.GetLocation(),
+				})
+			}
+		}
+	}
+
+	reported := map[string]bool{}
+	for _, owner := range structs {
+		for _, edge := range edges[owner] {
+			if !recursivePathExists(edge.to, owner, edges, map[*StructDef]bool{}) {
+				continue
+			}
+			key := recursiveCycleKey(owner, structs, edges)
+			if reported[key] {
+				continue
+			}
+			reported[key] = true
+			c.addError("Recursive field "+edge.from.Name+"."+edge.fieldName+" has infinite size. "+recursiveLayoutDiagnostic, edge.location)
+		}
+	}
+}
+
+func inlineStructReferences(t Type, seen map[Type]bool) []*StructDef {
+	return inlineStructReferencesWithNullable(t, seen, true)
+}
+
+func inlineStructReferencesWithNullable(t Type, seen map[Type]bool, nullableIsBoundary bool) []*StructDef {
+	t = deref(t)
 	if t == nil {
-		return false
+		return nil
 	}
-	if t.IsNullable() {
-		indirect = true
+	if _, ok := seen[t]; ok {
+		return nil
 	}
+	seen[t] = true
+
 	switch typ := t.(type) {
-	case *parse.MutableType:
-		return recursiveFieldHasInfiniteSize(typ.Inner, self, true)
-	case parse.MutableType:
-		return recursiveFieldHasInfiniteSize(typ.Inner, self, true)
-	case *parse.CustomType:
-		return typ.GetName() == self && !indirect
-	case parse.CustomType:
-		return typ.GetName() == self && !indirect
-	case *parse.List:
-		return recursiveFieldHasInfiniteSize(typ.Element, self, true)
-	case parse.List:
-		return recursiveFieldHasInfiniteSize(typ.Element, self, true)
-	case *parse.Map:
-		return recursiveFieldHasInfiniteSize(typ.Key, self, false) || recursiveFieldHasInfiniteSize(typ.Value, self, true)
-	case parse.Map:
-		return recursiveFieldHasInfiniteSize(typ.Key, self, false) || recursiveFieldHasInfiniteSize(typ.Value, self, true)
-	case *parse.ResultType:
-		return recursiveFieldHasInfiniteSize(typ.Val, self, indirect) || recursiveFieldHasInfiniteSize(typ.Err, self, indirect)
-	case parse.ResultType:
-		return recursiveFieldHasInfiniteSize(typ.Val, self, indirect) || recursiveFieldHasInfiniteSize(typ.Err, self, indirect)
-	case *parse.FunctionType:
-		if recursiveFieldHasInfiniteSize(typ.Return, self, indirect) {
-			return true
+	case *StructDef:
+		refs := []*StructDef{typ}
+		for _, field := range typ.Fields {
+			refs = append(refs, inlineStructReferencesWithNullable(field, seen, true)...)
 		}
-		for _, param := range typ.Params {
-			if recursiveFieldHasInfiniteSize(param, self, indirect) {
-				return true
-			}
+		return refs
+	case *Map:
+		return inlineStructReferencesWithNullable(typ.Key(), seen, false)
+	case *Maybe:
+		if nullableIsBoundary {
+			return nil
 		}
-		return false
-	case parse.FunctionType:
-		if recursiveFieldHasInfiniteSize(typ.Return, self, indirect) {
-			return true
+		return inlineStructReferencesWithNullable(typ.Of(), seen, false)
+	case *Result:
+		refs := inlineStructReferencesWithNullable(typ.Val(), seen, false)
+		refs = append(refs, inlineStructReferencesWithNullable(typ.Err(), seen, false)...)
+		return refs
+	case *Union:
+		refs := []*StructDef{}
+		for _, member := range typ.Types {
+			refs = append(refs, inlineStructReferencesWithNullable(member, seen, false)...)
 		}
-		for _, param := range typ.Params {
-			if recursiveFieldHasInfiniteSize(param, self, indirect) {
-				return true
-			}
-		}
-		return false
+		return refs
+	case *MutableRef, *List, *Trait, *ExternType, *FunctionDef, *ExternalFunctionDef:
+		return nil
 	default:
+		return nil
+	}
+}
+
+func recursiveMapKeyReferences(t Type, seen map[Type]bool) []*StructDef {
+	t = deref(t)
+	if t == nil {
+		return nil
+	}
+	if _, ok := seen[t]; ok {
+		return nil
+	}
+	seen[t] = true
+	switch typ := t.(type) {
+	case *Map:
+		refs := inlineStructReferencesWithNullable(typ.Key(), map[Type]bool{}, false)
+		refs = append(refs, recursiveMapKeyReferences(typ.Key(), seen)...)
+		refs = append(refs, recursiveMapKeyReferences(typ.Value(), seen)...)
+		return refs
+	case *List:
+		return recursiveMapKeyReferences(typ.Of(), seen)
+	case *Maybe:
+		return recursiveMapKeyReferences(typ.Of(), seen)
+	case *Result:
+		refs := recursiveMapKeyReferences(typ.Val(), seen)
+		refs = append(refs, recursiveMapKeyReferences(typ.Err(), seen)...)
+		return refs
+	case *MutableRef:
+		return nil
+	case *Union:
+		refs := []*StructDef{}
+		for _, member := range typ.Types {
+			refs = append(refs, recursiveMapKeyReferences(member, seen)...)
+		}
+		return refs
+	case *StructDef:
+		refs := []*StructDef{}
+		for _, field := range typ.Fields {
+			refs = append(refs, recursiveMapKeyReferences(field, seen)...)
+		}
+		return refs
+	case *FunctionDef:
+		refs := recursiveMapKeyReferences(typ.ReturnType, seen)
+		for _, param := range typ.Parameters {
+			refs = append(refs, recursiveMapKeyReferences(param.Type, seen)...)
+		}
+		return refs
+	case *ExternalFunctionDef:
+		refs := recursiveMapKeyReferences(typ.ReturnType, seen)
+		for _, param := range typ.Parameters {
+			refs = append(refs, recursiveMapKeyReferences(param.Type, seen)...)
+		}
+		return refs
+	default:
+		return nil
+	}
+}
+
+func recursivePathExists(from *StructDef, to *StructDef, edges map[*StructDef][]recursiveStructEdge, seen map[*StructDef]bool) bool {
+	if from == nil || to == nil {
 		return false
 	}
+	if from == to {
+		return true
+	}
+	if seen[from] {
+		return false
+	}
+	seen[from] = true
+	for _, edge := range edges[from] {
+		if recursivePathExists(edge.to, to, edges, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+func recursiveCycleKey(owner *StructDef, structs []*StructDef, edges map[*StructDef][]recursiveStructEdge) string {
+	parts := []string{}
+	for _, candidate := range structs {
+		if recursivePathExists(owner, candidate, edges, map[*StructDef]bool{}) && recursivePathExists(candidate, owner, edges, map[*StructDef]bool{}) {
+			parts = append(parts, candidate.ModulePath+"::"+candidate.Name)
+		}
+	}
+	if len(parts) == 0 {
+		return owner.ModulePath + "::" + owner.Name
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "|")
 }

--- a/compiler/checker/scope.go
+++ b/compiler/checker/scope.go
@@ -197,6 +197,8 @@ func extractGenericNames(t Type, names map[string]bool) {
 	case *Result:
 		extractGenericNames(t.val, names)
 		extractGenericNames(t.err, names)
+	case *MutableRef:
+		extractGenericNames(t.of, names)
 	case *Union:
 		for _, t := range t.Types {
 			extractGenericNames(t, names)
@@ -243,6 +245,8 @@ func hasGenericsInTypeSeen(t Type, seen map[Type]struct{}) bool {
 		return hasGenericsInTypeSeen(t.of, seen)
 	case *Result:
 		return hasGenericsInTypeSeen(t.val, seen) || hasGenericsInTypeSeen(t.err, seen)
+	case *MutableRef:
+		return hasGenericsInTypeSeen(t.of, seen)
 	case *Union:
 		return slices.ContainsFunc(t.Types, func(member Type) bool { return hasGenericsInTypeSeen(member, seen) })
 	case *StructDef:
@@ -312,6 +316,12 @@ func replaceGeneric(t Type, genericName string, concreteType Type) Type {
 			val: newVal,
 			err: newErr,
 		}
+	case *MutableRef:
+		newOf := replaceGeneric(t.of, genericName, concreteType)
+		if newOf == t.of {
+			return t
+		}
+		return MakeMutableRef(newOf)
 	case *FunctionDef:
 		newParams := make([]Parameter, len(t.Parameters))
 		for i, p := range t.Parameters {
@@ -398,6 +408,8 @@ func hasGeneric(t Type, genericName string) bool {
 		return hasGeneric(t.of, genericName)
 	case *Result:
 		return hasGeneric(t.val, genericName) || hasGeneric(t.err, genericName)
+	case *MutableRef:
+		return hasGeneric(t.of, genericName)
 	case *StructDef:
 		for _, fieldType := range t.Fields {
 			if hasGeneric(fieldType, genericName) {
@@ -475,6 +487,8 @@ func copyTypeWithTypeVarMap(t Type, typeVarMap map[string]*TypeVar) Type {
 			val: copyTypeWithTypeVarMap(typ.val, typeVarMap),
 			err: copyTypeWithTypeVarMap(typ.err, typeVarMap),
 		}
+	case *MutableRef:
+		return MakeMutableRef(copyTypeWithTypeVarMap(typ.of, typeVarMap))
 	case *Union:
 		newTypes := make([]Type, len(typ.Types))
 		for i, t := range typ.Types {

--- a/compiler/checker/scope.go
+++ b/compiler/checker/scope.go
@@ -236,6 +236,9 @@ func hasGenericsInTypeSeen(t Type, seen map[Type]struct{}) bool {
 	seen[t] = struct{}{}
 	switch t := t.(type) {
 	case *TypeVar:
+		if t.bound && t.actual != nil {
+			return hasGenericsInTypeSeen(t.actual, seen)
+		}
 		return true
 	case *List:
 		return hasGenericsInTypeSeen(t.of, seen)
@@ -448,25 +451,95 @@ func copyFunctionWithTypeVarMap(fnDef *FunctionDef, typeVarMap map[string]*TypeV
 // copyStructWithTypeVarMap creates a shallow copy of a StructDef with fresh TypeVar instances
 // for generic type parameters. This is used to create call-site-specific copies of generic structs.
 func copyStructWithTypeVarMap(structDef *StructDef, typeVarMap map[string]*TypeVar) *StructDef {
-	newFields := make(map[string]Type)
-	for name, fieldType := range structDef.Fields {
-		newFields[name] = copyTypeWithTypeVarMap(fieldType, typeVarMap)
-	}
+	return copyStructWithTypeVarMapSeen(structDef, typeVarMap, map[*StructDef]*StructDef{})
+}
 
-	return &StructDef{
-		Name:          structDef.Name,
-		ModulePath:    structDef.ModulePath,
-		Fields:        newFields,
-		Methods:       structDef.Methods, // Methods are not copied; they're shared
-		Self:          structDef.Self,
-		Traits:        structDef.Traits,
-		GenericParams: append([]string(nil), structDef.GenericParams...),
-		Private:       structDef.Private,
+func copyStructWithTypeVarMapSeen(structDef *StructDef, typeVarMap map[string]*TypeVar, seen map[*StructDef]*StructDef) *StructDef {
+	if structDef == nil {
+		return nil
+	}
+	if existing, ok := seen[structDef]; ok {
+		return existing
+	}
+	newFields := make(map[string]Type)
+	structCopy := &StructDef{
+		Name:       structDef.Name,
+		ModulePath: structDef.ModulePath,
+		Fields:     newFields,
+		Methods:    structDef.Methods, // Methods are not copied; they're shared
+		Self:       structDef.Self,
+		Traits:     structDef.Traits,
+		Private:    structDef.Private,
+	}
+	seen[structDef] = structCopy
+	for name, fieldType := range structDef.Fields {
+		newFields[name] = copyTypeWithTypeVarMapSeen(fieldType, typeVarMap, seen)
+	}
+	genericParams := []string{}
+	seenGenerics := map[string]bool{}
+	seenTypes := map[Type]bool{}
+	for _, fieldType := range newFields {
+		collectUnboundGenericsFromType(fieldType, &genericParams, seenGenerics, seenTypes)
+	}
+	structCopy.GenericParams = genericParams
+	return structCopy
+}
+
+func collectUnboundGenericsFromType(t Type, params *[]string, seenGenerics map[string]bool, seenTypes map[Type]bool) {
+	if t == nil {
+		return
+	}
+	if typeVar, ok := t.(*TypeVar); ok && typeVar.bound && typeVar.actual != nil {
+		t = typeVar.actual
+	}
+	if _, ok := seenTypes[t]; ok {
+		return
+	}
+	seenTypes[t] = true
+	switch typ := t.(type) {
+	case *TypeVar:
+		if !seenGenerics[typ.name] {
+			*params = append(*params, typ.name)
+			seenGenerics[typ.name] = true
+		}
+	case *List:
+		collectUnboundGenericsFromType(typ.of, params, seenGenerics, seenTypes)
+	case *Map:
+		collectUnboundGenericsFromType(typ.key, params, seenGenerics, seenTypes)
+		collectUnboundGenericsFromType(typ.value, params, seenGenerics, seenTypes)
+	case *Maybe:
+		collectUnboundGenericsFromType(typ.of, params, seenGenerics, seenTypes)
+	case *Result:
+		collectUnboundGenericsFromType(typ.val, params, seenGenerics, seenTypes)
+		collectUnboundGenericsFromType(typ.err, params, seenGenerics, seenTypes)
+	case *MutableRef:
+		collectUnboundGenericsFromType(typ.of, params, seenGenerics, seenTypes)
+	case *Union:
+		for _, member := range typ.Types {
+			collectUnboundGenericsFromType(member, params, seenGenerics, seenTypes)
+		}
+	case *StructDef:
+		for _, fieldType := range typ.Fields {
+			collectUnboundGenericsFromType(fieldType, params, seenGenerics, seenTypes)
+		}
+	case *FunctionDef:
+		for _, param := range typ.Parameters {
+			collectUnboundGenericsFromType(param.Type, params, seenGenerics, seenTypes)
+		}
+		collectUnboundGenericsFromType(typ.ReturnType, params, seenGenerics, seenTypes)
+	case *ExternType:
+		for _, typeArg := range typ.TypeArgs {
+			collectUnboundGenericsFromType(typeArg, params, seenGenerics, seenTypes)
+		}
 	}
 }
 
 // copyTypeWithTypeVarMap deep copies a type, replacing TypeVar instances with fresh ones
 func copyTypeWithTypeVarMap(t Type, typeVarMap map[string]*TypeVar) Type {
+	return copyTypeWithTypeVarMapSeen(t, typeVarMap, map[*StructDef]*StructDef{})
+}
+
+func copyTypeWithTypeVarMapSeen(t Type, typeVarMap map[string]*TypeVar, seenStructs map[*StructDef]*StructDef) Type {
 	switch typ := t.(type) {
 	case *TypeVar:
 		if fresh, exists := typeVarMap[typ.name]; exists {
@@ -474,25 +547,25 @@ func copyTypeWithTypeVarMap(t Type, typeVarMap map[string]*TypeVar) Type {
 		}
 		return typ // Keep as-is if not a generic parameter
 	case *List:
-		return &List{of: copyTypeWithTypeVarMap(typ.of, typeVarMap)}
+		return &List{of: copyTypeWithTypeVarMapSeen(typ.of, typeVarMap, seenStructs)}
 	case *Map:
 		return &Map{
-			key:   copyTypeWithTypeVarMap(typ.key, typeVarMap),
-			value: copyTypeWithTypeVarMap(typ.value, typeVarMap),
+			key:   copyTypeWithTypeVarMapSeen(typ.key, typeVarMap, seenStructs),
+			value: copyTypeWithTypeVarMapSeen(typ.value, typeVarMap, seenStructs),
 		}
 	case *Maybe:
-		return &Maybe{of: copyTypeWithTypeVarMap(typ.of, typeVarMap)}
+		return &Maybe{of: copyTypeWithTypeVarMapSeen(typ.of, typeVarMap, seenStructs)}
 	case *Result:
 		return &Result{
-			val: copyTypeWithTypeVarMap(typ.val, typeVarMap),
-			err: copyTypeWithTypeVarMap(typ.err, typeVarMap),
+			val: copyTypeWithTypeVarMapSeen(typ.val, typeVarMap, seenStructs),
+			err: copyTypeWithTypeVarMapSeen(typ.err, typeVarMap, seenStructs),
 		}
 	case *MutableRef:
-		return MakeMutableRef(copyTypeWithTypeVarMap(typ.of, typeVarMap))
+		return MakeMutableRef(copyTypeWithTypeVarMapSeen(typ.of, typeVarMap, seenStructs))
 	case *Union:
 		newTypes := make([]Type, len(typ.Types))
 		for i, t := range typ.Types {
-			newTypes[i] = copyTypeWithTypeVarMap(t, typeVarMap)
+			newTypes[i] = copyTypeWithTypeVarMapSeen(t, typeVarMap, seenStructs)
 		}
 		return &Union{
 			Name:       typ.Name,
@@ -500,13 +573,13 @@ func copyTypeWithTypeVarMap(t Type, typeVarMap map[string]*TypeVar) Type {
 			Types:      newTypes,
 		}
 	case *StructDef:
-		return copyStructWithTypeVarMap(typ, typeVarMap)
+		return copyStructWithTypeVarMapSeen(typ, typeVarMap, seenStructs)
 	case *FunctionDef:
 		return copyFunctionWithTypeVarMap(typ, typeVarMap)
 	case *ExternType:
 		newTypeArgs := make([]Type, len(typ.TypeArgs))
 		for i, typeArg := range typ.TypeArgs {
-			newTypeArgs[i] = copyTypeWithTypeVarMap(typeArg, typeVarMap)
+			newTypeArgs[i] = copyTypeWithTypeVarMapSeen(typeArg, typeVarMap, seenStructs)
 		}
 		return &ExternType{Name_: typ.Name_, GenericParams: append([]string(nil), typ.GenericParams...), TypeArgs: newTypeArgs, ExternalBinding: typ.ExternalBinding, ExternalBindingTarget: typ.ExternalBindingTarget, ExternalBindings: cloneExternalBindings(typ.ExternalBindings), private: typ.private}
 	default:

--- a/compiler/checker/structs_test.go
+++ b/compiler/checker/structs_test.go
@@ -135,7 +135,6 @@ func TestStructs(t *testing.T) {
 						p.age = 31`, personStructInput),
 			diagnostics: []checker.Diagnostic{
 				{Kind: checker.Error, Message: "Undefined variable: is_employed"},
-				{Kind: checker.Error, Message: "Missing field: employed"},
 			},
 		},
 	})

--- a/compiler/checker/structs_test.go
+++ b/compiler/checker/structs_test.go
@@ -112,11 +112,10 @@ func TestStructs(t *testing.T) {
 			},
 		},
 		{
-			name: "Can reassign to properties",
+			name: "Can reassign to properties of mutable structs",
 			input: fmt.Sprintf(`%s
 				mut p = Person{name: "Alice", age: 30, employed: true}
 				p.age = 31`, personStructInput),
-			// Copy semantics allow this to be valid, so no errors
 			diagnostics: []checker.Diagnostic{},
 		},
 		{
@@ -140,7 +139,7 @@ func TestStructs(t *testing.T) {
 	})
 }
 
-func TestCopySemantics(t *testing.T) {
+func TestMutableAggregateInitialization(t *testing.T) {
 	personStructInput := strings.Join([]string{
 		"struct Person {",
 		"  name: Str,",
@@ -150,11 +149,10 @@ func TestCopySemantics(t *testing.T) {
 
 	run(t, []test{
 		{
-			name: "mut assignment should accept copy from immutable struct",
+			name: "mutable binding can be initialized from immutable struct value",
 			input: fmt.Sprintf(`%s
 				let alice = Person{name: "Alice", age: 30}
 				mut bob = alice`, personStructInput),
-			// For now, just check that it compiles without errors
 			diagnostics: []checker.Diagnostic{},
 		},
 	})

--- a/compiler/checker/top_level_types.go
+++ b/compiler/checker/top_level_types.go
@@ -1,0 +1,408 @@
+package checker
+
+import (
+	"fmt"
+
+	"github.com/akonwi/ard/parse"
+)
+
+func (c *Checker) hoistTopLevelTypeDeclarations() {
+	seen := map[string]parse.Location{}
+	for i := range c.input.Statements {
+		stmt := c.input.Statements[i]
+		name, loc, ok := topLevelTypeDeclarationName(stmt)
+		if !ok {
+			continue
+		}
+		if _, dup := seen[name]; dup {
+			c.addError(fmt.Sprintf("Duplicate declaration: %s", name), loc)
+			c.markDuplicateTopLevelTypeDeclaration(stmt)
+			continue
+		}
+		seen[name] = loc
+
+		switch s := stmt.(type) {
+		case *parse.StructDefinition:
+			if c.topLevelStructDeclarations == nil {
+				c.topLevelStructDeclarations = map[string]*parse.StructDefinition{}
+			}
+			c.topLevelStructDeclarations[name] = s
+			genericParams := genericParamsFromStructDeclaration(s)
+			c.scope.add(name, &StructDef{
+				Name:          s.Name.Name,
+				ModulePath:    c.typeOwnerPath(),
+				Fields:        make(map[string]Type),
+				Methods:       make(map[string]*FunctionDef),
+				GenericParams: genericParams,
+				Private:       s.Private,
+			}, false)
+		case *parse.TraitDefinition:
+			c.scope.add(name, &Trait{Name: s.Name.Name, private: s.Private}, false)
+		case *parse.EnumDefinition:
+			c.scope.add(name, &Enum{Name: s.Name, ModulePath: c.typeOwnerPath(), Private: s.Private, Methods: make(map[string]*FunctionDef), Location: s.GetLocation()}, false)
+		case *parse.ExternTypeDeclaration:
+			typeArgs := make([]Type, len(s.TypeParams))
+			for i, param := range s.TypeParams {
+				typeArgs[i] = &TypeVar{name: param}
+			}
+			c.scope.add(name, &ExternType{Name_: s.Name, GenericParams: append([]string(nil), s.TypeParams...), TypeArgs: typeArgs, private: s.Private}, false)
+		case *parse.TypeDeclaration:
+			if len(s.Type) == 1 {
+				if c.topLevelTypeAliases == nil {
+					c.topLevelTypeAliases = map[string]*parse.TypeDeclaration{}
+				}
+				c.topLevelTypeAliases[name] = s
+			} else {
+				c.scope.add(name, &Union{Name: s.Name.Name, ModulePath: c.typeOwnerPath()}, false)
+			}
+		}
+	}
+}
+
+func (c *Checker) populateTopLevelTypeDefinitions() {
+	for i := range c.input.Statements {
+		switch c.input.Statements[i].(type) {
+		case *parse.StructDefinition, *parse.TraitDefinition, *parse.EnumDefinition, *parse.ExternTypeDeclaration, *parse.TypeDeclaration:
+			c.checkStmt(&c.input.Statements[i])
+		}
+	}
+}
+
+func isTopLevelTypeDeclaration(stmt parse.Statement) bool {
+	_, _, ok := topLevelTypeDeclarationName(stmt)
+	return ok
+}
+
+func (c *Checker) checkedTopLevelTypeStatement(stmt parse.Statement) *Statement {
+	if c.isDuplicateTopLevelTypeDeclaration(stmt) {
+		return nil
+	}
+	switch s := stmt.(type) {
+	case *parse.StructDefinition:
+		def, ok := c.hoistedStruct(s.Name.Name)
+		if !ok {
+			return nil
+		}
+		return &Statement{Stmt: def}
+	case *parse.ExternTypeDeclaration:
+		externType, ok := c.hoistedExternType(s.Name)
+		if !ok {
+			return nil
+		}
+		return &Statement{Stmt: externType}
+	case *parse.TypeDeclaration:
+		if len(s.Type) <= 1 {
+			return nil
+		}
+		unionType, ok := c.hoistedUnion(s.Name.Name)
+		if !ok {
+			return nil
+		}
+		return &Statement{Stmt: unionType}
+	default:
+		return nil
+	}
+}
+
+func topLevelTypeDeclarationName(stmt parse.Statement) (string, parse.Location, bool) {
+	switch s := stmt.(type) {
+	case *parse.StructDefinition:
+		return s.Name.Name, s.Name.GetLocation(), true
+	case *parse.TraitDefinition:
+		return s.Name.Name, s.Name.GetLocation(), true
+	case *parse.EnumDefinition:
+		return s.Name, s.GetLocation(), true
+	case *parse.ExternTypeDeclaration:
+		return s.Name, s.GetLocation(), true
+	case *parse.TypeDeclaration:
+		return s.Name.Name, s.Name.GetLocation(), true
+	default:
+		return "", parse.Location{}, false
+	}
+}
+
+func genericParamsFromStructDeclaration(decl *parse.StructDefinition) []string {
+	params := []string{}
+	seen := map[string]bool{}
+	for _, field := range decl.Fields {
+		collectGenericParamsFromDeclaredType(field.Type, &params, seen)
+	}
+	return params
+}
+
+func collectGenericParamsFromDeclaredType(t parse.DeclaredType, params *[]string, seen map[string]bool) {
+	if t == nil {
+		return
+	}
+	switch typ := t.(type) {
+	case *parse.GenericType:
+		if !seen[typ.Name] {
+			*params = append(*params, typ.Name)
+			seen[typ.Name] = true
+		}
+	case parse.GenericType:
+		if !seen[typ.Name] {
+			*params = append(*params, typ.Name)
+			seen[typ.Name] = true
+		}
+	case *parse.MutableType:
+		collectGenericParamsFromDeclaredType(typ.Inner, params, seen)
+	case parse.MutableType:
+		collectGenericParamsFromDeclaredType(typ.Inner, params, seen)
+	case *parse.List:
+		collectGenericParamsFromDeclaredType(typ.Element, params, seen)
+	case parse.List:
+		collectGenericParamsFromDeclaredType(typ.Element, params, seen)
+	case *parse.Map:
+		collectGenericParamsFromDeclaredType(typ.Key, params, seen)
+		collectGenericParamsFromDeclaredType(typ.Value, params, seen)
+	case parse.Map:
+		collectGenericParamsFromDeclaredType(typ.Key, params, seen)
+		collectGenericParamsFromDeclaredType(typ.Value, params, seen)
+	case *parse.ResultType:
+		collectGenericParamsFromDeclaredType(typ.Val, params, seen)
+		collectGenericParamsFromDeclaredType(typ.Err, params, seen)
+	case parse.ResultType:
+		collectGenericParamsFromDeclaredType(typ.Val, params, seen)
+		collectGenericParamsFromDeclaredType(typ.Err, params, seen)
+	case *parse.FunctionType:
+		for _, param := range typ.Params {
+			collectGenericParamsFromDeclaredType(param, params, seen)
+		}
+		collectGenericParamsFromDeclaredType(typ.Return, params, seen)
+	case parse.FunctionType:
+		for _, param := range typ.Params {
+			collectGenericParamsFromDeclaredType(param, params, seen)
+		}
+		collectGenericParamsFromDeclaredType(typ.Return, params, seen)
+	case *parse.CustomType:
+		for _, arg := range typ.TypeArgs {
+			collectGenericParamsFromDeclaredType(arg, params, seen)
+		}
+	case parse.CustomType:
+		for _, arg := range typ.TypeArgs {
+			collectGenericParamsFromDeclaredType(arg, params, seen)
+		}
+	}
+}
+
+func (c *Checker) markDuplicateTopLevelTypeDeclaration(stmt parse.Statement) {
+	if c.duplicateTopLevelTypeDeclarations == nil {
+		c.duplicateTopLevelTypeDeclarations = map[parse.Statement]bool{}
+	}
+	c.duplicateTopLevelTypeDeclarations[stmt] = true
+}
+
+func (c *Checker) isDuplicateTopLevelTypeDeclaration(stmt parse.Statement) bool {
+	return c.duplicateTopLevelTypeDeclarations != nil && c.duplicateTopLevelTypeDeclarations[stmt]
+}
+
+func (c *Checker) isResolvingStructDefinition(def *StructDef) bool {
+	if def == nil || def.ModulePath != c.typeOwnerPath() || c.resolvingTopLevelStructs == nil || !c.resolvingTopLevelStructs[def.Name] {
+		return false
+	}
+	sym, ok := c.scope.get(def.Name)
+	return ok && sym.Type == def
+}
+
+func (c *Checker) ensureStructDefinitionResolved(def *StructDef) {
+	if def == nil || c.topLevelStructDeclarations == nil {
+		return
+	}
+	if def.ModulePath != c.typeOwnerPath() {
+		return
+	}
+	sym, ok := c.scope.get(def.Name)
+	if !ok || sym.Type != def {
+		return
+	}
+	decl := c.topLevelStructDeclarations[def.Name]
+	if decl == nil {
+		return
+	}
+	c.populateStructDefinition(def, decl)
+}
+
+func (c *Checker) populateStructDefinition(def *StructDef, decl *parse.StructDefinition) {
+	if def == nil || decl == nil {
+		return
+	}
+	name := decl.Name.Name
+	if c.resolvedTopLevelStructs != nil && c.resolvedTopLevelStructs[name] {
+		return
+	}
+	if c.resolvingTopLevelStructs != nil && c.resolvingTopLevelStructs[name] {
+		return
+	}
+	if c.resolvingTopLevelStructs == nil {
+		c.resolvingTopLevelStructs = map[string]bool{}
+	}
+	c.resolvingTopLevelStructs[name] = true
+	defer delete(c.resolvingTopLevelStructs, name)
+
+	declaredGenericParams := append([]string(nil), def.GenericParams...)
+	if len(declaredGenericParams) == 0 {
+		declaredGenericParams = genericParamsFromStructDeclaration(decl)
+	}
+
+	def.Name = decl.Name.Name
+	def.ModulePath = c.typeOwnerPath()
+	def.Fields = make(map[string]Type)
+	if def.Methods == nil {
+		def.Methods = make(map[string]*FunctionDef)
+	}
+	def.GenericParams = declaredGenericParams
+	def.Private = decl.Private
+	resolvedGenericParams := []string{}
+	seenGenerics := make(map[string]bool)
+	for _, field := range decl.Fields {
+		fieldType := c.resolveType(field.Type)
+		if fieldType == nil {
+			continue
+		}
+
+		if _, dup := def.Fields[field.Name.Name]; dup {
+			c.addError(fmt.Sprintf("Duplicate field: %s", field.Name.Name), field.Name.GetLocation())
+			continue
+		}
+		def.Fields[field.Name.Name] = fieldType
+		collectGenericsFromType(fieldType, &resolvedGenericParams, seenGenerics)
+	}
+	if len(resolvedGenericParams) == 0 {
+		def.GenericParams = nil
+	} else {
+		def.GenericParams = resolvedGenericParams
+	}
+	if c.resolvedTopLevelStructs == nil {
+		c.resolvedTopLevelStructs = map[string]bool{}
+	}
+	c.resolvedTopLevelStructs[name] = true
+}
+
+func (c *Checker) hoistedStruct(name string) (*StructDef, bool) {
+	sym, ok := c.scope.get(name)
+	if !ok {
+		return nil, false
+	}
+	def, ok := sym.Type.(*StructDef)
+	if !ok {
+		return nil, false
+	}
+	return def, true
+}
+
+func (c *Checker) hoistedTrait(name string) (*Trait, bool) {
+	sym, ok := c.scope.get(name)
+	if !ok {
+		return nil, false
+	}
+	trait, ok := sym.Type.(*Trait)
+	if !ok {
+		return nil, false
+	}
+	return trait, true
+}
+
+func (c *Checker) hoistedEnum(name string) (*Enum, bool) {
+	sym, ok := c.scope.get(name)
+	if !ok {
+		return nil, false
+	}
+	enum, ok := sym.Type.(*Enum)
+	if !ok {
+		return nil, false
+	}
+	return enum, true
+}
+
+func (c *Checker) hoistedExternType(name string) (*ExternType, bool) {
+	sym, ok := c.scope.get(name)
+	if !ok {
+		return nil, false
+	}
+	externType, ok := sym.Type.(*ExternType)
+	if !ok {
+		return nil, false
+	}
+	return externType, true
+}
+
+func (c *Checker) hoistedUnion(name string) (*Union, bool) {
+	sym, ok := c.scope.get(name)
+	if !ok {
+		return nil, false
+	}
+	unionType, ok := sym.Type.(*Union)
+	if !ok {
+		return nil, false
+	}
+	return unionType, true
+}
+
+func (c *Checker) predeclareTopLevelTypeAliases() {
+	for name := range c.topLevelTypeAliases {
+		c.resolveTopLevelTypeAlias(name)
+	}
+}
+
+func (c *Checker) resolveTopLevelTypeAlias(name string) Type {
+	if c.resolvedTopLevelAliases != nil && c.resolvedTopLevelAliases[name] {
+		if sym, ok := c.scope.get(name); ok {
+			return sym.Type
+		}
+		return nil
+	}
+	decl := c.topLevelTypeAliases[name]
+	if decl == nil {
+		if sym, ok := c.scope.get(name); ok {
+			return sym.Type
+		}
+		return nil
+	}
+	if c.resolvingTopLevelAliases != nil && c.resolvingTopLevelAliases[name] {
+		c.addError(fmt.Sprintf("Recursive type alias: %s", name), decl.Name.GetLocation())
+		return &TypeVar{name: "unknown"}
+	}
+	if c.resolvingTopLevelAliases == nil {
+		c.resolvingTopLevelAliases = map[string]bool{}
+	}
+	c.resolvingTopLevelAliases[name] = true
+	defer delete(c.resolvingTopLevelAliases, name)
+
+	if custom, ok := decl.Type[0].(*parse.CustomType); ok && custom.Type.Target == nil {
+		if _, alias := c.topLevelTypeAliases[custom.GetName()]; alias {
+			c.resolveTopLevelTypeAlias(custom.GetName())
+		}
+	}
+	resolvedType := c.resolveType(decl.Type[0])
+	if resolvedType == nil {
+		c.addError(fmt.Sprintf("Unrecognized type: %s", decl.Type[0].GetName()), decl.Type[0].GetLocation())
+		return nil
+	}
+	c.scope.add(decl.Name.Name, resolvedType, false)
+	if c.resolvedTopLevelAliases == nil {
+		c.resolvedTopLevelAliases = map[string]bool{}
+	}
+	c.resolvedTopLevelAliases[name] = true
+	return resolvedType
+}
+
+func (c *Checker) validateTopLevelTypeAliases() {
+	for i := range c.input.Statements {
+		decl, ok := c.input.Statements[i].(*parse.TypeDeclaration)
+		if !ok || len(decl.Type) != 1 {
+			continue
+		}
+		custom, ok := decl.Type[0].(*parse.CustomType)
+		if !ok || len(custom.TypeArgs) > 0 {
+			continue
+		}
+		sym, ok := c.scope.get(custom.GetName())
+		if !ok {
+			continue
+		}
+		if namedTypeRequiresTypeArguments(sym.Type) {
+			c.addError(fmt.Sprintf("Generic type %s requires type arguments", custom.GetName()), custom.GetLocation())
+		}
+	}
+}

--- a/compiler/checker/traits_test.go
+++ b/compiler/checker/traits_test.go
@@ -30,6 +30,13 @@ func TestSelfRecursiveStructFieldsThroughIndirection(t *testing.T) {
 `,
 		},
 		{
+			name: "mutable reference self reference",
+			input: `struct Node {
+  parent: mut Node,
+}
+`,
+		},
+		{
 			name: "direct self reference is rejected",
 			input: `struct Node {
   child: Node,

--- a/compiler/checker/traits_test.go
+++ b/compiler/checker/traits_test.go
@@ -42,7 +42,275 @@ func TestSelfRecursiveStructFieldsThroughIndirection(t *testing.T) {
   child: Node,
 }
 `,
-			diagnostics: []checker.Diagnostic{{Kind: checker.Error, Message: "Recursive field Node.child has infinite size. Put the recursive reference behind a list, map, or nullable type."}},
+			diagnostics: []checker.Diagnostic{{Kind: checker.Error, Message: "Recursive field Node.child has infinite size. Put the recursive reference behind mut, list, map, nullable, trait, extern, or function indirection."}},
+		},
+	})
+}
+
+func TestSameModuleRecursiveTypeGroups(t *testing.T) {
+	run(t, []test{
+		{
+			name: "retained tree finite through list and trait object",
+			input: `struct Context {
+  tree: ViewTree,
+  node_id: Int,
+}
+
+struct ViewTree {
+  nodes: [TreeNode],
+}
+
+struct TreeNode {
+  view: View,
+  children: [Int],
+}
+
+trait View {
+  fn init(ctx: Context)
+}
+`,
+		},
+		{
+			name: "forward same module struct reference",
+			input: `struct A {
+  b: B,
+}
+
+struct B {
+  value: Int,
+}
+`,
+		},
+		{
+			name: "mut reference breaks recursive layout cycle",
+			input: `struct A {
+  b: mut B,
+}
+
+struct B {
+  a: A,
+}
+`,
+		},
+		{
+			name: "map value breaks recursive layout cycle",
+			input: `struct A {
+  values: [Str:B],
+}
+
+struct B {
+  a: A,
+}
+`,
+		},
+		{
+			name: "nullable breaks recursive layout cycle",
+			input: `struct A {
+  b: B?,
+}
+
+struct B {
+  a: A,
+}
+`,
+		},
+		{
+			name: "function type breaks recursive layout cycle",
+			input: `struct A {
+  make: fn() B,
+}
+
+struct B {
+  a: A,
+}
+`,
+		},
+		{
+			name: "forward generic struct reference with type arguments",
+			input: `struct Holder {
+  box: Box<Int>,
+}
+
+struct Box {
+  value: $T,
+}
+
+fn accept(holder: Holder) {}
+`,
+		},
+		{
+			name: "generic self specialization is rejected before partial types escape",
+			input: `struct Node {
+  next: Node<$T>?,
+  value: $T,
+}
+`,
+			diagnostics: []checker.Diagnostic{{Kind: checker.Error, Message: "Recursive generic self-reference Node is not supported yet"}},
+		},
+		{
+			name: "forward generic struct reference without type arguments is rejected",
+			input: `struct Holder {
+  box: Box,
+}
+
+struct Box {
+  value: $T,
+}
+`,
+			diagnostics: []checker.Diagnostic{{Kind: checker.Error, Message: "Generic type Box requires type arguments"}},
+		},
+		{
+			name: "enum and extern type names are hoisted",
+			input: `struct Holder {
+  mode: Mode,
+  runtime: Runtime,
+}
+
+enum Mode {
+  Ready,
+}
+
+extern type Runtime
+`,
+		},
+		{
+			name: "alias to later type is available to earlier fields",
+			input: `struct Holder {
+  value: Item,
+}
+
+type Item = Leaf
+
+struct Leaf {
+  value: Int,
+}
+`,
+		},
+		{
+			name: "alias chain to later type is resolved before fields",
+			input: `struct Holder {
+  value: A,
+}
+
+type A = B
+type B = Leaf
+
+struct Leaf {
+  value: Int,
+}
+`,
+		},
+		{
+			name: "nested alias dependency is resolved before fields",
+			input: `struct Holder {
+  values: A,
+}
+
+type A = [B]
+type B = Leaf
+
+struct Leaf {
+  value: Int,
+}
+`,
+		},
+		{
+			name: "generic specialized inline cycle is rejected",
+			input: `struct A {
+  box: Box<A>,
+}
+
+struct Box {
+  value: $T,
+}
+`,
+			diagnostics: []checker.Diagnostic{{Kind: checker.Error, Message: "Recursive field A.box has infinite size. Put the recursive reference behind mut, list, map, nullable, trait, extern, or function indirection."}},
+		},
+		{
+			name: "map key recursive cycle is rejected",
+			input: `struct A {
+  values: [A:Int],
+}
+`,
+			diagnostics: []checker.Diagnostic{{Kind: checker.Error, Message: "Recursive field A.values has infinite size. Put the recursive reference behind mut, list, map, nullable, trait, extern, or function indirection."}},
+		},
+		{
+			name: "nested map key recursive cycle is rejected",
+			input: `struct A {
+  values: [[A:Int]],
+}
+`,
+			diagnostics: []checker.Diagnostic{{Kind: checker.Error, Message: "Recursive field A.values has infinite size. Put the recursive reference behind mut, list, map, nullable, trait, extern, or function indirection."}},
+		},
+		{
+			name: "mut indirection permits recursive map key",
+			input: `struct A {
+  box: mut Box,
+}
+
+struct Box {
+  values: [A:Int],
+}
+`,
+		},
+		{
+			name: "nullable nested in result does not break layout yet",
+			input: `struct A {
+  result: A?!Str,
+}
+`,
+			diagnostics: []checker.Diagnostic{{Kind: checker.Error, Message: "Recursive field A.result has infinite size. Put the recursive reference behind mut, list, map, nullable, trait, extern, or function indirection."}},
+		},
+		{
+			name: "nullable nested in union does not break layout yet",
+			input: `type U = A? | Int
+
+struct A {
+  value: U,
+}
+`,
+			diagnostics: []checker.Diagnostic{{Kind: checker.Error, Message: "Recursive field A.value has infinite size. Put the recursive reference behind mut, list, map, nullable, trait, extern, or function indirection."}},
+		},
+		{
+			name: "direct mutual struct value cycle is rejected",
+			input: `struct A {
+  b: B,
+}
+
+struct B {
+  a: A,
+}
+`,
+			diagnostics: []checker.Diagnostic{{Kind: checker.Error, Message: "Recursive field A.b has infinite size. Put the recursive reference behind mut, list, map, nullable, trait, extern, or function indirection."}},
+		},
+	})
+}
+
+func TestTopLevelTypeDetailsAreHoistedBeforeBodies(t *testing.T) {
+	run(t, []test{
+		{
+			name: "function before later struct can use fields",
+			input: `fn make() B {
+  B{value: 1}
+}
+
+struct B {
+  value: Int,
+}
+`,
+		},
+		{
+			name: "impl before later trait sees required methods",
+			input: `struct S {}
+
+impl T for S {
+}
+
+trait T {
+  fn id() Int
+}
+`,
+			diagnostics: []checker.Diagnostic{{Kind: checker.Error, Message: "Missing method 'id' in trait 'T'"}},
 		},
 	})
 }

--- a/compiler/checker/type_equal.go
+++ b/compiler/checker/type_equal.go
@@ -97,6 +97,14 @@ func equalTypesSeen(left Type, right Type, seen map[typeEqualKey]struct{}) bool 
 			return r.actual == nil || equalTypesSeen(l, r.actual, seen)
 		}
 		return false
+	case *MutableRef:
+		if r, ok := right.(*MutableRef); ok {
+			return equalTypesSeen(l.of, r.of, seen)
+		}
+		if r, ok := right.(*TypeVar); ok {
+			return r.actual == nil || equalTypesSeen(l, r.actual, seen)
+		}
+		return false
 	case *ExternType:
 		if r, ok := right.(*TypeVar); ok && r.actual == nil {
 			return true
@@ -259,6 +267,8 @@ func typeEqualID(t Type) string {
 		return fmt.Sprintf("TypeVar:%p", v)
 	case *Result:
 		return fmt.Sprintf("Result:%p", v)
+	case *MutableRef:
+		return fmt.Sprintf("MutableRef:%p", v)
 	case *ExternType:
 		return fmt.Sprintf("Extern:%p", v)
 	case *FunctionDef:

--- a/compiler/checker/types.go
+++ b/compiler/checker/types.go
@@ -57,6 +57,47 @@ type Type interface {
 	hasTrait(trait *Trait) bool
 }
 
+type MutableRef struct {
+	of Type
+}
+
+func MakeMutableRef(of Type) *MutableRef {
+	return &MutableRef{of: of}
+}
+
+func (m *MutableRef) Of() Type { return m.of }
+func (m *MutableRef) String() string {
+	if m == nil || m.of == nil {
+		return "mut ?"
+	}
+	return "mut " + m.of.String()
+}
+func (m *MutableRef) get(name string) Type {
+	if m == nil || m.of == nil {
+		return nil
+	}
+	return m.of.get(name)
+}
+func (m *MutableRef) equal(other Type) bool {
+	r, ok := other.(*MutableRef)
+	return ok && equalTypes(m.of, r.of)
+}
+func (m *MutableRef) hasTrait(trait *Trait) bool {
+	return m != nil && m.of != nil && m.of.hasTrait(trait)
+}
+
+func mutableRefBase(t Type) (Type, bool) {
+	if ref, ok := t.(*MutableRef); ok {
+		return ref.of, true
+	}
+	return t, false
+}
+
+func derefMutableRef(t Type) Type {
+	base, _ := mutableRefBase(t)
+	return base
+}
+
 type Trait struct {
 	Name    string
 	methods []FunctionDef

--- a/compiler/formatter/imports.go
+++ b/compiler/formatter/imports.go
@@ -29,6 +29,19 @@ func removeUnusedImports(program *parse.Program) {
 
 func collectImportUsesInType(t parse.DeclaredType, used map[string]bool) {
 	switch v := t.(type) {
+	case *parse.MutableType:
+		collectImportUsesInType(v.Inner, used)
+	case parse.MutableType:
+		collectImportUsesInType(v.Inner, used)
+	case *parse.CustomType:
+		if v.Type.Target != nil {
+			if name := simpleImportUseName(v.Type.Target); name != "" {
+				used[name] = true
+			}
+		}
+		for _, arg := range v.TypeArgs {
+			collectImportUsesInType(arg, used)
+		}
 	case parse.CustomType:
 		if v.Type.Target != nil {
 			if name := simpleImportUseName(v.Type.Target); name != "" {
@@ -38,14 +51,27 @@ func collectImportUsesInType(t parse.DeclaredType, used map[string]bool) {
 		for _, arg := range v.TypeArgs {
 			collectImportUsesInType(arg, used)
 		}
+	case *parse.List:
+		collectImportUsesInType(v.Element, used)
 	case parse.List:
 		collectImportUsesInType(v.Element, used)
+	case *parse.Map:
+		collectImportUsesInType(v.Key, used)
+		collectImportUsesInType(v.Value, used)
 	case parse.Map:
 		collectImportUsesInType(v.Key, used)
 		collectImportUsesInType(v.Value, used)
+	case *parse.ResultType:
+		collectImportUsesInType(v.Val, used)
+		collectImportUsesInType(v.Err, used)
 	case parse.ResultType:
 		collectImportUsesInType(v.Val, used)
 		collectImportUsesInType(v.Err, used)
+	case *parse.FunctionType:
+		for _, p := range v.Params {
+			collectImportUsesInType(p, used)
+		}
+		collectImportUsesInType(v.Return, used)
 	case parse.FunctionType:
 		for _, p := range v.Params {
 			collectImportUsesInType(p, used)

--- a/compiler/formatter/printer.go
+++ b/compiler/formatter/printer.go
@@ -811,6 +811,8 @@ func (p printer) renderType(declared parse.DeclaredType) string {
 		return maybeNullable("Void", node.IsNullable())
 	case *parse.GenericType:
 		return maybeNullable("$"+node.Name, node.IsNullable())
+	case *parse.MutableType:
+		return "mut " + p.renderType(node.Inner)
 	case *parse.CustomType:
 		name := node.Name
 		if node.Type.Target != nil {

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -512,6 +512,9 @@ func (l *lowerer) lowerTypeDecls(typ air.TypeInfo) ([]ast.Decl, error) {
 			if err != nil {
 				return nil, err
 			}
+			if field.Mutable {
+				fieldType = &ast.StarExpr{X: fieldType}
+			}
 			fields = append(fields, &ast.Field{Names: []*ast.Ident{ast.NewIdent(l.goFieldName(typ, field.Name))}, Type: fieldType})
 		}
 		return []ast.Decl{&ast.GenDecl{Tok: token.TYPE, Specs: []ast.Spec{&ast.TypeSpec{Name: ast.NewIdent(typeName(l.program, typ)), Type: &ast.StructType{Fields: &ast.FieldList{List: fields}}}}}}, nil
@@ -751,8 +754,13 @@ func (l *lowerer) lowerStmt(fn air.Function, stmt air.Stmt) ([]ast.Stmt, error) 
 		}
 		out := append([]ast.Stmt{}, target.stmts...)
 		out = append(out, value.stmts...)
+		field := targetType.Fields[stmt.Field]
+		fieldTarget := ast.Expr(&ast.SelectorExpr{X: target.expr, Sel: ast.NewIdent(l.goFieldName(targetType, field.Name))})
+		if field.Mutable {
+			fieldTarget = &ast.StarExpr{X: fieldTarget}
+		}
 		out = append(out, &ast.AssignStmt{
-			Lhs: []ast.Expr{&ast.SelectorExpr{X: target.expr, Sel: ast.NewIdent(l.goFieldName(targetType, targetType.Fields[stmt.Field].Name))}},
+			Lhs: []ast.Expr{fieldTarget},
 			Tok: token.ASSIGN,
 			Rhs: []ast.Expr{value.expr},
 		})
@@ -1245,8 +1253,13 @@ func (l *lowerer) lowerExpr(fn air.Function, expr air.Expr) (loweredExpr, error)
 			}
 			stmts = append(stmts, value.stmts...)
 			fieldValue := value.expr
-			if fieldInfo, ok := structFieldByName(typ, field.Name); ok && fieldInfo.RecursiveNullable {
-				fieldValue = recursiveNullableValueAsPointer(l, fieldInfo.Type, fieldValue)
+			if fieldInfo, ok := structFieldByName(typ, field.Name); ok {
+				if fieldInfo.RecursiveNullable {
+					fieldValue = recursiveNullableValueAsPointer(l, fieldInfo.Type, fieldValue)
+				}
+				if fieldInfo.Mutable {
+					fieldValue = l.mutableReferenceArg(fn, field.Value, fieldValue)
+				}
 			}
 			elts = append(elts, &ast.KeyValueExpr{Key: ast.NewIdent(l.goFieldName(typ, field.Name)), Value: fieldValue})
 		}
@@ -1314,6 +1327,9 @@ func (l *lowerer) lowerExpr(fn air.Function, expr air.Expr) (loweredExpr, error)
 		}
 		field := targetType.Fields[expr.Field]
 		fieldExpr := &ast.SelectorExpr{X: target.expr, Sel: ast.NewIdent(l.goFieldName(targetType, field.Name))}
+		if field.Mutable {
+			return loweredExpr{stmts: target.stmts, expr: &ast.StarExpr{X: fieldExpr}}, nil
+		}
 		if field.RecursiveNullable {
 			return loweredExpr{stmts: target.stmts, expr: recursiveNullableFieldAsMaybe(l, expr.Type, fieldExpr)}, nil
 		}
@@ -2112,10 +2128,38 @@ func (l *lowerer) adaptCallArg(fn air.Function, arg air.Expr, argExpr ast.Expr, 
 	if !param.Mutable || !validTypeID(l.program, param.Type) || l.isVoidType(param.Type) {
 		return argExpr
 	}
+	return l.mutableReferenceArg(fn, arg, argExpr)
+}
+
+func (l *lowerer) mutableReferenceArg(fn air.Function, arg air.Expr, argExpr ast.Expr) ast.Expr {
 	if arg.Kind == air.ExprLoadLocal && l.localIsPointerParam(fn, arg.Local) {
 		return ast.NewIdent(localName(fn, arg.Local))
 	}
+	if arg.Kind == air.ExprGetField {
+		if fieldExpr, ok := l.mutableFieldReferenceExpr(fn, arg); ok {
+			return fieldExpr
+		}
+	}
 	return &ast.UnaryExpr{Op: token.AND, X: argExpr}
+}
+
+func (l *lowerer) mutableFieldReferenceExpr(fn air.Function, arg air.Expr) (ast.Expr, bool) {
+	if arg.Target == nil || !validTypeID(l.program, arg.Target.Type) {
+		return nil, false
+	}
+	targetType := l.program.Types[arg.Target.Type-1]
+	if targetType.Kind != air.TypeStruct || arg.Field < 0 || arg.Field >= len(targetType.Fields) {
+		return nil, false
+	}
+	field := targetType.Fields[arg.Field]
+	if !field.Mutable {
+		return nil, false
+	}
+	target, err := l.lowerExpr(fn, *arg.Target)
+	if err != nil {
+		return nil, false
+	}
+	return &ast.SelectorExpr{X: target.expr, Sel: ast.NewIdent(l.goFieldName(targetType, field.Name))}, true
 }
 
 func (l *lowerer) localValueExpr(fn air.Function, local air.LocalID) ast.Expr {

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -885,11 +885,6 @@ func (l *lowerer) lowerExpr(fn air.Function, expr air.Expr) (loweredExpr, error)
 		return l.lowerMakeClosure(fn, expr)
 	case air.ExprCallClosure:
 		return l.lowerCallClosure(fn, expr)
-	case air.ExprCopy:
-		if expr.Target == nil {
-			return loweredExpr{}, fmt.Errorf("copy missing target")
-		}
-		return l.lowerExprWithExpectedType(fn, *expr.Target, expr.Type)
 	case air.ExprMakeMaybeSome:
 		if expr.Target == nil {
 			return loweredExpr{}, fmt.Errorf("maybe some missing target")
@@ -1500,8 +1495,6 @@ func (l *lowerer) canOverrideExprType(expr air.Expr, expectedType air.TypeID) bo
 		return false
 	}
 	switch expr.Kind {
-	case air.ExprCopy:
-		return expr.Target != nil && l.canOverrideExprType(*expr.Target, expectedType)
 	case air.ExprMakeList:
 		return len(expr.Args) == 0 && from.Kind == air.TypeList && to.Kind == air.TypeList
 	case air.ExprMakeResultOk, air.ExprMakeResultErr,

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -3339,15 +3339,32 @@ func (l *lowerer) lowerCallClosure(fn air.Function, expr air.Expr) (loweredExpr,
 	if err != nil {
 		return loweredExpr{}, err
 	}
+	var targetInfo air.TypeInfo
+	hasFunctionType := false
+	if validTypeID(l.program, expr.Target.Type) {
+		info := l.program.Types[expr.Target.Type-1]
+		if info.Kind == air.TypeFunction {
+			targetInfo = info
+			hasFunctionType = true
+		}
+	}
 	args := make([]ast.Expr, 0, len(expr.Args))
 	stmts := append([]ast.Stmt{}, target.stmts...)
-	for _, arg := range expr.Args {
+	for i, arg := range expr.Args {
 		loweredArg, err := l.lowerExpr(fn, arg)
 		if err != nil {
 			return loweredExpr{}, err
 		}
 		stmts = append(stmts, loweredArg.stmts...)
-		args = append(args, loweredArg.expr)
+		argExpr := loweredArg.expr
+		if hasFunctionType && i < len(targetInfo.Params) {
+			param := air.Param{Type: targetInfo.Params[i]}
+			if i < len(targetInfo.ParamMutable) {
+				param.Mutable = targetInfo.ParamMutable[i]
+			}
+			argExpr = l.adaptCallArg(fn, arg, argExpr, param)
+		}
+		args = append(args, argExpr)
 	}
 	return loweredExpr{stmts: stmts, expr: &ast.CallExpr{Fun: target.expr, Args: args}}, nil
 }

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -4735,8 +4735,12 @@ func (l *lowerer) writeJSONEncodeHelper(b *strings.Builder, typeID air.TypeID) {
 	case air.TypeStruct:
 		fmt.Fprintf(b, "\tif err := enc.WriteToken(jsontext.BeginObject); err != nil { return err }\n")
 		for _, field := range info.Fields {
+			fieldValue := "value." + l.goFieldName(info, field.Name)
+			if field.Mutable {
+				fieldValue = "*" + fieldValue
+			}
 			fmt.Fprintf(b, "\tif err := enc.WriteToken(jsontext.String(%q)); err != nil { return err }\n", field.Name)
-			fmt.Fprintf(b, "\tif err := %s(enc, value.%s); err != nil { return err }\n", l.jsonEncodeHelperName(field.Type), l.goFieldName(info, field.Name))
+			fmt.Fprintf(b, "\tif err := %s(enc, %s); err != nil { return err }\n", l.jsonEncodeHelperName(field.Type), fieldValue)
 		}
 		fmt.Fprintf(b, "\treturn enc.WriteToken(jsontext.EndObject)\n")
 	case air.TypeEnum:

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -719,7 +719,7 @@ func (l *lowerer) lowerStmt(fn air.Function, stmt air.Stmt) ([]ast.Stmt, error) 
 			return out, nil
 		}
 		out = append(out, &ast.AssignStmt{
-			Lhs: []ast.Expr{ast.NewIdent(localName(fn, stmt.Local))},
+			Lhs: []ast.Expr{l.localAssignExpr(fn, stmt.Local)},
 			Tok: token.ASSIGN,
 			Rhs: []ast.Expr{value.expr},
 		})
@@ -828,7 +828,7 @@ func (l *lowerer) lowerExpr(fn air.Function, expr air.Expr) (loweredExpr, error)
 		}
 		return loweredExpr{stmts: stmts, expr: zero}, nil
 	case air.ExprLoadLocal:
-		return loweredExpr{expr: ast.NewIdent(localName(fn, expr.Local))}, nil
+		return loweredExpr{expr: l.localValueExpr(fn, expr.Local)}, nil
 	case air.ExprLoadGlobal:
 		if expr.Global < 0 || int(expr.Global) >= len(l.program.Globals) {
 			return loweredExpr{}, fmt.Errorf("unknown global %d", expr.Global)
@@ -1630,11 +1630,7 @@ func (l *lowerer) goParamType(param air.Param) (ast.Expr, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !param.Mutable || !validTypeID(l.program, param.Type) {
-		return typ, nil
-	}
-	info := l.program.Types[param.Type-1]
-	if info.Kind == air.TypeStruct {
+	if param.Mutable && validTypeID(l.program, param.Type) && !l.isVoidType(param.Type) {
 		return &ast.StarExpr{X: typ}, nil
 	}
 	return typ, nil
@@ -2113,37 +2109,34 @@ func (l *lowerer) resolvedExprType(fn air.Function, expr air.Expr) air.TypeID {
 }
 
 func (l *lowerer) adaptCallArg(fn air.Function, arg air.Expr, argExpr ast.Expr, param air.Param) ast.Expr {
-	if !validTypeID(l.program, param.Type) {
+	if !param.Mutable || !validTypeID(l.program, param.Type) || l.isVoidType(param.Type) {
 		return argExpr
 	}
-	paramType := l.program.Types[param.Type-1]
-	if paramType.Kind != air.TypeStruct {
-		return argExpr
+	if arg.Kind == air.ExprLoadLocal && l.localIsPointerParam(fn, arg.Local) {
+		return ast.NewIdent(localName(fn, arg.Local))
 	}
-	argIsPointer := l.localIsPointerParam(fn, arg)
-	switch {
-	case param.Mutable && !argIsPointer:
-		return &ast.UnaryExpr{Op: token.AND, X: argExpr}
-	case !param.Mutable && argIsPointer:
-		return &ast.StarExpr{X: argExpr}
-	default:
-		return argExpr
-	}
+	return &ast.UnaryExpr{Op: token.AND, X: argExpr}
 }
 
-func (l *lowerer) localIsPointerParam(fn air.Function, expr air.Expr) bool {
-	if expr.Kind != air.ExprLoadLocal {
+func (l *lowerer) localValueExpr(fn air.Function, local air.LocalID) ast.Expr {
+	name := ast.Expr(ast.NewIdent(localName(fn, local)))
+	if l.localIsPointerParam(fn, local) {
+		return &ast.StarExpr{X: name}
+	}
+	return name
+}
+
+func (l *lowerer) localAssignExpr(fn air.Function, local air.LocalID) ast.Expr {
+	return l.localValueExpr(fn, local)
+}
+
+func (l *lowerer) localIsPointerParam(fn air.Function, local air.LocalID) bool {
+	idx := int(local)
+	if idx < 0 || idx >= len(fn.Signature.Params) {
 		return false
 	}
-	local := int(expr.Local)
-	if local < 0 || local >= len(fn.Signature.Params) || !validTypeID(l.program, expr.Type) {
-		return false
-	}
-	param := fn.Signature.Params[local]
-	if !param.Mutable || !validTypeID(l.program, param.Type) {
-		return false
-	}
-	return l.program.Types[param.Type-1].Kind == air.TypeStruct
+	param := fn.Signature.Params[idx]
+	return param.Mutable && validTypeID(l.program, param.Type) && !l.isVoidType(param.Type)
 }
 
 func (l *lowerer) qualified(alias string, importPath string, name string) ast.Expr {
@@ -3387,11 +3380,11 @@ func (l *lowerer) lowerListPrepend(fn air.Function, expr air.Expr) (loweredExpr,
 	if err != nil {
 		return loweredExpr{}, err
 	}
-	name := localName(fn, expr.Target.Local)
-	assign := &ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(name)}, Tok: token.ASSIGN, Rhs: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent("append"), Args: []ast.Expr{&ast.CompositeLit{Type: &ast.ArrayType{Elt: elemType}, Elts: []ast.Expr{value.expr}}, ast.NewIdent(name)}, Ellipsis: 2}}}
+	target := l.localValueExpr(fn, expr.Target.Local)
+	assign := &ast.AssignStmt{Lhs: []ast.Expr{target}, Tok: token.ASSIGN, Rhs: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent("append"), Args: []ast.Expr{&ast.CompositeLit{Type: &ast.ArrayType{Elt: elemType}, Elts: []ast.Expr{value.expr}}, target}, Ellipsis: 2}}}
 	stmts := append([]ast.Stmt{}, value.stmts...)
 	stmts = append(stmts, assign)
-	return loweredExpr{stmts: stmts, expr: &ast.CallExpr{Fun: ast.NewIdent("len"), Args: []ast.Expr{ast.NewIdent(name)}}}, nil
+	return loweredExpr{stmts: stmts, expr: &ast.CallExpr{Fun: ast.NewIdent("len"), Args: []ast.Expr{target}}}, nil
 }
 
 func (l *lowerer) lowerListSort(fn air.Function, expr air.Expr) (loweredExpr, error) {
@@ -3441,15 +3434,15 @@ func (l *lowerer) lowerListPush(fn air.Function, expr air.Expr) (loweredExpr, er
 	if err != nil {
 		return loweredExpr{}, err
 	}
-	name := localName(fn, expr.Target.Local)
+	target := l.localValueExpr(fn, expr.Target.Local)
 	assign := &ast.AssignStmt{
-		Lhs: []ast.Expr{ast.NewIdent(name)},
+		Lhs: []ast.Expr{target},
 		Tok: token.ASSIGN,
-		Rhs: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent("append"), Args: []ast.Expr{ast.NewIdent(name), value.expr}}},
+		Rhs: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent("append"), Args: []ast.Expr{target, value.expr}}},
 	}
 	stmts := append([]ast.Stmt{}, value.stmts...)
 	stmts = append(stmts, assign)
-	return loweredExpr{stmts: stmts, expr: &ast.CallExpr{Fun: ast.NewIdent("len"), Args: []ast.Expr{ast.NewIdent(name)}}}, nil
+	return loweredExpr{stmts: stmts, expr: &ast.CallExpr{Fun: ast.NewIdent("len"), Args: []ast.Expr{target}}}, nil
 }
 
 func (l *lowerer) lowerMakeMap(fn air.Function, expr air.Expr) (loweredExpr, error) {

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -1339,25 +1339,16 @@ func (l *lowerer) lowerExpr(fn air.Function, expr air.Expr) (loweredExpr, error)
 	case air.ExprIf:
 		return l.lowerIfExpr(fn, expr)
 	case air.ExprCall:
-		args := make([]ast.Expr, 0, len(expr.Args))
-		stmts := []ast.Stmt{}
 		if !validFunctionID(l.program, expr.Function) {
 			return loweredExpr{}, fmt.Errorf("invalid function id %d", expr.Function)
 		}
 		target := l.program.Functions[expr.Function]
-		for i, arg := range expr.Args {
-			loweredArg, err := l.lowerExpr(fn, arg)
-			if err != nil {
-				return loweredExpr{}, err
-			}
-			stmts = append(stmts, loweredArg.stmts...)
-			argExpr := loweredArg.expr
-			if i < len(target.Signature.Params) {
-				argExpr = l.adaptCallArg(fn, arg, argExpr, target.Signature.Params[i])
-			}
-			args = append(args, argExpr)
+		args, stmts, writeback, err := l.lowerCallArgs(fn, expr.Args, target.Signature.Params)
+		if err != nil {
+			return loweredExpr{}, err
 		}
-		return loweredExpr{stmts: stmts, expr: &ast.CallExpr{Fun: ast.NewIdent(functionName(l.program, target)), Args: args}}, nil
+		call := &ast.CallExpr{Fun: ast.NewIdent(functionName(l.program, target)), Args: args}
+		return l.finishCallWithWriteback(expr.Type, stmts, call, writeback)
 	case air.ExprIntAdd, air.ExprIntSub, air.ExprIntMul, air.ExprIntDiv, air.ExprIntMod,
 		air.ExprFloatAdd, air.ExprFloatSub, air.ExprFloatMul, air.ExprFloatDiv,
 		air.ExprEq, air.ExprNotEq, air.ExprLt, air.ExprLte, air.ExprGt, air.ExprGte,
@@ -2124,11 +2115,125 @@ func (l *lowerer) resolvedExprType(fn air.Function, expr air.Expr) air.TypeID {
 	return expr.Type
 }
 
+func (l *lowerer) lowerCallArgs(fn air.Function, rawArgs []air.Expr, params []air.Param) ([]ast.Expr, []ast.Stmt, []ast.Stmt, error) {
+	args := make([]ast.Expr, 0, len(rawArgs))
+	stmts := []ast.Stmt{}
+	writeback := []ast.Stmt{}
+	for i, arg := range rawArgs {
+		loweredArg, err := l.lowerExpr(fn, arg)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		stmts = append(stmts, loweredArg.stmts...)
+		argExpr := loweredArg.expr
+		if i < len(params) {
+			var setup []ast.Stmt
+			var post []ast.Stmt
+			argExpr, setup, post, err = l.adaptCallArgWithStmts(fn, arg, argExpr, params[i])
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			stmts = append(stmts, setup...)
+			writeback = append(writeback, post...)
+		}
+		args = append(args, argExpr)
+	}
+	return args, stmts, writeback, nil
+}
+
+func (l *lowerer) finishCallWithWriteback(typeID air.TypeID, stmts []ast.Stmt, call ast.Expr, writeback []ast.Stmt) (loweredExpr, error) {
+	if len(writeback) == 0 {
+		return loweredExpr{stmts: stmts, expr: call}, nil
+	}
+	if l.isVoidType(typeID) {
+		stmts = append(stmts, &ast.ExprStmt{X: call})
+		stmts = append(stmts, writeback...)
+		return loweredExpr{stmts: stmts, expr: ast.NewIdent("nil")}, nil
+	}
+	resultTemp := l.nextTemp()
+	resultType, err := l.goType(typeID)
+	if err != nil {
+		return loweredExpr{}, err
+	}
+	stmts = append(stmts,
+		&ast.DeclStmt{Decl: &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent(resultTemp)}, Type: resultType}}}},
+		&ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(resultTemp)}, Tok: token.ASSIGN, Rhs: []ast.Expr{call}},
+	)
+	stmts = append(stmts, writeback...)
+	return loweredExpr{stmts: stmts, expr: ast.NewIdent(resultTemp)}, nil
+}
+
 func (l *lowerer) adaptCallArg(fn air.Function, arg air.Expr, argExpr ast.Expr, param air.Param) ast.Expr {
 	if !param.Mutable || !validTypeID(l.program, param.Type) || l.isVoidType(param.Type) {
 		return argExpr
 	}
 	return l.mutableReferenceArg(fn, arg, argExpr)
+}
+
+func (l *lowerer) adaptCallArgWithStmts(fn air.Function, arg air.Expr, argExpr ast.Expr, param air.Param) (ast.Expr, []ast.Stmt, []ast.Stmt, error) {
+	if !param.Mutable || !validTypeID(l.program, param.Type) || l.isVoidType(param.Type) {
+		return argExpr, nil, nil, nil
+	}
+	if adapted, setup, writeback, ok, err := l.mutableTraitObjectArg(fn, arg, argExpr, param); ok || err != nil {
+		return adapted, setup, writeback, err
+	}
+	return l.mutableReferenceArg(fn, arg, argExpr), nil, nil, nil
+}
+
+func (l *lowerer) mutableTraitObjectArg(fn air.Function, arg air.Expr, argExpr ast.Expr, param air.Param) (ast.Expr, []ast.Stmt, []ast.Stmt, bool, error) {
+	if !validTypeID(l.program, param.Type) || l.program.Types[param.Type-1].Kind != air.TypeTraitObject {
+		return nil, nil, nil, false, nil
+	}
+	if arg.Kind != air.ExprTraitUpcast || arg.Target == nil {
+		return nil, nil, nil, false, nil
+	}
+	writebackTarget, writebackSetup, ok, err := l.mutableTraitUpcastWritebackTarget(fn, *arg.Target)
+	if err != nil {
+		return nil, nil, nil, true, err
+	}
+	if !ok {
+		return nil, nil, nil, true, fmt.Errorf("mutable trait object argument is not an assignable place")
+	}
+	tmp := l.nextTemp()
+	setup := []ast.Stmt{&ast.AssignStmt{Lhs: []ast.Expr{ast.NewIdent(tmp)}, Tok: token.DEFINE, Rhs: []ast.Expr{argExpr}}}
+	targetType, err := l.goType(arg.Target.Type)
+	if err != nil {
+		return nil, nil, nil, true, err
+	}
+	writeback := append([]ast.Stmt{}, writebackSetup...)
+	writeback = append(writeback, &ast.AssignStmt{
+		Lhs: []ast.Expr{writebackTarget},
+		Tok: token.ASSIGN,
+		Rhs: []ast.Expr{&ast.TypeAssertExpr{X: ast.NewIdent(tmp), Type: targetType}},
+	})
+	return &ast.UnaryExpr{Op: token.AND, X: ast.NewIdent(tmp)}, setup, writeback, true, nil
+}
+
+func (l *lowerer) mutableTraitUpcastWritebackTarget(fn air.Function, arg air.Expr) (ast.Expr, []ast.Stmt, bool, error) {
+	switch arg.Kind {
+	case air.ExprLoadLocal:
+		return l.localAssignExpr(fn, arg.Local), nil, true, nil
+	case air.ExprGetField:
+		if arg.Target == nil || !validTypeID(l.program, arg.Target.Type) {
+			return nil, nil, false, nil
+		}
+		target, err := l.lowerExpr(fn, *arg.Target)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		targetType := l.program.Types[arg.Target.Type-1]
+		if targetType.Kind != air.TypeStruct || arg.Field < 0 || arg.Field >= len(targetType.Fields) {
+			return nil, nil, false, nil
+		}
+		field := targetType.Fields[arg.Field]
+		fieldTarget := ast.Expr(&ast.SelectorExpr{X: target.expr, Sel: ast.NewIdent(l.goFieldName(targetType, field.Name))})
+		if field.Mutable {
+			fieldTarget = &ast.StarExpr{X: fieldTarget}
+		}
+		return fieldTarget, target.stmts, true, nil
+	default:
+		return nil, nil, false, nil
+	}
 }
 
 func (l *lowerer) mutableReferenceArg(fn air.Function, arg air.Expr, argExpr ast.Expr) ast.Expr {
@@ -3348,25 +3453,23 @@ func (l *lowerer) lowerCallClosure(fn air.Function, expr air.Expr) (loweredExpr,
 			hasFunctionType = true
 		}
 	}
-	args := make([]ast.Expr, 0, len(expr.Args))
-	stmts := append([]ast.Stmt{}, target.stmts...)
-	for i, arg := range expr.Args {
-		loweredArg, err := l.lowerExpr(fn, arg)
-		if err != nil {
-			return loweredExpr{}, err
-		}
-		stmts = append(stmts, loweredArg.stmts...)
-		argExpr := loweredArg.expr
-		if hasFunctionType && i < len(targetInfo.Params) {
-			param := air.Param{Type: targetInfo.Params[i]}
+	params := []air.Param{}
+	if hasFunctionType {
+		params = make([]air.Param, len(targetInfo.Params))
+		for i, paramType := range targetInfo.Params {
+			params[i] = air.Param{Type: paramType}
 			if i < len(targetInfo.ParamMutable) {
-				param.Mutable = targetInfo.ParamMutable[i]
+				params[i].Mutable = targetInfo.ParamMutable[i]
 			}
-			argExpr = l.adaptCallArg(fn, arg, argExpr, param)
 		}
-		args = append(args, argExpr)
 	}
-	return loweredExpr{stmts: stmts, expr: &ast.CallExpr{Fun: target.expr, Args: args}}, nil
+	args, stmts, writeback, err := l.lowerCallArgs(fn, expr.Args, params)
+	if err != nil {
+		return loweredExpr{}, err
+	}
+	stmts = append(append([]ast.Stmt{}, target.stmts...), stmts...)
+	call := &ast.CallExpr{Fun: target.expr, Args: args}
+	return l.finishCallWithWriteback(expr.Type, stmts, call, writeback)
 }
 
 func (l *lowerer) lowerListSet(fn air.Function, expr air.Expr) (loweredExpr, error) {

--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -1306,6 +1306,46 @@ func TestGoTargetParityMutatingTraitDispatchUpdatesStoredTraitObject(t *testing.
 	}
 }
 
+func TestGoTargetParityMutableReferenceFieldUpdatesSharedStorage(t *testing.T) {
+	program := lowerParitySource(t, `
+		struct Tree {
+			count: Int,
+		}
+
+		struct Context {
+			tree: mut Tree,
+		}
+
+		fn bump(mut tree: Tree) {
+			tree.count = tree.count + 1
+		}
+
+		struct Box {
+			value: mut Int,
+		}
+
+		fn set(mut value: Int) {
+			value = 3
+		}
+
+		fn main() Int {
+			mut tree = Tree{count: 0}
+			let ctx = Context{tree: tree}
+			bump(ctx.tree)
+			ctx.tree.count = 2
+
+			mut count = 0
+			let box = Box{value: count}
+			set(box.value)
+
+			ctx.tree.count + tree.count + box.value + count
+		}
+	`)
+	if got := runGoTargetParityJSON(t, program); got != "10" {
+		t.Fatalf("got %s, want 10", got)
+	}
+}
+
 func TestGoTargetParityMutableReferenceParameterUpdatesCaller(t *testing.T) {
 	t.Run("struct", func(t *testing.T) {
 		program := lowerParitySource(t, `

--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -1293,10 +1293,10 @@ func TestGoTargetParityMutatingTraitDispatchUpdatesStoredTraitObject(t *testing.
 			let field_result = app.current()
 
 			mut typed_app = AppRoot{view: CounterView{count: 0}}
-			let typed_result = run_typed(mut typed_app)
+			let typed_result = run_typed(typed_app)
 
 			mut any_app = AppRoot{view: CounterView{count: 0}}
-			let any_result = run_any(mut any_app)
+			let any_result = run_any(any_app)
 
 			field_result + typed_result + any_result
 		}
@@ -1304,6 +1304,63 @@ func TestGoTargetParityMutatingTraitDispatchUpdatesStoredTraitObject(t *testing.
 	if got := runGoTargetParityJSON(t, program); got != "3" {
 		t.Fatalf("got %s, want 3", got)
 	}
+}
+
+func TestGoTargetParityMutableReferenceParameterUpdatesCaller(t *testing.T) {
+	t.Run("struct", func(t *testing.T) {
+		program := lowerParitySource(t, `
+			struct Counter {
+				value: Int,
+			}
+
+			fn bump(mut c: Counter) {
+				c.value = c.value + 1
+			}
+
+			fn main() Int {
+				mut counter = Counter{value: 0}
+				bump(counter)
+				counter.value
+			}
+		`)
+		if got := runGoTargetParityJSON(t, program); got != "1" {
+			t.Fatalf("got %s, want 1", got)
+		}
+	})
+
+	t.Run("list", func(t *testing.T) {
+		program := lowerParitySource(t, `
+			fn append_one(mut values: [Int]) {
+				values.push(1)
+			}
+
+			fn main() Int {
+				mut values: [Int] = []
+				append_one(values)
+				values.size()
+			}
+		`)
+		if got := runGoTargetParityJSON(t, program); got != "1" {
+			t.Fatalf("got %s, want 1", got)
+		}
+	})
+
+	t.Run("primitive", func(t *testing.T) {
+		program := lowerParitySource(t, `
+			fn bump(mut count: Int) {
+				count = count + 1
+			}
+
+			fn main() Int {
+				mut count = 0
+				bump(count)
+				count
+			}
+		`)
+		if got := runGoTargetParityJSON(t, program); got != "1" {
+			t.Fatalf("got %s, want 1", got)
+		}
+	})
 }
 
 func TestGoTargetParityMutMethodClosureCapturesSelf(t *testing.T) {

--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -1242,6 +1242,48 @@ func TestGoTargetParityMutatingTraitImplClosureCapturesSelf(t *testing.T) {
 	}
 }
 
+func TestGoTargetParityMutableTraitObjectParameterFromConcrete(t *testing.T) {
+	program := lowerParitySource(t, `
+		struct Context {
+			node_id: Int,
+		}
+
+		trait View {
+			fn init(ctx: Context)
+			fn node_id() Int
+		}
+
+		fn add_child(ctx: Context, mut child: View) {
+			child.init(Context{node_id: ctx.node_id + 1})
+		}
+
+		struct Leaf {
+			initialized: Bool,
+			node_id: Int,
+		}
+
+		impl View for Leaf {
+			fn mut init(ctx: Context) {
+				self.initialized = true
+				self.node_id = ctx.node_id
+			}
+
+			fn node_id() Int {
+				self.node_id
+			}
+		}
+
+		fn main() Int {
+			mut leaf = Leaf{initialized: false, node_id: 0}
+			add_child(Context{node_id: 41}, leaf)
+			if leaf.initialized { leaf.node_id } else { 0 }
+		}
+	`)
+	if got := runGoTargetParityJSON(t, program); got != "42" {
+		t.Fatalf("got %s, want 42", got)
+	}
+}
+
 func TestGoTargetParityMutatingTraitDispatchUpdatesStoredTraitObject(t *testing.T) {
 	program := lowerParitySource(t, `
 		trait View {

--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -74,6 +74,97 @@ func TestGoTargetParityRecursiveStructFields(t *testing.T) {
 				}
 			`,
 		},
+		{
+			name: "mutual nullable reference",
+			input: `
+				use ard/maybe
+				struct A { b: B? }
+				struct B { a: A }
+				fn main() Int {
+					let a = A{b: maybe::none()}
+					let b = B{a: a}
+					if b.a.b.is_none() { 1 } else { 0 }
+				}
+			`,
+		},
+		{
+			name: "mutual nullable references",
+			input: `
+				use ard/maybe
+				struct A { b: B? }
+				struct B { a: A? }
+				fn main() Int {
+					let a = A{b: maybe::none()}
+					if a.b.is_none() { 1 } else { 0 }
+				}
+			`,
+		},
+		{
+			name: "generic nullable reference",
+			input: `
+				struct A { box: Box<A>? }
+				struct Box { value: $T }
+				fn main() Int { 1 }
+			`,
+		},
+		{
+			name: "nullable union reference",
+			input: `
+				use ard/maybe
+				type U = A | Int
+				struct A { u: U? }
+				fn main() Int {
+					let a = A{u: maybe::none()}
+					if a.u.is_none() { 1 } else { 0 }
+				}
+			`,
+		},
+		{
+			name: "function field self reference",
+			input: `
+				struct A { make: fn() A }
+				fn main() Int { 1 }
+			`,
+		},
+		{
+			name: "same module retained tree recursive type group",
+			input: `
+				struct Context {
+					tree: ViewTree,
+					node_id: Int,
+				}
+
+				struct ViewTree {
+					nodes: [TreeNode],
+				}
+
+				struct TreeNode {
+					view: View,
+					children: [Int],
+				}
+
+				trait View {
+					fn init(ctx: Context)
+					fn id() Int
+				}
+
+				struct Leaf {
+					value: Int,
+				}
+
+				impl View for Leaf {
+					fn init(ctx: Context) {}
+					fn id() Int { self.value }
+				}
+
+				fn main() Int {
+					let tree = ViewTree{nodes: []}
+					let ctx = Context{tree: tree, node_id: 1}
+					let node = TreeNode{view: Leaf{value: 41}, children: []}
+					node.view.id() + ctx.node_id
+				}
+			`,
+		},
 	})
 }
 

--- a/compiler/go/parity_test.go
+++ b/compiler/go/parity_test.go
@@ -1401,6 +1401,29 @@ func TestGoTargetParityMutableReferenceParameterUpdatesCaller(t *testing.T) {
 			t.Fatalf("got %s, want 1", got)
 		}
 	})
+
+	t.Run("closure function type", func(t *testing.T) {
+		program := lowerParitySource(t, `
+			type MutIntFn = fn(mut Int)
+
+			fn bump(mut count: Int) {
+				count = count + 1
+			}
+
+			fn apply(f: MutIntFn, mut count: Int) {
+				f(count)
+			}
+
+			fn main() Int {
+				mut count = 0
+				apply(bump, count)
+				count
+			}
+		`)
+		if got := runGoTargetParityJSON(t, program); got != "1" {
+			t.Fatalf("got %s, want 1", got)
+		}
+	})
 }
 
 func TestGoTargetParityMutMethodClosureCapturesSelf(t *testing.T) {

--- a/compiler/javascript/air_backend.go
+++ b/compiler/javascript/air_backend.go
@@ -729,14 +729,14 @@ func (l *airJSLowerer) lowerStmt(fn air.Function, stmt air.Stmt) (string, error)
 			if err != nil {
 				return "", err
 			}
-			lines = append(lines, l.localName(fn, stmt.Local)+" = "+value+";")
+			lines = append(lines, l.localAssignTarget(fn, stmt.Local)+" = "+value+";")
 			return strings.Join(lines, "\n"), nil
 		}
 		value, err := l.lowerExpr(fn, *stmt.Value)
 		if err != nil {
 			return "", err
 		}
-		return l.localName(fn, stmt.Local) + " = " + value + ";", nil
+		return l.localAssignTarget(fn, stmt.Local) + " = " + value + ";", nil
 	case air.StmtSetField:
 		target, err := l.lowerExpr(fn, *stmt.Target)
 		if err != nil {
@@ -819,7 +819,7 @@ func (l *airJSLowerer) lowerExpr(fn air.Function, expr air.Expr) (string, error)
 	case air.ExprConstStr:
 		return strconv.Quote(expr.Str), nil
 	case air.ExprLoadLocal:
-		return l.localName(fn, expr.Local), nil
+		return l.localValueName(fn, expr.Local), nil
 	case air.ExprLoadGlobal:
 		return l.globalRef(fn.Module, expr.Global), nil
 	case air.ExprFunctionRef:
@@ -843,11 +843,7 @@ func (l *airJSLowerer) lowerExpr(fn air.Function, expr air.Expr) (string, error)
 			}
 			return renderJSExpr(jsCallExprIR{Callee: receiver + "." + jsName(info.Method), Args: args}), nil
 		}
-		args, err := l.lowerArgs(fn, expr.Args)
-		if err != nil {
-			return "", err
-		}
-		return renderJSExpr(jsCallExprIR{Callee: l.functionRef(fn.Module, expr.Function), Args: args}), nil
+		return l.lowerFunctionCall(fn, expr)
 	case air.ExprCallExtern:
 		call, err := l.lowerExternCallRaw(fn, expr)
 		if err != nil {
@@ -1738,6 +1734,82 @@ func (l *airJSLowerer) lowerStrOp(fn air.Function, expr air.Expr) (string, error
 	}
 }
 
+func (l *airJSLowerer) lowerFunctionCall(fn air.Function, expr air.Expr) (string, error) {
+	if expr.Function < 0 || int(expr.Function) >= len(l.program.Functions) {
+		return "", fmt.Errorf("invalid function id %d", expr.Function)
+	}
+	target := l.program.Functions[expr.Function]
+	args := make([]string, len(expr.Args))
+	setup := []string{}
+	writeback := []string{}
+	for i, arg := range expr.Args {
+		value, err := l.lowerExpr(fn, arg)
+		if err != nil {
+			return "", err
+		}
+		if i < len(target.Signature.Params) && target.Signature.Params[i].Mutable {
+			refArg, refSetup, refWriteback, err := l.mutableArgRef(fn, arg, value)
+			if err != nil {
+				return "", err
+			}
+			args[i] = refArg
+			setup = append(setup, refSetup...)
+			writeback = append(writeback, refWriteback...)
+			continue
+		}
+		args[i] = value
+	}
+	call := renderJSExpr(jsCallExprIR{Callee: l.functionRef(fn.Module, expr.Function), Args: args})
+	if len(setup) == 0 && len(writeback) == 0 {
+		return call, nil
+	}
+	result := l.temp("call")
+	lines := append([]string{}, setup...)
+	lines = append(lines, "const "+result+" = "+call+";")
+	lines = append(lines, writeback...)
+	lines = append(lines, "return "+result+";")
+	return renderJSDoc(jsIIFEDoc(strings.Join(lines, "\n"))), nil
+}
+
+func (l *airJSLowerer) mutableArgRef(fn air.Function, arg air.Expr, value string) (string, []string, []string, error) {
+	if arg.Kind == air.ExprLoadLocal && l.localIsMutableParam(fn, arg.Local) {
+		return l.localName(fn, arg.Local), nil, nil, nil
+	}
+	place, ok, err := l.mutablePlace(fn, arg, value)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	if !ok {
+		return "", nil, nil, fmt.Errorf("mutable argument is not an assignable place")
+	}
+	ref := l.temp("mut")
+	setup := []string{"const " + ref + " = { value: " + place + " };"}
+	writeback := []string{place + " = " + ref + ".value;"}
+	return ref, setup, writeback, nil
+}
+
+func (l *airJSLowerer) mutablePlace(fn air.Function, arg air.Expr, value string) (string, bool, error) {
+	switch arg.Kind {
+	case air.ExprLoadLocal:
+		return l.localAssignTarget(fn, arg.Local), true, nil
+	case air.ExprGetField:
+		if arg.Target == nil {
+			return "", false, fmt.Errorf("field place missing target")
+		}
+		target, err := l.lowerExpr(fn, *arg.Target)
+		if err != nil {
+			return "", false, err
+		}
+		t, ok := l.typeInfo(arg.Target.Type)
+		if !ok || arg.Field < 0 || arg.Field >= len(t.Fields) {
+			return "", false, fmt.Errorf("unknown field %d on type %d", arg.Field, arg.Target.Type)
+		}
+		return target + "." + jsName(t.Fields[arg.Field].Name), true, nil
+	default:
+		return value, false, nil
+	}
+}
+
 func (l *airJSLowerer) lowerArgs(fn air.Function, args []air.Expr) ([]string, error) {
 	out := make([]string, len(args))
 	for i, arg := range args {
@@ -1794,6 +1866,26 @@ func (l *airJSLowerer) localName(fn air.Function, local air.LocalID) string {
 		}
 	}
 	return base
+}
+
+func (l *airJSLowerer) localValueName(fn air.Function, local air.LocalID) string {
+	name := l.localName(fn, local)
+	if l.localIsMutableParam(fn, local) {
+		return name + ".value"
+	}
+	return name
+}
+
+func (l *airJSLowerer) localAssignTarget(fn air.Function, local air.LocalID) string {
+	return l.localValueName(fn, local)
+}
+
+func (l *airJSLowerer) localIsMutableParam(fn air.Function, local air.LocalID) bool {
+	idx := int(local)
+	if idx < 0 || idx >= len(fn.Signature.Params) {
+		return false
+	}
+	return fn.Signature.Params[idx].Mutable
 }
 
 func (l *airJSLowerer) typeModule(typeID air.TypeID) (air.ModuleID, bool) {

--- a/compiler/javascript/air_backend.go
+++ b/compiler/javascript/air_backend.go
@@ -1366,11 +1366,42 @@ func (l *airJSLowerer) lowerCallClosure(fn air.Function, expr air.Expr) (string,
 	if err != nil {
 		return "", err
 	}
-	args, err := l.lowerArgs(fn, expr.Args)
-	if err != nil {
-		return "", err
+	var targetInfo air.TypeInfo
+	hasFunctionType := false
+	if info, ok := l.typeInfo(expr.Target.Type); ok && info.Kind == air.TypeFunction {
+		targetInfo = info
+		hasFunctionType = true
 	}
-	return renderJSExpr(jsCallExprIR{Callee: target, Args: args}), nil
+	args := make([]string, len(expr.Args))
+	setup := []string{}
+	writeback := []string{}
+	for i, arg := range expr.Args {
+		value, err := l.lowerExpr(fn, arg)
+		if err != nil {
+			return "", err
+		}
+		if hasFunctionType && i < len(targetInfo.Params) && i < len(targetInfo.ParamMutable) && targetInfo.ParamMutable[i] {
+			refArg, refSetup, refWriteback, err := l.mutableArgRef(fn, arg, value)
+			if err != nil {
+				return "", err
+			}
+			args[i] = refArg
+			setup = append(setup, refSetup...)
+			writeback = append(writeback, refWriteback...)
+			continue
+		}
+		args[i] = value
+	}
+	call := renderJSExpr(jsCallExprIR{Callee: target, Args: args})
+	if len(setup) == 0 && len(writeback) == 0 {
+		return call, nil
+	}
+	result := l.temp("call")
+	lines := append([]string{}, setup...)
+	lines = append(lines, "const "+result+" = "+call+";")
+	lines = append(lines, writeback...)
+	lines = append(lines, "return "+result+";")
+	return renderJSDoc(jsIIFEDoc(strings.Join(lines, "\n"))), nil
 }
 
 func (l *airJSLowerer) lowerBlockWithBindings(fn air.Function, block air.Block, bindings []string) (string, error) {

--- a/compiler/javascript/air_backend.go
+++ b/compiler/javascript/air_backend.go
@@ -1030,8 +1030,6 @@ func (l *airJSLowerer) lowerExpr(fn air.Function, expr air.Expr) (string, error)
 		return renderJSExpr(jsCallExprIR{Callee: "ardToString", Args: []string{value}}), nil
 	case air.ExprToDynamic, air.ExprTraitUpcast:
 		return l.lowerExpr(fn, *expr.Target)
-	case air.ExprCopy:
-		return l.lowerExpr(fn, *expr.Target)
 	case air.ExprPanic:
 		message, err := l.lowerExpr(fn, *expr.Target)
 		if err != nil {

--- a/compiler/javascript/air_backend.go
+++ b/compiler/javascript/air_backend.go
@@ -750,7 +750,12 @@ func (l *airJSLowerer) lowerStmt(fn air.Function, stmt air.Stmt) (string, error)
 		if !ok || stmt.Field < 0 || stmt.Field >= len(t.Fields) {
 			return "", fmt.Errorf("unknown field %d on type %d", stmt.Field, stmt.Target.Type)
 		}
-		return target + "." + jsName(t.Fields[stmt.Field].Name) + " = " + value + ";", nil
+		field := t.Fields[stmt.Field]
+		fieldTarget := target + "." + jsName(field.Name)
+		if field.Mutable {
+			fieldTarget += ".value"
+		}
+		return fieldTarget + " = " + value + ";", nil
 	case air.StmtExpr:
 		if stmt.Expr != nil && stmt.Expr.Kind == air.ExprIf {
 			return l.lowerIfStmt(fn, *stmt.Expr)
@@ -862,15 +867,26 @@ func (l *airJSLowerer) lowerExpr(fn air.Function, expr air.Expr) (string, error)
 		return l.lowerCallClosure(fn, expr)
 	case air.ExprMakeStruct:
 		args := make([]string, len(expr.Fields))
+		typeInfo, ok := l.typeInfo(expr.Type)
+		if !ok {
+			return "", fmt.Errorf("unknown struct type %d", expr.Type)
+		}
+		fieldsByName := map[string]air.FieldInfo{}
+		for _, field := range typeInfo.Fields {
+			fieldsByName[field.Name] = field
+		}
 		for i, field := range expr.Fields {
 			value, err := l.lowerExpr(fn, field.Value)
 			if err != nil {
 				return "", err
 			}
+			if info, ok := fieldsByName[field.Name]; ok && info.Mutable {
+				value, err = l.mutableRefCellExpr(fn, field.Value, value)
+				if err != nil {
+					return "", err
+				}
+			}
 			args[i] = value
-		}
-		if _, ok := l.typeInfo(expr.Type); !ok {
-			return "", fmt.Errorf("unknown struct type %d", expr.Type)
 		}
 		return renderJSExpr(jsNewExprIR{Ctor: l.typeRef(fn.Module, expr.Type), Args: args}), nil
 	case air.ExprGetField:
@@ -883,7 +899,11 @@ func (l *airJSLowerer) lowerExpr(fn air.Function, expr air.Expr) (string, error)
 			return "", fmt.Errorf("unknown field %d on type %d", expr.Field, expr.Target.Type)
 		}
 		field := t.Fields[expr.Field]
-		return target + "." + jsName(field.Name), nil
+		fieldExpr := target + "." + jsName(field.Name)
+		if field.Mutable {
+			return fieldExpr + ".value", nil
+		}
+		return fieldExpr, nil
 	case air.ExprEnumVariant:
 		t, ok := l.typeInfo(expr.Type)
 		if !ok || expr.Variant < 0 || expr.Variant >= len(t.Variants) {
@@ -1775,6 +1795,11 @@ func (l *airJSLowerer) mutableArgRef(fn air.Function, arg air.Expr, value string
 	if arg.Kind == air.ExprLoadLocal && l.localIsMutableParam(fn, arg.Local) {
 		return l.localName(fn, arg.Local), nil, nil, nil
 	}
+	if cell, ok, err := l.mutableFieldCell(fn, arg); err != nil {
+		return "", nil, nil, err
+	} else if ok {
+		return cell, nil, nil, nil
+	}
 	place, ok, err := l.mutablePlace(fn, arg, value)
 	if err != nil {
 		return "", nil, nil, err
@@ -1786,6 +1811,44 @@ func (l *airJSLowerer) mutableArgRef(fn air.Function, arg air.Expr, value string
 	setup := []string{"const " + ref + " = { value: " + place + " };"}
 	writeback := []string{place + " = " + ref + ".value;"}
 	return ref, setup, writeback, nil
+}
+
+func (l *airJSLowerer) mutableRefCellExpr(fn air.Function, arg air.Expr, value string) (string, error) {
+	if arg.Kind == air.ExprLoadLocal && l.localIsMutableParam(fn, arg.Local) {
+		return l.localName(fn, arg.Local), nil
+	}
+	if cell, ok, err := l.mutableFieldCell(fn, arg); err != nil {
+		return "", err
+	} else if ok {
+		return cell, nil
+	}
+	place, ok, err := l.mutablePlace(fn, arg, value)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("mutable reference field value is not an assignable place")
+	}
+	return "({ get value() { return " + place + "; }, set value(__value) { " + place + " = __value; } })", nil
+}
+
+func (l *airJSLowerer) mutableFieldCell(fn air.Function, arg air.Expr) (string, bool, error) {
+	if arg.Kind != air.ExprGetField || arg.Target == nil {
+		return "", false, nil
+	}
+	target, err := l.lowerExpr(fn, *arg.Target)
+	if err != nil {
+		return "", false, err
+	}
+	t, ok := l.typeInfo(arg.Target.Type)
+	if !ok || arg.Field < 0 || arg.Field >= len(t.Fields) {
+		return "", false, fmt.Errorf("unknown field %d on type %d", arg.Field, arg.Target.Type)
+	}
+	field := t.Fields[arg.Field]
+	if !field.Mutable {
+		return "", false, nil
+	}
+	return target + "." + jsName(field.Name), true, nil
 }
 
 func (l *airJSLowerer) mutablePlace(fn air.Function, arg air.Expr, value string) (string, bool, error) {
@@ -1804,7 +1867,12 @@ func (l *airJSLowerer) mutablePlace(fn air.Function, arg air.Expr, value string)
 		if !ok || arg.Field < 0 || arg.Field >= len(t.Fields) {
 			return "", false, fmt.Errorf("unknown field %d on type %d", arg.Field, arg.Target.Type)
 		}
-		return target + "." + jsName(t.Fields[arg.Field].Name), true, nil
+		field := t.Fields[arg.Field]
+		place := target + "." + jsName(field.Name)
+		if field.Mutable {
+			place += ".value"
+		}
+		return place, true, nil
 	default:
 		return value, false, nil
 	}

--- a/compiler/javascript/javascript_test.go
+++ b/compiler/javascript/javascript_test.go
@@ -384,6 +384,55 @@ fn main() {
 	}
 }
 
+func TestRunMutableReferenceParameterUpdatesCaller(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not installed")
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write ard.toml: %v", err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`
+use ard/io
+
+struct Counter {
+  value: Int,
+}
+
+fn bump(mut c: Counter) {
+  c.value = c.value + 1
+}
+
+fn bump_int(mut count: Int) {
+  count = count + 1
+}
+
+fn main() {
+  mut counter = Counter{value: 0}
+  bump(counter)
+  io::print(counter.value.to_str())
+
+  mut count = 0
+  bump_int(count)
+  io::print(count.to_str())
+}
+`), 0o644); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+
+	cmd := exec.Command("go", "run", "-tags=goexperiment.jsonv2", ".", "run", "--target", "js-server", mainPath)
+	cmd.Dir = ".."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("did not expect js-server mutable reference run error: %v\n%s", err, string(out))
+	}
+	if string(out) != "1\n1\n" {
+		t.Fatalf("unexpected output: %q", string(out))
+	}
+}
+
 func TestRunExecutesDecodeAndJSONStdlibProgram(t *testing.T) {
 	if _, err := exec.LookPath("node"); err != nil {
 		t.Skip("node not installed")

--- a/compiler/javascript/javascript_test.go
+++ b/compiler/javascript/javascript_test.go
@@ -413,8 +413,14 @@ fn bump(mut c: Counter) {
   c.value = c.value + 1
 }
 
+type MutIntFn = fn(mut Int)
+
 fn bump_int(mut count: Int) {
   count = count + 1
+}
+
+fn apply(f: MutIntFn, mut count: Int) {
+  f(count)
 }
 
 fn main() {
@@ -436,6 +442,10 @@ fn main() {
   let box = Box{value: shared_count}
   bump_int(box.value)
   io::print((box.value + shared_count).to_str())
+
+  mut closure_count = 0
+  apply(bump_int, closure_count)
+  io::print(closure_count.to_str())
 }
 `), 0o644); err != nil {
 		t.Fatalf("failed to write source: %v", err)
@@ -447,7 +457,7 @@ fn main() {
 	if err != nil {
 		t.Fatalf("did not expect js-server mutable reference run error: %v\n%s", err, string(out))
 	}
-	if string(out) != "1\n4\n1\n2\n" {
+	if string(out) != "1\n4\n1\n2\n1\n" {
 		t.Fatalf("unexpected output: %q", string(out))
 	}
 }

--- a/compiler/javascript/javascript_test.go
+++ b/compiler/javascript/javascript_test.go
@@ -401,6 +401,14 @@ struct Counter {
   value: Int,
 }
 
+struct Context {
+  counter: mut Counter,
+}
+
+struct Box {
+  value: mut Int,
+}
+
 fn bump(mut c: Counter) {
   c.value = c.value + 1
 }
@@ -414,9 +422,20 @@ fn main() {
   bump(counter)
   io::print(counter.value.to_str())
 
+  mut shared = Counter{value: 0}
+  let ctx = Context{counter: shared}
+  bump(ctx.counter)
+  ctx.counter.value = 2
+  io::print((ctx.counter.value + shared.value).to_str())
+
   mut count = 0
   bump_int(count)
   io::print(count.to_str())
+
+  mut shared_count = 0
+  let box = Box{value: shared_count}
+  bump_int(box.value)
+  io::print((box.value + shared_count).to_str())
 }
 `), 0o644); err != nil {
 		t.Fatalf("failed to write source: %v", err)
@@ -428,7 +447,7 @@ fn main() {
 	if err != nil {
 		t.Fatalf("did not expect js-server mutable reference run error: %v\n%s", err, string(out))
 	}
-	if string(out) != "1\n1\n" {
+	if string(out) != "1\n4\n1\n2\n" {
 		t.Fatalf("unexpected output: %q", string(out))
 	}
 }

--- a/compiler/lsp/hover.go
+++ b/compiler/lsp/hover.go
@@ -98,6 +98,8 @@ func typeDeclString(t parse.DeclaredType) string {
 
 	var s string
 	switch tt := t.(type) {
+	case *parse.MutableType:
+		s = "mut " + typeDeclString(tt.Inner)
 	case *parse.List:
 		s = "[" + typeDeclString(tt.Element) + "]"
 	case *parse.Map:

--- a/compiler/lsp/references.go
+++ b/compiler/lsp/references.go
@@ -754,6 +754,8 @@ func referenceExprName(expr parse.Expression) string {
 
 func declaredTypeReferenceName(declared parse.DeclaredType) string {
 	switch t := declared.(type) {
+	case *parse.MutableType:
+		return declaredTypeReferenceName(t.Inner)
 	case *parse.CustomType:
 		return t.Name
 	case *parse.List:
@@ -964,6 +966,8 @@ func customTypeReferencesTargetFile(t *parse.CustomType, targetDef *definitionTa
 
 func definitionForDeclaredType(declared parse.DeclaredType, prog *parse.Program, filePath string) *definitionTarget {
 	switch t := declared.(type) {
+	case *parse.MutableType:
+		return definitionForDeclaredType(t.Inner, prog, filePath)
 	case *parse.CustomType:
 		if t.Name == "" {
 			return nil
@@ -975,6 +979,8 @@ func definitionForDeclaredType(declared parse.DeclaredType, prog *parse.Program,
 
 func declaredTypeChildren(declared parse.DeclaredType) []parse.DeclaredType {
 	switch t := declared.(type) {
+	case *parse.MutableType:
+		return []parse.DeclaredType{t.Inner}
 	case *parse.List:
 		return []parse.DeclaredType{t.Element}
 	case *parse.Map:

--- a/compiler/parse/ast.go
+++ b/compiler/parse/ast.go
@@ -109,6 +109,22 @@ func (s StringType) GetName() string {
 	return "String"
 }
 
+type MutableType struct {
+	Location
+	Inner DeclaredType
+}
+
+func (m MutableType) IsNullable() bool {
+	return false
+}
+
+func (m MutableType) GetName() string {
+	if m.Inner == nil {
+		return "mut"
+	}
+	return m.Inner.GetName()
+}
+
 type FunctionType struct {
 	Location
 	Nullable        bool

--- a/compiler/parse/parser.go
+++ b/compiler/parse/parser.go
@@ -1408,6 +1408,19 @@ func (p *parser) assignment() (Statement, error) {
 }
 
 func (p *parser) parseType() DeclaredType {
+	if p.match(mut) {
+		mutToken := p.previous()
+		inner := p.parseType()
+		end := mutToken.getLocation().End
+		if inner != nil {
+			end = inner.GetLocation().End
+		}
+		return &MutableType{
+			Location: Location{Start: mutToken.getLocation().Start, End: end},
+			Inner:    inner,
+		}
+	}
+
 	static := p.parseStaticPath()
 	if static != nil {
 		// Parse generic type arguments if present

--- a/compiler/parse/structs_test.go
+++ b/compiler/parse/structs_test.go
@@ -61,6 +61,23 @@ func TestStructDefinitions(t *testing.T) {
 			},
 		},
 		{
+			name: "A struct with mutable reference field",
+			input: `struct Context {
+					tree: mut ViewTree,
+				}`,
+			output: Program{
+				Imports: []Import{},
+				Statements: []Statement{
+					&StructDefinition{
+						Name: Identifier{Name: "Context"},
+						Fields: []StructField{
+							{Identifier{Name: "tree"}, &MutableType{Inner: &CustomType{Name: "ViewTree"}}},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Method definitions",
 			input: `
 					impl Shape {

--- a/compiler/std_lib/ffi/generate.go
+++ b/compiler/std_lib/ffi/generate.go
@@ -402,6 +402,12 @@ func typeGoType(typ parse.DeclaredType, aliases map[string]string, definedTypes 
 		goType = "string"
 	case *parse.VoidType:
 		goType = "struct{}"
+	case *parse.MutableType:
+		inner, err := typeGoType(t.Inner, aliases, definedTypes)
+		if err != nil {
+			return "", err
+		}
+		goType = "*" + inner
 	case *parse.List:
 		elem, err := typeGoType(t.Element, aliases, definedTypes)
 		if err != nil {
@@ -835,6 +841,8 @@ func collectGenerics(typ parse.DeclaredType, out map[string]struct{}) {
 	switch t := typ.(type) {
 	case *parse.GenericType:
 		out[t.Name] = struct{}{}
+	case *parse.MutableType:
+		collectGenerics(t.Inner, out)
 	case *parse.List:
 		collectGenerics(t.Element, out)
 	case *parse.Map:

--- a/docs/adrs/0020-support-recursive-struct-fields-through-indirection.md
+++ b/docs/adrs/0020-support-recursive-struct-fields-through-indirection.md
@@ -6,15 +6,13 @@ Accepted
 
 ## Context
 
-Ard currently resolves struct field types while the struct being declared is not yet available as a type name. This prevents intuitive recursive data structures such as trees:
+Ard needs to support recursive data structures without requiring users to write manual forward declarations or opaque wrapper types for common cases. A tree type should be able to mention its own type name in a field:
 
 ```ard
 struct Node {
   children: [Node],
 }
 ```
-
-The checker reports `Unrecognized type: Node` for the field type. This is an implementation limitation rather than a durable language rule users should have to model around.
 
 Recursive value types also need a sound representation rule. A direct inline field such as:
 
@@ -26,7 +24,7 @@ struct Node {
 
 has infinite size in value-oriented targets such as Go and should not be accepted as ordinary inline storage. In Go, the equivalent `child Node` field is invalid, while recursive references through fixed-size descriptors such as slices, maps, pointers, or interfaces are valid.
 
-Ard already has source-level type constructors that can act as representation boundaries for common recursive shapes:
+Ard has source-level type constructors that can act as representation boundaries for recursive shapes:
 
 ```ard
 struct Node {
@@ -36,21 +34,33 @@ struct Node {
 }
 ```
 
-Lists and maps are naturally indirect/container-backed. Nullable recursive fields should also be treated as an indirection boundary so parent pointers and linked structures can be expressed without requiring a separate user-visible `Box` or `Ref` type for common cases.
+ADR 0022 extends this set by making `mut T` an explicit mutable-reference representation. That means `mut T` is also a sizedness boundary:
 
-This decision is separate from broader declaration-order cycles between different type declarations, such as a `Node` field containing `[View]` while the `View` trait also mentions `Node`. Those cycles are out of scope for this decision. The immediate goal is sound support for explicit self-reference in struct fields.
+```ard
+struct Node {
+  parent: mut Node,
+}
+```
+
+The same rule generalizes from self-recursive structs to same-module recursive type groups. The checker hoists same-module type names before resolving fields and signatures, then rejects only cycles whose value layout remains inline all the way around.
 
 ## Decision
 
-Allow a struct declaration to reference its own type name within its field types.
+Allow same-module type declarations to reference each other and themselves in type positions without user-written forward declarations.
 
-Accept self-recursive field references when the recursive occurrence is beneath one of Ard's supported indirection boundaries:
+Accept recursive references when every cycle crosses at least one finite representation boundary. Supported boundaries include:
 
+- mutable references, for example `mut Node`
 - list values, for example `[Node]`
 - map values, for example `[Str:Node]`
-- nullable values, for example `Node?`
+- direct nullable fields, for example `Node?`
+- trait object positions, for example `View`
+- extern/opaque types
+- function descriptors, for example `fn() Node`
 
-Reject direct inline self-recursive fields because they have infinite value size:
+Map keys do not count as an indirection boundary for recursive layout. A recursive map key can make the map key type itself infinitely recursive or otherwise invalid for the target, so those cycles should still be rejected.
+
+Reject direct inline recursive fields because they have infinite value size:
 
 ```ard
 struct Node {
@@ -58,30 +68,46 @@ struct Node {
 }
 ```
 
-The checker should produce a clear diagnostic explaining that the recursive field has infinite size and should be placed behind a supported indirection boundary such as a list, map, or nullable field:
+Also reject mutually recursive groups with no boundary:
 
-```text
-Recursive field Node.child has infinite size. Put the recursive reference behind a list, map, or nullable type.
+```ard
+struct A {
+  b: B,
+}
+
+struct B {
+  a: A,
+}
 ```
 
-Recursive nullable fields are part of the supported surface, not a follow-up feature. Backends must represent nullable self-recursive fields with finite storage. For the Go target, recursive nullable struct fields should lower as pointer-backed optional fields, such as `*Node`, instead of inline `Maybe<Node>`. The backend must adapt source-level `Maybe` operations on those fields so `none` maps to `nil`, `some(value)` stores an allocated value, absence checks compare with `nil`, and unwrapping performs a nil check before dereferencing.
+The checker should produce a clear diagnostic explaining that the recursive field has infinite size and should be placed behind a supported indirection boundary:
+
+```text
+Recursive field Node.child has infinite size. Put the recursive reference behind mut, list, map, nullable, trait, extern, or function indirection.
+```
+
+Recursive nullable fields are part of the supported surface when the nullable value is directly stored as the recursive struct field. Backends must represent those fields with finite storage. For the Go target, recursive nullable struct fields should lower as pointer-backed optional fields, such as `*Node`, instead of inline `Maybe<Node>`. The backend must adapt source-level `Maybe` operations on those fields so `none` maps to `nil`, `some(value)` stores an allocated value, absence checks compare with `nil`, and unwrapping performs a nil check before dereferencing.
+
+Nested nullable references inside inline containers such as `Result` or union payloads are not accepted as layout-breaking until backends can represent those nested positions with finite storage.
 
 Lists and maps of recursive structs should lower to the target's ordinary finite container representations where possible. On the Go target, `[Node]` can lower to `[]Node` and `[Str:Node]` can lower to `map[string]Node` because slices and maps are fixed-size descriptors that point to separately allocated storage.
 
-Do not add user-visible forward declarations, mutually recursive declaration groups, or a first-class `Box`/`Ref` type as part of this decision. Those features may still be useful later, but self-recursive struct fields through existing indirection forms should work directly and idiomatically.
+Do not add user-visible forward declarations or a first-class `Box`/`Ref` type as part of this decision. Existing Ard type syntax should work directly and idiomatically for supported recursive layouts.
 
 ## Consequences
 
-- Ard can model common recursive data structures such as trees and parent-linked nodes directly.
-- The checker must register a struct's own type name before resolving that struct's fields, then complete the struct definition after field resolution.
-- The checker must validate recursive field paths and reject inline cycles that do not pass through an accepted indirection boundary.
+- Ard can model common recursive data structures such as trees, parent-linked nodes, retained UI trees, and recursive capability graphs directly.
+- The checker must hoist same-module type names before resolving fields, trait method signatures, enum declarations, extern types, and aliases.
+- The checker must validate recursive type groups and reject inline cycles that do not pass through an accepted representation boundary.
+- `mut T` is a mutable-reference boundary for recursive layout, matching ADR 0022.
 - Backends must preserve finite representations for all accepted recursive shapes.
-- Nullable recursive fields require special care because a generic inline `Maybe<T>` representation would be infinitely recursive for `T == Node`.
-- Direct recursive value fields remain invalid, preserving soundness and avoiding target compiler failures.
-- This does not solve cross-type declaration-order cycles. Broader same-module type hoisting or explicit recursive declaration mechanisms are out of scope.
+- Direct nullable recursive struct fields require special care because a generic inline `Maybe<T>` representation would be infinitely recursive for `T == Node`.
+- Direct recursive value fields and boundary-free mutual cycles remain invalid, preserving soundness and avoiding target compiler failures.
+- User-visible forward declarations are unnecessary for same-module recursive type groups.
 
 ## Related
 
+- `docs/adrs/0022-use-mut-for-mutable-references.md`
 - `docs/adrs/0012-represent-optional-values-with-maybe.md`
 - `docs/adrs/0009-support-traits-for-shared-behavior.md`
 - `compiler/checker`

--- a/docs/adrs/0022-use-mut-for-mutable-references.md
+++ b/docs/adrs/0022-use-mut-for-mutable-references.md
@@ -1,0 +1,146 @@
+# 0022: Use `mut` for Mutable References
+
+## Status
+
+Proposed
+
+## Context
+
+Ard currently uses `mut` for two related but different ideas:
+
+- a local binding may be reassigned or mutated;
+- a function parameter or call argument marked `mut` requests a mutable local copy of the value.
+
+This copy-oriented rule makes mutation explicit and avoids accidental mutation of shared data, but it also makes `mut` read like a reference while behaving like a clone. For example:
+
+```ard
+fn update_person(mut person: Person) {
+  person.age = 99
+}
+
+let alice = Person{name: "Alice", age: 30}
+update_person(mut alice) // today this mutates only a copy
+```
+
+That behavior is surprising for APIs that intend to mutate caller-owned state, and it means `mut` is not a representation boundary. A `mut Context`, `mut ViewTree`, or `mut Node` position cannot currently be used to break a recursive value-layout cycle because the language still models the value as an owned copy rather than an explicit reference.
+
+Retained UI and runtime-capability APIs are a motivating case. A framework may want a context or tree value to be passed around as a mutable capability with identity, not copied into each function or closure. In those designs, mutable reference positions should have finite representation, similar to pointers/references/interfaces in target languages.
+
+Recursive type references are another motivating case. ADR 0020 supports self-recursive struct fields through existing indirection forms such as lists, maps, and nullable values, but broader mutually recursive type groups still need a finite representation boundary. If `mut T` is an explicit mutable reference, it can serve as that boundary for recursive graphs where identity and mutation are intended.
+
+Ard still needs explicit copy semantics. If `mut` becomes reference-oriented, the language needs another visible way to ask for an independent value copy when that is the intended behavior.
+
+## Decision
+
+Explore changing `mut` from copy semantics to explicit mutable-reference semantics.
+
+Under this direction, a `mut` parameter, function-type parameter, receiver, closure capture, or field is a mutable reference to a value of the annotated type rather than an owned copied value. Call sites do not need a second `mut` marker when passing an already-mutable addressable place; the parameter type expresses the mutable-reference requirement and the checker enforces it:
+
+```ard
+fn update_person(mut person: Person) {
+  person.age = 99
+}
+
+mut alice = Person{name: "Alice", age: 30}
+update_person(alice) // mutates alice
+```
+
+A mutable reference has finite representation and is a sizedness boundary. Recursive type analysis should treat `mut T` as an indirection edge, allowing mutually recursive type references when every cycle crosses such a boundary:
+
+```ard
+struct A {
+  b: mut B,
+}
+
+struct B {
+  a: mut A,
+}
+```
+
+The checker should still reject inline value cycles that do not cross a finite boundary:
+
+```ard
+struct A { b: B }
+struct B { a: A }
+```
+
+Introduce an explicit copy operation for independent value copies. Prefer making this a standard-library operation, likely `ard/core::copy`, instead of a new expression keyword in the first design:
+
+```ard
+use ard/core
+
+fn updated_person(person: Person) Person {
+  mut updated = core::copy(person)
+  updated.age = 99
+  updated
+}
+```
+
+`core::copy` should mean a deep Ard value copy matching today's copy semantics. The exact implementation strategy for generic deep copy can be deferred, but the user-facing meaning should be explicit: use `core::copy(value)` when identity should be broken.
+
+Additional sugar, such as a copy parameter modifier, can be considered later, but copies should remain visible at the call site or in the function body so users can see where identity is intentionally broken.
+
+Local mutable bindings still declare mutable local storage. The key semantic change is that `mut` no longer means “clone this argument for mutation” in parameter/call positions. Assignments or bindings that need an independent deep copy should use `core::copy` explicitly.
+
+Mutable references may alias. If two `mut T` references are created from the same mutable place, both point to the same storage and mutation through either reference is visible through the other:
+
+```ard
+mut alice = Person{name: "Alice", age: 30}
+
+let a: mut Person = alice
+let b: mut Person = alice
+
+a.age = 31
+b.age = 32
+// alice.age, a.age, and b.age are all 32
+```
+
+This is intentional. Ard should rely on explicit mutable-reference types rather than Rust-style exclusive mutable borrows for the first reference model.
+
+Mutable references may escape ordinary lexical scopes through return values, struct fields, and closures. An escaping mutable reference requires stable storage; backends must heap-lift or box the referenced storage as needed so the reference cannot dangle:
+
+```ard
+struct Context {
+  tree: mut ViewTree,
+}
+
+fn make_context() Context {
+  mut tree = ViewTree{nodes: []}
+  Context{tree: tree} // tree is lifted so Context.tree remains valid
+}
+```
+
+Creating a mutable reference still requires an addressable mutable place. Passing immutable bindings, literals, or non-reference return values to `mut T` parameters should be rejected unless the language later defines a stable temporary/reference-return rule.
+
+Fiber boundaries are different from ordinary lexical escape. Mutable references should not be captured by `async::start`, `async::eval`, or other cross-fiber closures until Ard defines explicit concurrency safety rules for shared mutable references.
+
+## Consequences
+
+- This is a breaking language change. Existing code that relied on `mut` parameters receiving defensive copies must migrate to explicit `core::copy`.
+- Code that already intended mutable-reference behavior becomes more direct and less surprising.
+- `mut T` becomes a representation boundary for recursive layout and same-module recursive type groups, unblocking retained graphs and cyclic object models that require identity.
+- `mut T` is sufficient for the first reference feature. Do not add a separate immutable reference form as part of this decision; ordinary values remain the read-only/default access mode.
+- Use `field: mut T` for mutable-reference fields and analogous type-position syntax for other reference positions.
+- The checker must distinguish ordinary values from mutable references, require mutable-reference calls to pass addressable mutable places, and reject passing immutable bindings where mutation could occur.
+- Explicit mutable-reference syntax is sufficient for the first safety model. Do not require Rust-style exclusive mutable borrows as part of this decision.
+- Multiple mutable references may point to the same storage; mutations through one alias are visible through the others.
+- Escaping mutable references require stable storage. The compiler/backends must heap-lift or box referenced locals when mutable references escape through returns, struct fields, or closures.
+- AIR needs first-class mutable-reference types and operations such as reference load, field mutation through a reference, and reference capture.
+- Backends need finite mutable-reference representations. Go can generally use pointers or pointer-backed wrappers; JavaScript can use object cells or object references where necessary.
+- Async/fiber rules need to stay conservative. Mutable references should not be captured by fibers unless Ard defines safe sharing rules for those references.
+- Documentation must be updated to replace the current “`mut` means copy” explanation with “`mut` means mutable access/reference” and separate explicit `core::copy` semantics.
+
+## Deferred Work
+
+- Define the implementation strategy and type coverage for generic deep copying in `ard/core::copy`.
+- Define concurrency rules for mutable references that cross fiber boundaries.
+
+## Related
+
+- `docs/adrs/0020-support-recursive-struct-fields-through-indirection.md`
+- `docs/adrs/0003-use-generic-fibers-for-async-eval.md`
+- `README.md`
+- `compiler/checker`
+- `compiler/air`
+- `compiler/go`
+- `compiler/javascript`

--- a/docs/adrs/0022-use-mut-for-mutable-references.md
+++ b/docs/adrs/0022-use-mut-for-mutable-references.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -32,7 +32,7 @@ Ard still needs explicit copy semantics. If `mut` becomes reference-oriented, th
 
 ## Decision
 
-Explore changing `mut` from copy semantics to explicit mutable-reference semantics.
+Change `mut` from copy semantics to explicit mutable-reference semantics.
 
 Under this direction, a `mut` parameter, function-type parameter, receiver, closure capture, or field is a mutable reference to a value of the annotated type rather than an owned copied value. Call sites do not need a second `mut` marker when passing an already-mutable addressable place; the parameter type expresses the mutable-reference requirement and the checker enforces it:
 

--- a/website/src/content/docs/guide/functions.md
+++ b/website/src/content/docs/guide/functions.md
@@ -35,7 +35,7 @@ In order for a function to apply side-effects or mutations to parameters, the pa
 
 ```ard
 fn add_ten(mut value: Int) {
-  value += 10
+  value =+ 10
 }
 
 mut count = 0

--- a/website/src/content/docs/guide/variables.md
+++ b/website/src/content/docs/guide/variables.md
@@ -87,42 +87,32 @@ if some_condition {
 
 Ard uses explicit copy semantics to ensure data safety and prevent accidental mutation of shared data.
 
-### Variable Assignment
+### Mutable References
 
-When assigning complex types (structs, lists, maps) to mutable variables, Ard creates deep copies:
+A `mut` binding creates mutable local storage. A function parameter marked `mut` receives mutable access to caller-owned storage, so the caller must pass an addressable mutable value:
 
 ```ard
 struct Person { name: Str, age: Int }
 
-let original = Person { name: "Alice", age: 30 }
-mut copy = original  // Creates a deep copy
-copy.age = 31
-// original.age is still 30, copy.age is 31
-```
-
-### Function Parameters
-
-When a function parameter is mutable, you must use the `mut` keyword to explicitly create a copy:
-
-```ard
 fn update_person(mut person: Person) {
-    person.age = 99  // Only affects the copy
+    person.age = 99  // Mutates the caller's value
 }
 
-let alice = Person { name: "Alice", age: 30 }
-update_person(mut alice)  // Explicitly request a copy with `mut`
-// alice.age is still 30 (original unchanged)
+mut alice = Person { name: "Alice", age: 30 }
+update_person(alice)
+// alice.age is now 99
 ```
 
-Without the `mut` keyword, passing an immutable value to a mutable parameter will result in a compile-time error.
+Passing an immutable value to a mutable parameter is a compile-time error:
 
-### Identity vs Equality
+```ard
+let bob = Person { name: "Bob", age: 30 }
+update_person(bob) // Error: expected a mutable Person
+```
 
-Copied values are equal in content but not identical in memory. This prevents accidental mutation of shared data while maintaining value semantics.
+### Explicit Copies
 
-### Primitives
-
-Primitives (Int, Str, Bool, etc.) and functions are immutable, so they don't trigger copying for simple assignments. When passed to mutable parameters with the `mut` keyword, they are copied for consistency.
+Copying should be explicit when independent identity is required. The standard library `ard/core::copy(value)` API is reserved for this purpose; generic deep-copy coverage is still being defined.
 
 ## Shadowing
 

--- a/website/src/content/docs/guide/variables.md
+++ b/website/src/content/docs/guide/variables.md
@@ -83,13 +83,11 @@ if some_condition {
 // 'inner' is out of scope
 ```
 
-## Copy Semantics
+## Mutable References
 
-Ard uses explicit copy semantics to ensure data safety and prevent accidental mutation of shared data.
+A `mut` binding creates mutable local storage. In type positions, `mut T` means mutable reference to a `T`.
 
-### Mutable References
-
-A `mut` binding creates mutable local storage. A function parameter marked `mut` receives mutable access to caller-owned storage, so the caller must pass an addressable mutable value:
+A function parameter marked `mut` receives mutable access to caller-owned storage, so the caller must pass an addressable mutable value. There is no extra `mut` marker at the call site:
 
 ```ard
 struct Person { name: Str, age: Int }
@@ -110,6 +108,8 @@ let bob = Person { name: "Bob", age: 30 }
 update_person(bob) // Error: expected a mutable Person
 ```
 
+Mutable references may alias. If two `mut T` references point at the same mutable storage, mutations through either reference are visible through the other.
+
 ### Mutable Reference Fields
 
 Struct fields can hold mutable references:
@@ -125,9 +125,7 @@ ctx.tree.add_child(child)
 
 The `ctx` binding is immutable, but `ctx.tree` is mutable access to the referenced `ViewTree`. Field assignment writes through the reference; it does not rebind the field slot.
 
-### Explicit Copies
-
-Copying should be explicit when independent identity is required. The standard library `ard/core::copy(value)` API is reserved for this purpose; generic deep-copy coverage is still being defined.
+`mut T` is also a representation boundary for recursive types, so it can be used to model linked structures and retained object graphs that require identity.
 
 ## Shadowing
 

--- a/website/src/content/docs/guide/variables.md
+++ b/website/src/content/docs/guide/variables.md
@@ -110,6 +110,21 @@ let bob = Person { name: "Bob", age: 30 }
 update_person(bob) // Error: expected a mutable Person
 ```
 
+### Mutable Reference Fields
+
+Struct fields can hold mutable references:
+
+```ard
+struct Context {
+  tree: mut ViewTree,
+}
+
+let ctx = Context{tree: tree}
+ctx.tree.add_child(child)
+```
+
+The `ctx` binding is immutable, but `ctx.tree` is mutable access to the referenced `ViewTree`. Field assignment writes through the reference; it does not rebind the field slot.
+
 ### Explicit Copies
 
 Copying should be explicit when independent identity is required. The standard library `ard/core::copy(value)` API is reserved for this purpose; generic deep-copy coverage is still being defined.

--- a/zed-plugin/languages/ard/highlights.scm
+++ b/zed-plugin/languages/ard/highlights.scm
@@ -14,6 +14,7 @@
 (import_statement "as" @keyword)
 (variable_declaration "let" @keyword)
 (variable_declaration "mut" @keyword)
+(mutable_type "mut" @keyword)
 (function_declaration "test" @keyword)
 (function_declaration "fn" @keyword)
 (extern_function "extern" @keyword)


### PR DESCRIPTION
## Summary

- switch `mut` parameters and fields to mutable-reference semantics instead of copy semantics
- add mutable-reference field support across parser/checker/AIR/Go/JS plus tree-sitter grammar updates
- hoist same-module type declarations and validate finite recursive type groups
- remove stale implicit-copy marker machinery now that copying is deferred to an explicit API
- update docs/ADR language for mutable references and recursive layout boundaries

## Breaking change

`mut` no longer means “copy for mutation” in parameter/call positions. A `mut T` parameter or field is a mutable reference to caller-owned/addressable storage, and call sites no longer use an extra `mut` marker.

## Validation

- `git diff --check`
- `cd compiler && go generate ./std_lib/ffi && go test ./...`
- `cd compiler && go test ./checker ./air ./go -count=1`
- `cd tree-sitter-ard && npm test`
- `cd compiler && go run main.go build /Users/akonwi/Developer/agent/tinear/main.ard --out /tmp/tinear-203`

Fixes #202
Closes #203
