### PR TITLE
perf(lsp): cache parsed and checked analysis

### DIFF
--- a/compiler/lsp/analysis_cache.go
+++ b/compiler/lsp/analysis_cache.go
@@ -1,0 +1,273 @@
+package lsp
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/akonwi/ard/checker"
+	"github.com/akonwi/ard/parse"
+)
+
+type parseCacheEntry struct {
+	sourceHash string
+	program    *parse.Program
+	errors     []parse.ParseError
+}
+
+type diagnosticCacheEntry struct {
+	sourceHash    string
+	overlayHash   string
+	workspaceHash string
+	diagnostics   []checker.Diagnostic
+	err           error
+}
+
+// AnalysisCache stores parsed and checked LSP analysis results keyed by content.
+type AnalysisCache struct {
+	mu          sync.Mutex
+	parsed      map[string]parseCacheEntry
+	diagnostics map[string]diagnosticCacheEntry
+	checkCount  int
+}
+
+func NewAnalysisCache() *AnalysisCache {
+	return &AnalysisCache{
+		parsed:      make(map[string]parseCacheEntry),
+		diagnostics: make(map[string]diagnosticCacheEntry),
+	}
+}
+
+func (c *AnalysisCache) Parse(source string, filePath string) parseCacheEntry {
+	if c == nil {
+		return parseSource(source, filePath)
+	}
+
+	sourceHash := contentHash(source)
+	c.mu.Lock()
+	if entry, ok := c.parsed[filePath]; ok && entry.sourceHash == sourceHash {
+		c.mu.Unlock()
+		return entry
+	}
+	c.mu.Unlock()
+
+	entry := parseSource(source, filePath)
+	entry.sourceHash = sourceHash
+
+	c.mu.Lock()
+	c.parsed[filePath] = entry
+	c.mu.Unlock()
+	return entry
+}
+
+func (c *AnalysisCache) Program(source string, filePath string) *parse.Program {
+	return c.Parse(source, filePath).program
+}
+
+func (c *AnalysisCache) Diagnostics(source string, filePath string, overlays map[string]string) ([]checker.Diagnostic, error) {
+	if c == nil {
+		return analyzeDiagnosticsUncached(source, filePath, overlays)
+	}
+
+	sourceHash := contentHash(source)
+	overlayHash := overlaysHash(overlays)
+	workspaceHash := workspaceFingerprint(filePath)
+	key := filePath
+
+	c.mu.Lock()
+	if entry, ok := c.diagnostics[key]; ok &&
+		entry.sourceHash == sourceHash &&
+		entry.overlayHash == overlayHash &&
+		entry.workspaceHash == workspaceHash {
+		c.mu.Unlock()
+		return cloneDiagnostics(entry.diagnostics), entry.err
+	}
+	c.mu.Unlock()
+
+	diagnostics, err := c.analyzeDiagnostics(source, filePath, overlays)
+
+	c.mu.Lock()
+	c.diagnostics[key] = diagnosticCacheEntry{
+		sourceHash:    sourceHash,
+		overlayHash:   overlayHash,
+		workspaceHash: workspaceHash,
+		diagnostics:   cloneDiagnostics(diagnostics),
+		err:           err,
+	}
+	c.mu.Unlock()
+
+	return diagnostics, err
+}
+
+func (c *AnalysisCache) Invalidate(filePath string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.parsed, filePath)
+	delete(c.diagnostics, filePath)
+}
+
+func (c *AnalysisCache) InvalidateAll() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.parsed = make(map[string]parseCacheEntry)
+	c.diagnostics = make(map[string]diagnosticCacheEntry)
+}
+
+func (c *AnalysisCache) CheckCount() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.checkCount
+}
+
+func (c *AnalysisCache) analyzeDiagnostics(source string, filePath string, overlays map[string]string) ([]checker.Diagnostic, error) {
+	diagnostics, err := c.analyzeDiagnosticsUncached(source, filePath, overlays)
+	c.mu.Lock()
+	c.checkCount++
+	c.mu.Unlock()
+	return diagnostics, err
+}
+
+func (c *AnalysisCache) analyzeDiagnosticsUncached(source string, filePath string, overlays map[string]string) ([]checker.Diagnostic, error) {
+	result := c.Parse(source, filePath)
+	return diagnosticsFromParseResult(result, filePath, overlays)
+}
+
+func analyzeDiagnosticsUncached(source string, filePath string, overlays map[string]string) ([]checker.Diagnostic, error) {
+	result := parseSource(source, filePath)
+	return diagnosticsFromParseResult(result, filePath, overlays)
+}
+
+func diagnosticsFromParseResult(result parseCacheEntry, filePath string, overlays map[string]string) ([]checker.Diagnostic, error) {
+	if result.program == nil {
+		return nil, fmt.Errorf("failed to parse: no program returned")
+	}
+	if len(result.errors) > 0 {
+		diags := make([]checker.Diagnostic, 0, len(result.errors))
+		for _, err := range result.errors {
+			diags = append(diags, checker.NewDiagnostic(checker.Error, err.Message, filePath, err.Location))
+		}
+		return diags, nil
+	}
+
+	workingDir := filepath.Dir(filePath)
+	moduleResolver, err := checker.NewModuleResolver(workingDir)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing module resolver: %w", err)
+	}
+	for overlayPath, overlaySource := range overlays {
+		moduleResolver.SetOverlay(overlayPath, overlaySource)
+	}
+
+	relPath, err := filepath.Rel(workingDir, filePath)
+	if err != nil {
+		relPath = filePath
+	}
+
+	c := checker.New(relPath, result.program, moduleResolver, checker.CheckOptions{})
+	c.Check()
+	return c.Diagnostics(), nil
+}
+
+func parseSource(source string, filePath string) parseCacheEntry {
+	result := parse.Parse([]byte(source), filePath)
+	return parseCacheEntry{
+		program: result.Program,
+		errors:  append([]parse.ParseError(nil), result.Errors...),
+	}
+}
+
+func contentHash(source string) string {
+	sum := sha256.Sum256([]byte(source))
+	return hex.EncodeToString(sum[:])
+}
+
+func overlaysHash(overlays map[string]string) string {
+	if len(overlays) == 0 {
+		return ""
+	}
+	paths := make([]string, 0, len(overlays))
+	for path := range overlays {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	h := sha256.New()
+	for _, path := range paths {
+		h.Write([]byte(path))
+		h.Write([]byte{0})
+		h.Write([]byte(overlays[path]))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func workspaceFingerprint(filePath string) string {
+	root := workspaceRoot(filepath.Dir(filePath))
+	h := sha256.New()
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules":
+				return filepath.SkipDir
+			default:
+				return nil
+			}
+		}
+		if filepath.Ext(path) != ".ard" {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			rel = path
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		h.Write([]byte(filepath.ToSlash(rel)))
+		h.Write([]byte{0})
+		h.Write(data)
+		h.Write([]byte{0})
+		return nil
+	})
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func workspaceRoot(start string) string {
+	dir := filepath.Clean(start)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "ard.toml")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return filepath.Clean(start)
+		}
+		dir = parent
+	}
+}
+
+func cloneDiagnostics(diagnostics []checker.Diagnostic) []checker.Diagnostic {
+	if diagnostics == nil {
+		return nil
+	}
+	return append([]checker.Diagnostic(nil), diagnostics...)
+}
+
+var defaultAnalysisCache = NewAnalysisCache()

