### PR TITLE
fix(compiler): preserve generic specialization in AIR

### DIFF
--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -355,7 +355,11 @@ func (l *lowerer) lowerGlobalByID(id GlobalID, def *checker.VariableDef) error {
 	global := l.program.Globals[id]
 	fn := Function{Module: global.Module, Name: "<global>"}
 	fl := l.newFunctionLowerer(&fn, nil, nil)
-	value, actualType, err := fl.lowerContextualExpr(def.Value, global.Type)
+	contextType, err := fl.contextualType(global.Type)
+	if err != nil {
+		return err
+	}
+	value, actualType, err := fl.lowerContextualExpr(def.Value, contextType)
 	if err != nil {
 		return err
 	}
@@ -566,9 +570,26 @@ func (l *lowerer) newFunctionLowerer(fn *Function, def *checker.FunctionDef, par
 		typeVars: map[string]TypeID{},
 	}
 	if def != nil {
+		for name, typ := range def.GenericBindings {
+			typeID, err := fl.internType(typ)
+			if err == nil {
+				fl.typeVars[name] = typeID
+			}
+		}
+		paramOffset := 0
+		if len(fn.Signature.Params) == len(def.Parameters)+1 {
+			receiver := def.Receiver
+			if receiver == "" {
+				receiver = "self"
+			}
+			if fn.Signature.Params[0].Name == receiver {
+				paramOffset = 1
+			}
+		}
 		for i, param := range def.Parameters {
-			if i < len(fn.Signature.Params) {
-				fl.bindTypeVars(param.Type, fn.Signature.Params[i].Type)
+			signatureIndex := i + paramOffset
+			if signatureIndex < len(fn.Signature.Params) {
+				fl.bindTypeVars(param.Type, fn.Signature.Params[signatureIndex].Type)
 			}
 		}
 		fl.bindTypeVars(def.ReturnType, fn.Signature.Return)
@@ -660,6 +681,93 @@ func (fl *functionLowerer) internType(t checker.Type) (TypeID, error) {
 		return fl.l.internType(t)
 	}
 	return fl.internCompositeType(t)
+}
+
+func (fl *functionLowerer) internContextualCheckerType(t checker.Type) (TypeID, error) {
+	typeID, err := fl.internType(t)
+	if err == nil {
+		return fl.contextualType(typeID)
+	}
+	if !typeHasUnresolvedTypeVar(t) {
+		return NoType, err
+	}
+	return fl.internWeakContextType(t)
+}
+
+func (fl *functionLowerer) internWeakContextType(t checker.Type) (TypeID, error) {
+	switch typ := t.(type) {
+	case *checker.TypeVar:
+		if typ.Actual() != nil {
+			return fl.internWeakContextType(typ.Actual())
+		}
+		return fl.l.internType(checker.Void)
+	case *checker.Maybe:
+		elem, err := fl.internWeakContextPart(typ.Of())
+		if err != nil {
+			return NoType, err
+		}
+		return fl.internMaybeType(elem), nil
+	case *checker.Result:
+		value, err := fl.internWeakContextPart(typ.Val())
+		if err != nil {
+			return NoType, err
+		}
+		errType, err := fl.internWeakContextPart(typ.Err())
+		if err != nil {
+			return NoType, err
+		}
+		return fl.internResultType(value, errType), nil
+	default:
+		return NoType, fmt.Errorf("unresolved generic type variable in contextual type %s", t.String())
+	}
+}
+
+func (fl *functionLowerer) internWeakContextPart(t checker.Type) (TypeID, error) {
+	typeID, err := fl.internType(t)
+	if err == nil {
+		return typeID, nil
+	}
+	if !typeHasUnresolvedTypeVar(t) {
+		return NoType, err
+	}
+	return fl.l.internType(checker.Void)
+}
+
+func (fl *functionLowerer) contextualType(typeID TypeID) (TypeID, error) {
+	if !validTypeID(&fl.l.program, typeID) {
+		return typeID, nil
+	}
+	info, _ := fl.l.typeInfo(typeID)
+	switch info.Kind {
+	case TypeMaybe:
+		if validTypeID(&fl.l.program, info.Elem) {
+			return typeID, nil
+		}
+		voidID, err := fl.l.internType(checker.Void)
+		if err != nil {
+			return NoType, err
+		}
+		return fl.internMaybeType(voidID), nil
+	case TypeResult:
+		if validTypeID(&fl.l.program, info.Value) && validTypeID(&fl.l.program, info.Error) {
+			return typeID, nil
+		}
+		voidID, err := fl.l.internType(checker.Void)
+		if err != nil {
+			return NoType, err
+		}
+		value := info.Value
+		if !validTypeID(&fl.l.program, value) {
+			value = voidID
+		}
+		errType := info.Error
+		if !validTypeID(&fl.l.program, errType) {
+			errType = voidID
+		}
+		return fl.internResultType(value, errType), nil
+	default:
+		return typeID, nil
+	}
 }
 
 func (fl *functionLowerer) internCompositeType(t checker.Type) (TypeID, error) {
@@ -976,8 +1084,8 @@ func (l *lowerer) lowerMethodFunction(id FunctionID, def *checker.FunctionDef) e
 	return nil
 }
 
-func (l *lowerer) declareInstanceMethodFunction(module ModuleID, ownerName string, ownerType TypeID, def *checker.FunctionDef) (FunctionID, error) {
-	key := methodFunctionKey(module, ownerName, "instance", def.Name)
+func (l *lowerer) declareInstanceMethodFunction(module ModuleID, ownerName string, ownerType TypeID, def *checker.FunctionDef, args []checker.Expression, returnType TypeID) (FunctionID, error) {
+	key := methodFunctionKey(module, fmt.Sprintf("%s#%d", ownerName, ownerType), "instance", def.Name)
 	if id, ok := l.functions[key]; ok {
 		return id, nil
 	}
@@ -988,16 +1096,25 @@ func (l *lowerer) declareInstanceMethodFunction(module ModuleID, ownerName strin
 	}
 	params := make([]Param, 0, len(def.Parameters)+1)
 	params = append(params, Param{Name: receiver, Type: ownerType, Mutable: def.Mutates})
-	for _, param := range def.Parameters {
-		typeID, err := l.internType(param.Type)
+	for i, param := range def.Parameters {
+		typeID := NoType
+		var err error
+		if i < len(args) {
+			typeID, err = l.internType(args[i].Type())
+		} else {
+			typeID, err = l.internType(param.Type)
+		}
 		if err != nil {
 			return NoFunction, err
 		}
 		params = append(params, Param{Name: param.Name, Type: typeID, Mutable: param.Mutable})
 	}
-	returnType, err := l.internType(def.ReturnType)
-	if err != nil {
-		return NoFunction, err
+	if !validTypeID(&l.program, returnType) {
+		var err error
+		returnType, err = l.internType(def.ReturnType)
+		if err != nil {
+			return NoFunction, err
+		}
 	}
 
 	id := FunctionID(len(l.program.Functions))
@@ -1863,6 +1980,11 @@ func (fl *functionLowerer) lowerExprWithExpectedRaw(expr checker.Expression, exp
 			return fl.lowerMapLiteral(expected, m, expectedInfo.Key, expectedInfo.Value)
 		}
 	}
+	if inst, ok := expr.(*checker.StructInstance); ok {
+		if expectedInfo, hasInfo := fl.l.typeInfo(expected); hasInfo && expectedInfo.Kind == TypeStruct {
+			return fl.lowerStructInstance(expected, inst)
+		}
+	}
 	if closure, ok := expr.(*checker.FunctionDef); ok {
 		if expectedInfo, hasInfo := fl.l.typeInfo(expected); hasInfo && expectedInfo.Kind == TypeFunction {
 			return fl.lowerClosure(expected, closure)
@@ -1895,6 +2017,9 @@ func (fl *functionLowerer) lowerExprWithExpectedRaw(expr checker.Expression, exp
 	}
 	if match, ok := expr.(*checker.ConditionalMatch); ok {
 		return fl.lowerConditionalMatch(expected, match)
+	}
+	if op, ok := expr.(*checker.TryOp); ok && validTypeID(&fl.l.program, expected) {
+		return fl.lowerTryOp(expected, op)
 	}
 	return fl.lowerExpr(expr)
 }
@@ -2215,6 +2340,9 @@ func (fl *functionLowerer) lowerDynamicWrapIfNeeded(expr checker.Expression, exp
 	}
 	actual, err := fl.internType(expr.Type())
 	if err != nil {
+		if typeHasUnresolvedTypeVar(expr.Type()) {
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 	if actual == expected {
@@ -2306,7 +2434,7 @@ func (fl *functionLowerer) lowerStmt(stmt checker.Statement) (*Stmt, error) {
 	}
 	switch s := stmt.Stmt.(type) {
 	case *checker.VariableDef:
-		typeID, err := fl.internType(s.Type())
+		typeID, err := fl.internContextualCheckerType(s.Type())
 		if err != nil {
 			return nil, err
 		}
@@ -2765,6 +2893,9 @@ func (fl *functionLowerer) lowerExpr(expr checker.Expression) (*Expr, error) {
 				return fl.lowerFunctionTypeCall(e.Name, e.Args, target)
 			}
 		}
+	}
+	if prop, ok := expr.(*checker.InstanceProperty); ok {
+		return fl.lowerInstanceProperty(NoType, prop)
 	}
 	typeID, err := fl.internType(expr.Type())
 	if err != nil {
@@ -3728,7 +3859,13 @@ func (fl *functionLowerer) lowerResultMatch(typeID TypeID, match *checker.Result
 }
 
 func (fl *functionLowerer) lowerResultMethod(typeID TypeID, method *checker.ResultMethod) (*Expr, error) {
-	target, err := fl.lowerExpr(method.Subject)
+	var target *Expr
+	var err error
+	if subjectType, ok := fl.resultMethodSubjectType(method); ok {
+		target, err = fl.lowerExprWithExpected(method.Subject, subjectType)
+	} else {
+		target, err = fl.lowerExpr(method.Subject)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -3757,6 +3894,28 @@ func (fl *functionLowerer) lowerResultMethod(typeID TypeID, method *checker.Resu
 		return nil, fmt.Errorf("unsupported AIR Result method %d", method.Kind)
 	}
 	return &Expr{Kind: kind, Type: typeID, Target: target, Args: args}, nil
+}
+
+func (fl *functionLowerer) resultMethodSubjectType(method *checker.ResultMethod) (TypeID, bool) {
+	subjectType, ok := method.Subject.Type().(*checker.Result)
+	if !ok {
+		return NoType, false
+	}
+	valueType := subjectType.Val()
+	errType := subjectType.Err()
+	if returnType, ok := method.ReturnType.(*checker.Result); ok {
+		if typeHasUnresolvedTypeVar(valueType) {
+			valueType = returnType.Val()
+		}
+		if typeHasUnresolvedTypeVar(errType) {
+			errType = returnType.Err()
+		}
+	}
+	typeID, err := fl.internContextualCheckerType(checker.MakeResult(valueType, errType))
+	if err != nil {
+		return NoType, false
+	}
+	return typeID, true
 }
 
 func (fl *functionLowerer) lowerTryOp(typeID TypeID, op *checker.TryOp) (*Expr, error) {
@@ -3962,6 +4121,9 @@ func (fl *functionLowerer) lowerInstanceProperty(typeID TypeID, prop *checker.In
 	}
 	for _, field := range targetInfo.Fields {
 		if field.Name == prop.Property {
+			if !validTypeID(&fl.l.program, typeID) {
+				typeID = field.Type
+			}
 			return &Expr{Kind: ExprGetField, Type: typeID, Target: target, Field: field.Index}, nil
 		}
 	}
@@ -4246,7 +4408,7 @@ func (fl *functionLowerer) lowerUserDefinedInstanceMethod(typeID TypeID, target 
 			return nil, err
 		}
 	}
-	id, err := fl.l.declareInstanceMethodFunction(module, typeInfo.Name, target.Type, def)
+	id, err := fl.l.declareInstanceMethodFunction(module, typeInfo.Name, target.Type, def, method.Method.Args, typeID)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -1085,11 +1085,6 @@ func (l *lowerer) lowerMethodFunction(id FunctionID, def *checker.FunctionDef) e
 }
 
 func (l *lowerer) declareInstanceMethodFunction(module ModuleID, ownerName string, ownerType TypeID, def *checker.FunctionDef, args []checker.Expression, returnType TypeID) (FunctionID, error) {
-	key := methodFunctionKey(module, fmt.Sprintf("%s#%d", ownerName, ownerType), "instance", def.Name)
-	if id, ok := l.functions[key]; ok {
-		return id, nil
-	}
-
 	receiver := def.Receiver
 	if receiver == "" {
 		receiver = "self"
@@ -1115,6 +1110,12 @@ func (l *lowerer) declareInstanceMethodFunction(module ModuleID, ownerName strin
 		if err != nil {
 			return NoFunction, err
 		}
+	}
+
+	signature := Signature{Params: params, Return: returnType}
+	key := concreteFunctionKey(module, fmt.Sprintf("method/%s#%d/instance/%s", ownerName, ownerType, def.Name), signature)
+	if id, ok := l.functions[key]; ok {
+		return id, nil
 	}
 
 	id := FunctionID(len(l.program.Functions))

--- a/compiler/air/lower_test.go
+++ b/compiler/air/lower_test.go
@@ -904,6 +904,186 @@ func TestLowerImportedGenericModuleFunctionSpecialization(t *testing.T) {
 	}
 }
 
+func TestLowerImportedGenericStdlibFunctionBodyUsesConcreteBindings(t *testing.T) {
+	program := lowerSource(t, `
+		use ard/list
+
+		fn main() [Int] {
+			list::keep([1, 2, 3], fn(value) { value > 1 })
+		}
+	`)
+
+	keep := findFunction(t, program, "keep")
+	if len(keep.Signature.Params) != 2 {
+		t.Fatalf("keep param count = %d, want 2", len(keep.Signature.Params))
+	}
+	returnType := testTypeInfo(t, program, keep.Signature.Return)
+	if returnType.Kind != TypeList || typeKind(t, program, returnType.Elem) != TypeInt {
+		t.Fatalf("keep return = %#v, want [Int]", returnType)
+	}
+	for _, local := range keep.Locals {
+		info := testTypeInfo(t, program, local.Type)
+		if info.Kind == TypeList && typeKind(t, program, info.Elem) == TypeVoid {
+			t.Fatalf("keep local %s has [Void], want concrete generic binding", local.Name)
+		}
+	}
+}
+
+func TestLowerGenericStructMethodBodyUsesReceiverBindings(t *testing.T) {
+	program := lowerSource(t, `
+		struct Box {
+			item: $T
+		}
+
+		impl Box {
+			fn get() $T {
+				self.item
+			}
+		}
+
+		fn main() Int {
+			let box: Box<Int> = Box{item: 42}
+			box.get()
+		}
+	`)
+
+	get := findFunction(t, program, "Box.get")
+	if typeKind(t, program, get.Signature.Return) != TypeInt {
+		t.Fatalf("get return kind = %v, want TypeInt", typeKind(t, program, get.Signature.Return))
+	}
+}
+
+func TestLowerGenericStructMethodSpecializationsDoNotCollapse(t *testing.T) {
+	program := lowerSource(t, `
+		struct Box {
+			item: $T
+		}
+
+		impl Box {
+			fn get() $T {
+				self.item
+			}
+		}
+
+		fn get_int(box: Box<Int>) Int {
+			box.get()
+		}
+
+		fn get_str(box: Box<Str>) Str {
+			box.get()
+		}
+	`)
+
+	intGet := findFunction(t, program, "get_int")
+	strGet := findFunction(t, program, "get_str")
+	if intGet.Body.Result == nil || intGet.Body.Result.Kind != ExprCall {
+		t.Fatalf("get_int result = %#v, want method call", intGet.Body.Result)
+	}
+	if strGet.Body.Result == nil || strGet.Body.Result.Kind != ExprCall {
+		t.Fatalf("get_str result = %#v, want method call", strGet.Body.Result)
+	}
+	if intGet.Body.Result.Function == strGet.Body.Result.Function {
+		t.Fatalf("generic method specializations collapsed to function %d", intGet.Body.Result.Function)
+	}
+	if typeKind(t, program, program.Functions[intGet.Body.Result.Function].Signature.Return) != TypeInt {
+		t.Fatalf("get_int method return kind = %v, want Int", typeKind(t, program, program.Functions[intGet.Body.Result.Function].Signature.Return))
+	}
+	if typeKind(t, program, program.Functions[strGet.Body.Result.Function].Signature.Return) != TypeStr {
+		t.Fatalf("get_str method return kind = %v, want Str", typeKind(t, program, program.Functions[strGet.Body.Result.Function].Signature.Return))
+	}
+}
+
+func TestLowerSameShapeStructsWithDifferentMethodsStayDistinct(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "ard.toml"), []byte("name = \"app\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	firstPath := filepath.Join(root, "first.ard")
+	if err := os.WriteFile(firstPath, []byte(`
+		struct Item {
+			value: Int
+		}
+
+		impl Item {
+			fn value_plus_one() Int {
+				self.value + 1
+			}
+		}
+	`), 0o644); err != nil {
+		t.Fatalf("write first module: %v", err)
+	}
+	secondPath := filepath.Join(root, "second.ard")
+	if err := os.WriteFile(secondPath, []byte(`
+		struct Item {
+			value: Int
+		}
+
+		impl Item {
+			fn value_text() Str {
+				self.value.to_str()
+			}
+		}
+	`), 0o644); err != nil {
+		t.Fatalf("write second module: %v", err)
+	}
+
+	mainPath := filepath.Join(root, "main.ard")
+	result := parse.Parse([]byte(`
+		use app/first
+		use app/second
+
+		fn read_first(item: first::Item) Int {
+			item.value_plus_one()
+		}
+
+		fn read_second(item: second::Item) Str {
+			item.value_text()
+		}
+	`), mainPath)
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	resolver, err := checker.NewModuleResolver(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := checker.New(mainPath, result.Program, resolver)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+	program, err := Lower(c.Module())
+	if err != nil {
+		t.Fatalf("lower error: %v", err)
+	}
+
+	firstItem := findType(t, program, "Item")
+	var secondItem TypeInfo
+	for _, typ := range program.Types {
+		if typ.Name == "Item" && typ.ID != firstItem.ID {
+			secondItem = typ
+			break
+		}
+	}
+	if secondItem.ID == NoType {
+		t.Fatal("second Item type not found")
+	}
+	if firstItem.ID == secondItem.ID {
+		t.Fatalf("same-shape imported structs collapsed to type %d", firstItem.ID)
+	}
+	readFirst := findFunction(t, program, "read_first")
+	readSecond := findFunction(t, program, "read_second")
+	if typeKind(t, program, readFirst.Signature.Params[0].Type) != TypeStruct {
+		t.Fatalf("read_first param kind = %v, want struct", typeKind(t, program, readFirst.Signature.Params[0].Type))
+	}
+	if typeKind(t, program, readSecond.Signature.Params[0].Type) != TypeStruct {
+		t.Fatalf("read_second param kind = %v, want struct", typeKind(t, program, readSecond.Signature.Params[0].Type))
+	}
+	if readFirst.Signature.Params[0].Type == readSecond.Signature.Params[0].Type {
+		t.Fatalf("same-shape imported struct params collapsed to type %d", readFirst.Signature.Params[0].Type)
+	}
+}
+
 func TestLowerTestsManifest(t *testing.T) {
 	program := lowerSourceWithTests(t, `
 		use ard/testing

--- a/compiler/air/lower_test.go
+++ b/compiler/air/lower_test.go
@@ -993,6 +993,46 @@ func TestLowerGenericStructMethodSpecializationsDoNotCollapse(t *testing.T) {
 	}
 }
 
+func TestLowerGenericStructMethodOwnGenericSpecializationsDoNotCollapse(t *testing.T) {
+	program := lowerSource(t, `
+		struct Box {
+			item: Int
+		}
+
+		impl Box {
+			fn echo(value: $U) $U {
+				value
+			}
+		}
+
+		fn echo_int(box: Box) Int {
+			box.echo(1)
+		}
+
+		fn echo_str(box: Box) Str {
+			box.echo("x")
+		}
+	`)
+
+	intEcho := findFunction(t, program, "echo_int")
+	strEcho := findFunction(t, program, "echo_str")
+	if intEcho.Body.Result == nil || intEcho.Body.Result.Kind != ExprCall {
+		t.Fatalf("echo_int result = %#v, want method call", intEcho.Body.Result)
+	}
+	if strEcho.Body.Result == nil || strEcho.Body.Result.Kind != ExprCall {
+		t.Fatalf("echo_str result = %#v, want method call", strEcho.Body.Result)
+	}
+	if intEcho.Body.Result.Function == strEcho.Body.Result.Function {
+		t.Fatalf("method-local generic specializations collapsed to function %d", intEcho.Body.Result.Function)
+	}
+	if typeKind(t, program, program.Functions[intEcho.Body.Result.Function].Signature.Return) != TypeInt {
+		t.Fatalf("echo_int method return kind = %v, want Int", typeKind(t, program, program.Functions[intEcho.Body.Result.Function].Signature.Return))
+	}
+	if typeKind(t, program, program.Functions[strEcho.Body.Result.Function].Signature.Return) != TypeStr {
+		t.Fatalf("echo_str method return kind = %v, want Str", typeKind(t, program, program.Functions[strEcho.Body.Result.Function].Signature.Return))
+	}
+}
+
 func TestLowerSameShapeStructsWithDifferentMethodsStayDistinct(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "ard.toml"), []byte("name = \"app\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -2793,6 +2793,7 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 
 						// Copy the function with the struct's generic bindings applied
 						fnDefCopy = copyFunctionWithTypeVarMap(fnDef, *genericScope.genericContext)
+						fnDefCopy.GenericBindings = cloneTypeMap(genericBindings)
 					} else {
 						fnDefCopy = fnDef
 					}
@@ -5033,6 +5034,7 @@ func substituteType(t Type, typeMap map[string]Type) Type {
 			Mutates:                 typ.Mutates,
 			IsTest:                  typ.IsTest,
 			Private:                 typ.Private,
+			GenericBindings:         cloneTypeMap(typ.GenericBindings),
 		}
 	case *ExternType:
 		substitutedArgs := make([]Type, len(typ.TypeArgs))
@@ -5043,6 +5045,87 @@ func substituteType(t Type, typeMap map[string]Type) Type {
 	// Handle other compound types
 	default:
 		return t
+	}
+}
+
+func cloneTypeMap(in map[string]Type) map[string]Type {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]Type, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func concreteTypeVarBindings(in map[string]*TypeVar) map[string]Type {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]Type, len(in))
+	for key, value := range in {
+		if value != nil && value.Actual() != nil {
+			out[key] = value.Actual()
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func inferGenericBindingsFromFunction(original, specialized *FunctionDef) map[string]Type {
+	if original == nil || specialized == nil {
+		return nil
+	}
+	bindings := map[string]Type{}
+	for i, param := range original.Parameters {
+		if i < len(specialized.Parameters) {
+			inferGenericBindingsFromTypes(param.Type, specialized.Parameters[i].Type, bindings)
+		}
+	}
+	inferGenericBindingsFromTypes(original.ReturnType, specialized.ReturnType, bindings)
+	if len(bindings) == 0 {
+		return nil
+	}
+	return bindings
+}
+
+func inferGenericBindingsFromTypes(original, specialized Type, bindings map[string]Type) {
+	specialized = derefType(specialized)
+	switch orig := original.(type) {
+	case *TypeVar:
+		if specialized != nil && !hasGenericsInType(specialized) {
+			bindings[orig.Name()] = specialized
+		}
+	case *Maybe:
+		if spec, ok := specialized.(*Maybe); ok {
+			inferGenericBindingsFromTypes(orig.Of(), spec.Of(), bindings)
+		}
+	case *Result:
+		if spec, ok := specialized.(*Result); ok {
+			inferGenericBindingsFromTypes(orig.Val(), spec.Val(), bindings)
+			inferGenericBindingsFromTypes(orig.Err(), spec.Err(), bindings)
+		}
+	case *List:
+		if spec, ok := specialized.(*List); ok {
+			inferGenericBindingsFromTypes(orig.Of(), spec.Of(), bindings)
+		}
+	case *Map:
+		if spec, ok := specialized.(*Map); ok {
+			inferGenericBindingsFromTypes(orig.Key(), spec.Key(), bindings)
+			inferGenericBindingsFromTypes(orig.Value(), spec.Value(), bindings)
+		}
+	case *FunctionDef:
+		if spec, ok := specialized.(*FunctionDef); ok {
+			for i, param := range orig.Parameters {
+				if i < len(spec.Parameters) {
+					inferGenericBindingsFromTypes(param.Type, spec.Parameters[i].Type, bindings)
+				}
+			}
+			inferGenericBindingsFromTypes(orig.ReturnType, spec.ReturnType, bindings)
+		}
 	}
 }
 
@@ -5252,8 +5335,16 @@ func (c *Checker) checkAndProcessArguments(fnDef *FunctionDef, resolvedExprs []p
 		bindings := genericScope.getGenericBindings()
 
 		if len(bindings) == 0 {
-			// No generics were bound, use original function
-			fnToUse = fnDef
+			// No generics were bound from arguments. A receiver specialization
+			// may still have pre-bound generics, as with Box<T>.get().
+			if len(fnDefCopy.GenericBindings) == 0 {
+				fnDefCopy.GenericBindings = inferGenericBindingsFromFunction(fnDef, fnDefCopy)
+			}
+			if len(fnDefCopy.GenericBindings) > 0 {
+				fnToUse = fnDefCopy
+			} else {
+				fnToUse = fnDef
+			}
 		} else {
 			// Create specialized function with resolved generics
 			fnToUse = &FunctionDef{
@@ -5264,6 +5355,7 @@ func (c *Checker) checkAndProcessArguments(fnDef *FunctionDef, resolvedExprs []p
 				Body:                    fnDefCopy.Body,
 				Mutates:                 fnDefCopy.Mutates,
 				Private:                 fnDefCopy.Private,
+				GenericBindings:         cloneTypeMap(bindings),
 			}
 
 			// Replace generics in parameters
@@ -5361,6 +5453,7 @@ func (c *Checker) resolveGenericFunction(fnDef *FunctionDef, args []Expression, 
 		Body:                    fnDefCopy.Body,
 		Mutates:                 fnDefCopy.Mutates,
 		Private:                 fnDefCopy.Private,
+		GenericBindings:         cloneTypeMap(bindings),
 	}
 
 	// Replace generics in parameters

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -984,6 +984,7 @@ type FunctionDef struct {
 	IsTest                  bool
 	Body                    *Block
 	Private                 bool
+	GenericBindings         map[string]Type
 }
 
 func (f FunctionDef) String() string {

--- a/compiler/checker/scope.go
+++ b/compiler/checker/scope.go
@@ -428,7 +428,7 @@ func copyFunctionWithTypeVarMap(fnDef *FunctionDef, typeVarMap map[string]*TypeV
 		}
 	}
 
-	return &FunctionDef{
+	copy := &FunctionDef{
 		Name:                    fnDef.Name,
 		Parameters:              newParams,
 		ReturnType:              copyTypeWithTypeVarMap(fnDef.ReturnType, typeVarMap),
@@ -436,7 +436,12 @@ func copyFunctionWithTypeVarMap(fnDef *FunctionDef, typeVarMap map[string]*TypeV
 		Body:                    fnDef.Body,
 		Mutates:                 fnDef.Mutates,
 		Private:                 fnDef.Private,
+		GenericBindings:         cloneTypeMap(fnDef.GenericBindings),
 	}
+	if bindings := concreteTypeVarBindings(typeVarMap); bindings != nil {
+		copy.GenericBindings = bindings
+	}
+	return copy
 }
 
 // copyStructWithTypeVarMap creates a shallow copy of a StructDef with fresh TypeVar instances


### PR DESCRIPTION
## Summary
- preserve concrete generic bindings on specialized checker function definitions
- use those bindings when lowering generic stdlib functions and generic struct methods into AIR
- remove methods from struct AIR type identity, with regression coverage that same-shaped structs remain distinct by module/type and generic method specializations do not collapse

## Soundness notes
- Keeping methods out of the struct AIR key appears sound with the current type identity model: named structs still include module/name in the key, while generic method specializations are separated by concrete owner type IDs in method function keys.
- I initially tested stricter unresolved-generic AIR errors, but Go target tests showed that was not sound yet, so that strictness is not included in this PR.

## Tests
- cd compiler && go test ./air ./checker
- cd compiler && go test -run TestGoTargetParityMaybeResultCombinators ./go
- cd compiler && go test ./go