--- a/compiler/lsp/diagnostics.go
+++ b/compiler/lsp/diagnostics.go
@@ -3,7 +3,6 @@ package lsp
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/akonwi/ard/checker"
 	"github.com/akonwi/ard/formatter"
@@ -27,43 +26,7 @@ func parseAndCheckWithOverlays(source string, filePath string, overlays map[stri
 			err = fmt.Errorf("analysis panic: %v", r)
 		}
 	}()
-
-	// Parse the source
-	result := parse.Parse([]byte(source), filePath)
-	if result.Program == nil {
-		return nil, fmt.Errorf("failed to parse: no program returned")
-	}
-
-	if len(result.Errors) > 0 {
-		// Convert parse errors to checker-style diagnostics
-		diags := make([]checker.Diagnostic, 0, len(result.Errors))
-		for _, err := range result.Errors {
-			diags = append(diags, checker.NewDiagnostic(checker.Error, err.Message, filePath, err.Location))
-		}
-		return diags, nil
-	}
-
-	program := result.Program
-
-	// Initialize the module resolver
-	workingDir := filepath.Dir(filePath)
-	moduleResolver, err := checker.NewModuleResolver(workingDir)
-	if err != nil {
-		return nil, fmt.Errorf("error initializing module resolver: %w", err)
-	}
-	for overlayPath, overlaySource := range overlays {
-		moduleResolver.SetOverlay(overlayPath, overlaySource)
-	}
-
-	relPath, err := filepath.Rel(workingDir, filePath)
-	if err != nil {
-		relPath = filePath
-	}
-
-	c := checker.New(relPath, program, moduleResolver, checker.CheckOptions{})
-	c.Check()
-
-	return c.Diagnostics(), nil
+	return analyzeDiagnosticsUncached(source, filePath, overlays)
 }
 
 func formatSource(source string, filePath string) (string, error) {
@@ -185,10 +148,10 @@ func (s *Server) analyzeDiagnostics(doc *Doc, docs []Doc) (diagnostics []checker
 	}
 	overlays := overlaySources(docs)
 	analyzer := s.diagnosticsAnalyzer
-	if analyzer == nil {
-		analyzer = parseAndCheckWithOverlays
+	if analyzer != nil {
+		return analyzer(doc.Text, filePath, overlays)
 	}
-	return analyzer(doc.Text, filePath, overlays)
+	return s.analysisCache.Diagnostics(doc.Text, filePath, overlays)
 }
 
 func analysisErrorDiagnostic(err error) protocol.Diagnostic {

--- a/compiler/lsp/diagnostics_test.go
+++ b/compiler/lsp/diagnostics_test.go
@@ -154,6 +154,104 @@ let value = tools::new_name()
 	}
 }
 
+func TestAnalysisCacheReusesDiagnosticsForUnchangedInputs(t *testing.T) {
+	cache := NewAnalysisCache()
+	source := `let x = 5`
+	filePath := filepath.Join(t.TempDir(), "main.ard")
+
+	first, err := cache.Diagnostics(source, filePath, nil)
+	if err != nil {
+		t.Fatalf("first diagnostics failed: %v", err)
+	}
+	second, err := cache.Diagnostics(source, filePath, nil)
+	if err != nil {
+		t.Fatalf("second diagnostics failed: %v", err)
+	}
+	if len(first) != 0 || len(second) != 0 {
+		t.Fatalf("expected no diagnostics, got first=%v second=%v", first, second)
+	}
+	if got := cache.CheckCount(); got != 1 {
+		t.Fatalf("check count = %d, want 1", got)
+	}
+}
+
+func TestAnalysisCacheInvalidatesDiagnosticsWhenOverlayChanges(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.0.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	modPath := filepath.Join(root, "tools.ard")
+	if err := os.WriteFile(modPath, []byte("fn value() Int { 1 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(root, "main.ard")
+	source := `use test_project/tools
+
+let value = tools::value()
+`
+	cache := NewAnalysisCache()
+
+	first, err := cache.Diagnostics(source, mainPath, map[string]string{
+		modPath: "fn value() Int { 1 }\n",
+	})
+	if err != nil {
+		t.Fatalf("first diagnostics failed: %v", err)
+	}
+	second, err := cache.Diagnostics(source, mainPath, map[string]string{
+		modPath: "fn renamed() Int { 1 }\n",
+	})
+	if err != nil {
+		t.Fatalf("second diagnostics failed: %v", err)
+	}
+	if len(first) != 0 {
+		t.Fatalf("expected first diagnostics to be clean, got %v", first)
+	}
+	if len(second) == 0 {
+		t.Fatal("expected changed overlay to invalidate cached diagnostics")
+	}
+	if got := cache.CheckCount(); got != 2 {
+		t.Fatalf("check count = %d, want 2", got)
+	}
+}
+
+func TestAnalysisCacheInvalidatesDiagnosticsWhenWorkspaceFileChanges(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.0.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	modPath := filepath.Join(root, "tools.ard")
+	if err := os.WriteFile(modPath, []byte("fn value() Int { 1 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(root, "main.ard")
+	source := `use test_project/tools
+
+let value = tools::value()
+`
+	cache := NewAnalysisCache()
+
+	first, err := cache.Diagnostics(source, mainPath, nil)
+	if err != nil {
+		t.Fatalf("first diagnostics failed: %v", err)
+	}
+	if err := os.WriteFile(modPath, []byte("fn renamed() Int { 1 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	second, err := cache.Diagnostics(source, mainPath, nil)
+	if err != nil {
+		t.Fatalf("second diagnostics failed: %v", err)
+	}
+	if len(first) != 0 {
+		t.Fatalf("expected first diagnostics to be clean, got %v", first)
+	}
+	if len(second) == 0 {
+		t.Fatal("expected workspace file change to invalidate cached diagnostics")
+	}
+	if got := cache.CheckCount(); got != 2 {
+		t.Fatalf("check count = %d, want 2", got)
+	}
+}
+
 // TestPublishDiagnosticsLifecycle verifies the full cycle doesn't panic.
 func TestPublishDiagnosticsLifecycle(t *testing.T) {
 	server := NewServer()

--- a/compiler/lsp/hover.go
+++ b/compiler/lsp/hover.go
@@ -54,10 +54,9 @@ func computeHover(source string, filePath string, position protocol.Position) *h
 	return describeExpr(expr, source, filePath, prog)
 }
 
-// parseAndCache parses source and returns the parsed program.
+// parseAndCache parses source and returns the cached parsed program.
 func parseAndCache(source string, filePath string) *parse.Program {
-	result := parse.Parse([]byte(source), filePath)
-	return result.Program
+	return defaultAnalysisCache.Program(source, filePath)
 }
 
 // lspPositionToParsePoint converts an LSP position back to a parse Point.

--- a/compiler/lsp/references.go
+++ b/compiler/lsp/references.go
@@ -365,22 +365,23 @@ func projectReferenceDocuments(currentFile string, overlays map[string]string) [
 
 func readReferenceDocument(filePath string, overlays map[string]string) (referenceDocument, bool) {
 	if source, ok := normalizedReferenceOverlays(overlays)[cleanReferencePath(filePath)]; ok {
-		result := parse.Parse([]byte(source), filePath)
-		if result.Program == nil {
+		prog := defaultAnalysisCache.Program(source, filePath)
+		if prog == nil {
 			return referenceDocument{}, false
 		}
-		return referenceDocument{filePath: filePath, source: source, prog: result.Program}, true
+		return referenceDocument{filePath: filePath, source: source, prog: prog}, true
 	}
 
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return referenceDocument{}, false
 	}
-	result := parse.Parse(data, filePath)
-	if result.Program == nil {
+	source := string(data)
+	prog := defaultAnalysisCache.Program(source, filePath)
+	if prog == nil {
 		return referenceDocument{}, false
 	}
-	return referenceDocument{filePath: filePath, source: string(data), prog: result.Program}, true
+	return referenceDocument{filePath: filePath, source: source, prog: prog}, true
 }
 
 func cleanReferencePath(filePath string) string {

--- a/compiler/lsp/server.go
+++ b/compiler/lsp/server.go
@@ -33,10 +33,11 @@ func (s *stdio) Close() error {
 
 // Server is the Ard LSP server.
 type Server struct {
-	cache       *DocumentCache
-	handlers    map[string]jsonrpc2.Handler
-	conn        jsonrpc2.Conn
-	projectRoot string
+	cache         *DocumentCache
+	analysisCache *AnalysisCache
+	handlers      map[string]jsonrpc2.Handler
+	conn          jsonrpc2.Conn
+	projectRoot   string
 
 	diagnosticsMu        sync.Mutex
 	diagnosticsTimers    map[uri.URI]*time.Timer
@@ -49,11 +50,11 @@ type Server struct {
 func NewServer() *Server {
 	s := &Server{
 		cache:                NewDocumentCache(),
+		analysisCache:        NewAnalysisCache(),
 		handlers:             make(map[string]jsonrpc2.Handler),
 		diagnosticsTimers:    make(map[uri.URI]*time.Timer),
 		diagnosticsDelay:     100 * time.Millisecond,
 		diagnosticsPublisher: nil,
-		diagnosticsAnalyzer:  parseAndCheckWithOverlays,
 	}
 	s.diagnosticsPublisher = s.publishDiagnostics
 	s.registerHandlers()
@@ -291,6 +292,9 @@ func (s *Server) handleDidOpen(ctx context.Context, reply jsonrpc2.Replier, req 
 		params.TextDocument.Version,
 		params.TextDocument.Text,
 	)
+	if filePath, err := filePathFromURI(params.TextDocument.URI); err == nil {
+		s.analysisCache.Invalidate(filePath)
+	}
 	s.scheduleDiagnosticsForOpenDocuments()
 
 	return reply(ctx, nil, nil)
@@ -310,6 +314,9 @@ func (s *Server) handleDidChange(ctx context.Context, reply jsonrpc2.Replier, re
 				return reply(ctx, nil, fmt.Errorf("invalid document change: %w", err))
 			}
 			s.cache.Update(params.TextDocument.URI, params.TextDocument.Version, updated)
+			if filePath, err := filePathFromURI(params.TextDocument.URI); err == nil {
+				s.analysisCache.Invalidate(filePath)
+			}
 		}
 	}
 
@@ -329,6 +336,9 @@ func (s *Server) handleDidClose(ctx context.Context, reply jsonrpc2.Replier, req
 	}
 
 	s.cache.Close(params.TextDocument.URI)
+	if filePath, err := filePathFromURI(params.TextDocument.URI); err == nil {
+		s.analysisCache.Invalidate(filePath)
+	}
 	s.scheduleDiagnostics(params.TextDocument.URI)
 	s.scheduleDiagnosticsForOpenDocuments()
 


### PR DESCRIPTION
## Summary
- add an LSP analysis cache for parsed programs and diagnostics/check results
- key diagnostics by source, open-document overlays, and workspace Ard file contents
- invalidate cached state on LSP document open/change/close
- reuse cached parsed programs in existing feature helper paths

## Why
Issue #167 was still relevant after recent LSP improvements: document text and stale diagnostics were handled, but parsed and checked analysis was still recomputed for repeated requests.

## Validation
- `cd compiler && go test ./lsp -run TestAnalysisCache -count=1`
- `cd compiler && go test ./lsp -count=1`
- `cd compiler && go test -race ./lsp -count=1`

Draft until reviewed locally in an editor-backed LSP session.