### PR TITLE
refactor(checker): move struct methods to side table

### DIFF
--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -105,6 +105,27 @@ func (l *lowerer) mustIntern(t checker.Type) TypeID {
 	return id
 }
 
+func (l *lowerer) structMethods(def *checker.StructDef) map[string]*checker.FunctionDef {
+	if def == nil {
+		return nil
+	}
+	owner := checker.StructMethodOwner(def)
+	for _, mod := range l.moduleByName {
+		if mod == nil || mod.Program() == nil {
+			continue
+		}
+		if methods := mod.Program().StructMethodsFor(owner); methods != nil {
+			return methods
+		}
+	}
+	return nil
+}
+
+func (l *lowerer) hasStructMethod(def *checker.StructDef, name string) bool {
+	methods := l.structMethods(def)
+	return methods != nil && methods[name] != nil
+}
+
 func (l *lowerer) lowerModule(module checker.Module) error {
 	if module == nil {
 		return fmt.Errorf("cannot lower nil module")
@@ -698,7 +719,7 @@ func (l *lowerer) declareTraitImplsForType(module ModuleID, typ checker.Type) er
 	switch typed := typ.(type) {
 	case *checker.StructDef:
 		traits = typed.Traits
-		methods = typed.Methods
+		methods = l.structMethods(typed)
 	case *checker.Enum:
 		traits = typed.Traits
 		methods = typed.Methods
@@ -1686,23 +1707,6 @@ func airStructKeySeen(typ *checker.StructDef, seen map[checker.Type]struct{}) st
 			key += ","
 		}
 		key += name + ":" + airTypeKeySeen(typ.Fields[name], seen)
-	}
-	key += "}"
-	if len(typ.Methods) == 0 {
-		return key
-	}
-	methodNames := make([]string, 0, len(typ.Methods))
-	for name := range typ.Methods {
-		methodNames = append(methodNames, name)
-	}
-	sort.Strings(methodNames)
-	key += " methods{"
-	for i, name := range methodNames {
-		if i > 0 {
-			key += ","
-		}
-		method := typ.Methods[name]
-		key += name + ":" + airFunctionTypeKeySeen(method.Parameters, method.ReturnType, seen)
 	}
 	key += "}"
 	return key
@@ -4623,7 +4627,7 @@ func (l *lowerer) moduleForInstanceMethod(method *checker.InstanceMethod, fallba
 		for _, stmt := range mod.Program().Statements {
 			switch def := stmt.Stmt.(type) {
 			case *checker.StructDef:
-				if def.Name == ownerName && def.Methods[method.Method.Name] != nil {
+				if def.Name == ownerName && l.hasStructMethod(def, method.Method.Name) {
 					return l.internModule(modulePath)
 				}
 			case *checker.Enum:

--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -109,13 +109,41 @@ func (l *lowerer) structMethods(def *checker.StructDef) map[string]*checker.Func
 	if def == nil {
 		return nil
 	}
-	owner := checker.StructMethodOwner(def)
+	return checker.StructMethodsInModules(l.moduleByName, checker.StructMethodOwner(def))
+}
+
+func (l *lowerer) findReachableModule(path string) checker.Module {
+	if mod, ok := l.moduleByName[path]; ok {
+		return mod
+	}
 	for _, mod := range l.moduleByName {
-		if mod == nil || mod.Program() == nil {
-			continue
+		if found := findReachableModuleSeen(mod, path, map[string]bool{}); found != nil {
+			l.moduleByName[path] = found
+			return found
 		}
-		if methods := mod.Program().StructMethodsFor(owner); methods != nil {
-			return methods
+	}
+	return nil
+}
+
+func findReachableModuleSeen(mod checker.Module, path string, seen map[string]bool) checker.Module {
+	if mod == nil {
+		return nil
+	}
+	modPath := mod.Path()
+	if modPath == path {
+		return mod
+	}
+	if seen[modPath] {
+		return nil
+	}
+	seen[modPath] = true
+	program := mod.Program()
+	if program == nil {
+		return nil
+	}
+	for _, imported := range program.Imports {
+		if found := findReachableModuleSeen(imported, path, seen); found != nil {
+			return found
 		}
 	}
 	return nil
@@ -4618,6 +4646,7 @@ func (l *lowerer) moduleForInstanceMethod(method *checker.InstanceMethod, fallba
 		return fallback
 	}
 	if ownerModulePath != "" {
+		l.findReachableModule(ownerModulePath)
 		return l.internModule(ownerModulePath)
 	}
 	for modulePath, mod := range l.moduleByName {

--- a/compiler/air/lower_test.go
+++ b/compiler/air/lower_test.go
@@ -53,6 +53,45 @@ func TestLowerTinyProgram(t *testing.T) {
 	}
 }
 
+func TestLowerTransitiveStructMethodCanReadOwnerModuleGlobal(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.1.0\""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "c.ard"), []byte(`
+		let SECRET = "ok"
+
+		struct C {}
+
+		impl C {
+			fn greet() Str {
+				SECRET
+			}
+		}
+	`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "b.ard"), []byte(`
+		use test_project/c
+
+		type C = c::C
+	`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	program := lowerProjectSource(t, tempDir, `
+		use test_project/b
+
+		fn use_c(value: b::C) Str {
+			value.greet()
+		}
+	`)
+	greet := findFunction(t, program, "C.greet")
+	if greet.Body.Result == nil || greet.Body.Result.Kind != ExprLoadGlobal {
+		t.Fatalf("greet result = %#v, want ExprLoadGlobal", greet.Body.Result)
+	}
+}
+
 func TestLowerFunctionCanReadModuleLevelLet(t *testing.T) {
 	program := lowerSource(t, `
 		let refresh_event = "inbox.refresh"
@@ -900,6 +939,28 @@ func lowerSource(t *testing.T, input string) *Program {
 		t.Fatalf("parse error: %s", result.Errors[0].Message)
 	}
 	c := checker.New("test.ard", result.Program, nil)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+	program, err := Lower(c.Module())
+	if err != nil {
+		t.Fatalf("lower error: %v", err)
+	}
+	return program
+}
+
+func lowerProjectSource(t *testing.T, root string, input string) *Program {
+	t.Helper()
+	result := parse.Parse([]byte(input), filepath.Join(root, "main.ard"))
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	resolver, err := checker.NewModuleResolver(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := checker.New("main.ard", result.Program, resolver)
 	c.Check()
 	if c.HasErrors() {
 		t.Fatalf("checker diagnostics: %v", c.Diagnostics())

--- a/compiler/checker/async_test.go
+++ b/compiler/checker/async_test.go
@@ -86,7 +86,7 @@ func TestAsyncChannels(t *testing.T) {
 			ch.send("wrong")
 			`,
 			diagnostics: []checker.Diagnostic{
-				{Kind: checker.Error, Message: "Type mismatch: Expected Int, got Str"},
+				{Kind: checker.Error, Message: "type mismatch: expected Int, got Str"},
 			},
 		},
 	})

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -12,8 +12,9 @@ import (
 )
 
 type Program struct {
-	Imports    map[string]Module
-	Statements []Statement
+	Imports       map[string]Module
+	Statements    []Statement
+	StructMethods map[MethodOwner]map[string]*FunctionDef
 }
 
 type Module interface {
@@ -163,26 +164,13 @@ func derefTypeSeen(t Type, seen map[Type]bool) Type {
 				fieldsChanged = true
 			}
 		}
-		methodsChanged := false
-		newMethods := make(map[string]*FunctionDef, len(typ.Methods))
-		for name, method := range typ.Methods {
-			derefMethod, _ := derefTypeSeen(method, seen).(*FunctionDef)
-			if derefMethod == nil {
-				derefMethod = method
-			}
-			newMethods[name] = derefMethod
-			if derefMethod != method {
-				methodsChanged = true
-			}
-		}
-		if !fieldsChanged && !methodsChanged {
+		if !fieldsChanged {
 			return typ
 		}
 		return &StructDef{
 			Name:          typ.Name,
 			ModulePath:    typ.ModulePath,
 			Fields:        newFields,
-			Methods:       newMethods,
 			Self:          typ.Self,
 			Traits:        typ.Traits,
 			GenericParams: append([]string(nil), typ.GenericParams...),
@@ -281,8 +269,9 @@ func New(filePath string, input *parse.Program, moduleResolver *ModuleResolver, 
 		moduleResolver: moduleResolver,
 		options:        normalizeCheckOptions(moduleResolver, options),
 		program: &Program{
-			Imports:    map[string]Module{},
-			Statements: []Statement{},
+			Imports:       map[string]Module{},
+			Statements:    []Statement{},
+			StructMethods: map[MethodOwner]map[string]*FunctionDef{},
 		},
 		scope: &rootScope,
 	}
@@ -592,12 +581,7 @@ func (c *Checker) specializeAliasedType(originalType Type, typeArgs []parse.Decl
 			resolvedArgType := c.resolveType(typeArg)
 			typeVarMap[genericParams[i]] = &TypeVar{name: genericParams[i], actual: resolvedArgType, bound: true}
 		}
-		structCopy := copyStructWithTypeVarMap(structDef, typeVarMap)
-		structCopy.Methods = make(map[string]*FunctionDef, len(structDef.Methods))
-		for methodName, methodDef := range structDef.Methods {
-			structCopy.Methods[methodName] = copyFunctionWithTypeVarMap(methodDef, typeVarMap)
-		}
-		return structCopy
+		return copyStructWithTypeVarMap(structDef, typeVarMap)
 	}
 
 	// 3. Replace generics
@@ -926,8 +910,8 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 					})
 					fnDef.Receiver = s.Receiver.Name
 					fnDef.Mutates = method.Mutates
-					// add the method to the struct
-					targetType.Methods[method.Name] = fnDef
+					// add the method to the struct method table
+					c.addStructMethod(targetType, fnDef)
 				}
 
 				// Check if all required methods are implemented
@@ -1532,7 +1516,7 @@ func (c *Checker) checkStmt(stmt *parse.Statement) *Statement {
 					if fnDef != nil {
 						fnDef.Receiver = s.Receiver.Name
 						fnDef.Mutates = method.Mutates
-						def.Methods[method.Name] = fnDef
+						c.addStructMethod(def, fnDef)
 					}
 				}
 				return &Statement{Stmt: def}
@@ -2047,7 +2031,6 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 		Name:          structDefCopy.Name,
 		ModulePath:    structDefCopy.ModulePath,
 		Fields:        fieldTypes,
-		Methods:       structDefCopy.Methods,
 		Self:          structDefCopy.Self,
 		Traits:        structDefCopy.Traits,
 		GenericParams: structDefCopy.GenericParams,
@@ -2344,20 +2327,68 @@ func (c *Checker) extractGenericBindingsFromSpecializedStruct(originalDef, speci
 			continue
 		}
 
-		// Extract generic names from the original field type
-		genericNames := make(map[string]bool)
-		extractGenericNames(originalFieldType, genericNames)
-
-		// For each generic found, bind it to the corresponding specialized type
-		for genericName := range genericNames {
-			if _, alreadyBound := bindings[genericName]; !alreadyBound {
-				// Bind this generic to the specialized field type
-				bindings[genericName] = specializedFieldType
-			}
-		}
+		bindGenericTypes(originalFieldType, specializedFieldType, bindings)
 	}
 
 	return bindings
+}
+
+func bindGenericTypes(original Type, specialized Type, bindings map[string]Type) {
+	original = deref(original)
+	specialized = deref(specialized)
+	switch orig := original.(type) {
+	case *TypeVar:
+		if orig.name != "" {
+			if _, alreadyBound := bindings[orig.name]; !alreadyBound {
+				bindings[orig.name] = specialized
+			}
+		}
+	case *List:
+		if spec, ok := specialized.(*List); ok {
+			bindGenericTypes(orig.of, spec.of, bindings)
+		}
+	case *Map:
+		if spec, ok := specialized.(*Map); ok {
+			bindGenericTypes(orig.key, spec.key, bindings)
+			bindGenericTypes(orig.value, spec.value, bindings)
+		}
+	case *Maybe:
+		if spec, ok := specialized.(*Maybe); ok {
+			bindGenericTypes(orig.of, spec.of, bindings)
+		}
+	case *Result:
+		if spec, ok := specialized.(*Result); ok {
+			bindGenericTypes(orig.val, spec.val, bindings)
+			bindGenericTypes(orig.err, spec.err, bindings)
+		}
+	case *ExternType:
+		if spec, ok := specialized.(*ExternType); ok {
+			for i := range orig.TypeArgs {
+				if i >= len(spec.TypeArgs) {
+					break
+				}
+				bindGenericTypes(orig.TypeArgs[i], spec.TypeArgs[i], bindings)
+			}
+		}
+	case *StructDef:
+		if spec, ok := specialized.(*StructDef); ok {
+			for name, originalField := range orig.Fields {
+				if specializedField, ok := spec.Fields[name]; ok {
+					bindGenericTypes(originalField, specializedField, bindings)
+				}
+			}
+		}
+	case *FunctionDef:
+		if spec, ok := specialized.(*FunctionDef); ok {
+			for i := range orig.Parameters {
+				if i >= len(spec.Parameters) {
+					break
+				}
+				bindGenericTypes(orig.Parameters[i].Type, spec.Parameters[i].Type, bindings)
+			}
+			bindGenericTypes(orig.ReturnType, spec.ReturnType, bindings)
+		}
+	}
 }
 
 func (c *Checker) checkIfChain(s *parse.IfStatement) Expression {
@@ -2665,7 +2696,14 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 			if subj.Type() == nil {
 				panic(fmt.Errorf("Cannot access %+v on nil: %s", subj.(*Variable).sym, s.Target))
 			}
-			sig := subj.Type().get(s.Method.Name)
+			var sig Type
+			if structDef, ok := subj.Type().(*StructDef); ok {
+				if method, ok := c.structMethod(structDef, s.Method.Name); ok {
+					sig = method
+				}
+			} else {
+				sig = subj.Type().get(s.Method.Name)
+			}
 			if sig == nil {
 				c.addError(fmt.Sprintf("Undefined: %s.%s", subj, s.Method.Name), s.Method.GetLocation())
 				return nil
@@ -2717,14 +2755,8 @@ func (c *Checker) checkExpr(expr parse.Expression) Expression {
 			// Check if the subject is a struct and if the original struct definition has generics
 			structType, isStruct := subj.Type().(*StructDef)
 			if isStruct {
-				// Look up the original struct definition by name to check if it's generic
-				scopeSymbol, _ := c.scope.get(structType.Name)
-				var originalDef *StructDef
-				if scopeSymbol != nil {
-					if origType, ok := scopeSymbol.Type.(*StructDef); ok {
-						originalDef = origType
-					}
-				}
+				// Look up the original named struct definition by module/name to check if it's generic.
+				originalDef := c.structDefinition(structType)
 
 				// If the original definition has generics, the current structType might be
 				// a specialized version with concrete field types (e.g., item: Int instead of item: $T)
@@ -5663,7 +5695,14 @@ func (c *Checker) checkAccessorChainWithMaybes(parseExpr parse.Expression) Expre
 			isMaybe = true
 		}
 
-		sig := innerType.get(p.Method.Name)
+		var sig Type
+		if structDef, ok := innerType.(*StructDef); ok {
+			if method, ok := c.structMethod(structDef, p.Method.Name); ok {
+				sig = method
+			}
+		} else {
+			sig = innerType.get(p.Method.Name)
+		}
 		if sig == nil {
 			c.addError(fmt.Sprintf("Undefined: %s.%s", innerType, p.Method.Name), p.Method.GetLocation())
 			return nil

--- a/compiler/checker/functions.go
+++ b/compiler/checker/functions.go
@@ -176,20 +176,14 @@ func (c *Checker) validateAsyncEval(fnNode parse.Expression) *FiberEval {
 					Name:          fiberStructDef.Name,
 					ModulePath:    fiberStructDef.ModulePath,
 					Fields:        make(map[string]Type),
-					Methods:       make(map[string]*FunctionDef),
 					GenericParams: append([]string(nil), fiberStructDef.GenericParams...),
 					Private:       fiberStructDef.Private,
 				}
 
-				// Copy fields, replacing $T with the closure's return type
+				// Copy fields, replacing $T with the closure's return type. Methods stay
+				// in the module method table and are specialized at call sites.
 				for fieldName, fieldType := range fiberStructDef.Fields {
 					fiberCopy.Fields[fieldName] = copyTypeWithTypeVarMap(fieldType, typeVarMap)
-				}
-
-				// Copy and specialize methods
-				for methodName, methodDef := range fiberStructDef.Methods {
-					methodCopy := copyFunctionWithTypeVarMap(methodDef, typeVarMap)
-					fiberCopy.Methods[methodName] = methodCopy
 				}
 
 				fiberType = fiberCopy

--- a/compiler/checker/method_identity_test.go
+++ b/compiler/checker/method_identity_test.go
@@ -1,0 +1,82 @@
+package checker
+
+import (
+	"testing"
+
+	"github.com/akonwi/ard/parse"
+)
+
+func TestStructMethodsAreStoredInProgramSideTable(t *testing.T) {
+	result := parse.Parse([]byte(`
+		struct Frame {}
+
+		impl Frame {
+			fn sub() Frame {
+				self
+			}
+		}
+	`), "test.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	c := New("test.ard", result.Program, nil)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+
+	sym, ok := c.scope.get("Frame")
+	if !ok {
+		t.Fatal("Frame missing from scope")
+	}
+	frame, ok := sym.Type.(*StructDef)
+	if !ok {
+		t.Fatalf("Frame symbol type = %T, want *StructDef", sym.Type)
+	}
+	if got := frame.get("sub"); got != nil {
+		t.Fatalf("StructDef.get returned method %T; methods should not be in value-shape lookup", got)
+	}
+	if _, ok := c.program.StructMethod(StructMethodOwner(frame), "sub"); !ok {
+		t.Fatal("method sub missing from Program.StructMethods side table")
+	}
+}
+
+func TestStructSideTableMethodUsesGenericBindingsFromNestedFields(t *testing.T) {
+	result := parse.Parse([]byte(`
+		extern type Chan<$T>
+
+		struct Channel {
+			chan: Chan<$T>
+		}
+
+		impl Channel {
+			fn send(value: $T) Bool {
+				true
+			}
+		}
+
+		extern fn new() Channel<Int> = "NewChannel"
+
+		let ch = new()
+		ch.send(42)
+	`), "test.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	c := New("test.ard", result.Program, nil)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+}
+
+func TestStructEqualityIndependentOfMethodSideTable(t *testing.T) {
+	left := &StructDef{Name: "Frame", Fields: map[string]Type{}}
+	right := &StructDef{Name: "Frame", Fields: map[string]Type{}}
+	program := &Program{}
+	program.AddStructMethod(StructMethodOwner(right), "sub", &FunctionDef{Name: "sub", ReturnType: right})
+
+	if !left.equal(right) {
+		t.Fatal("struct equality should ignore side-table method signatures")
+	}
+}

--- a/compiler/checker/method_identity_test.go
+++ b/compiler/checker/method_identity_test.go
@@ -1,6 +1,8 @@
 package checker
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/akonwi/ard/parse"
@@ -67,6 +69,91 @@ func TestStructSideTableMethodUsesGenericBindingsFromNestedFields(t *testing.T) 
 	c.Check()
 	if c.HasErrors() {
 		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+}
+
+func TestStructMethodLookupUsesOwnerModuleBeyondDirectImports(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.1.0\""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "db.ard"), []byte(`
+		use ard/sql
+
+		fn init() sql::Database {
+			sql::open("postgres://example").expect("connect")
+		}
+	`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := parse.Parse([]byte(`
+		use test_project/db
+
+		let conn = db::init()
+		let query = conn.query("SELECT 1")
+	`), filepath.Join(tempDir, "main.ard"))
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	resolver, err := NewModuleResolver(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := New(filepath.Join(tempDir, "main.ard"), result.Program, resolver)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+}
+
+func TestTransitiveGenericStructMethodUsesOwnerDefinition(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"test_project\"\nard = \">= 0.1.0\""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "box.ard"), []byte(`
+		struct Box {
+			item: $T
+		}
+
+		impl Box {
+			fn put(value: $T) Bool {
+				true
+			}
+		}
+	`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "aliases.ard"), []byte(`
+		use test_project/box
+
+		type IntBox = box::Box<Int>
+	`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := parse.Parse([]byte(`
+		use test_project/aliases
+
+		fn save(box: aliases::IntBox) Bool {
+			box.put("oops")
+		}
+	`), filepath.Join(tempDir, "main.ard"))
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	resolver, err := NewModuleResolver(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := New(filepath.Join(tempDir, "main.ard"), result.Program, resolver)
+	c.Check()
+	if !c.HasErrors() {
+		t.Fatal("checker succeeded; expected generic method argument error")
+	}
+	if got := c.Diagnostics()[0].Message; got != "type mismatch: expected Int, got Str" {
+		t.Fatalf("first diagnostic = %q, want generic method argument mismatch", got)
 	}
 }
 

--- a/compiler/checker/methods.go
+++ b/compiler/checker/methods.go
@@ -1,0 +1,118 @@
+package checker
+
+// MethodOwner identifies the named type whose method namespace a method belongs to.
+type MethodOwner struct {
+	ModulePath string
+	TypeName   string
+}
+
+func StructMethodOwner(def *StructDef) MethodOwner {
+	if def == nil {
+		return MethodOwner{}
+	}
+	return MethodOwner{ModulePath: def.ModulePath, TypeName: def.Name}
+}
+
+func (p *Program) AddStructMethod(owner MethodOwner, name string, method *FunctionDef) {
+	if p == nil || owner.TypeName == "" || name == "" || method == nil {
+		return
+	}
+	if p.StructMethods == nil {
+		p.StructMethods = map[MethodOwner]map[string]*FunctionDef{}
+	}
+	methods := p.StructMethods[owner]
+	if methods == nil {
+		methods = map[string]*FunctionDef{}
+		p.StructMethods[owner] = methods
+	}
+	methods[name] = method
+}
+
+func (p *Program) StructMethod(owner MethodOwner, name string) (*FunctionDef, bool) {
+	if p == nil || p.StructMethods == nil {
+		return nil, false
+	}
+	methods := p.StructMethods[owner]
+	if methods == nil {
+		return nil, false
+	}
+	method, ok := methods[name]
+	return method, ok
+}
+
+func (p *Program) StructMethodsFor(owner MethodOwner) map[string]*FunctionDef {
+	if p == nil || p.StructMethods == nil {
+		return nil
+	}
+	return p.StructMethods[owner]
+}
+
+func (c *Checker) addStructMethod(def *StructDef, method *FunctionDef) {
+	if def == nil || method == nil {
+		return
+	}
+	c.program.AddStructMethod(StructMethodOwner(def), method.Name, method)
+}
+
+func (c *Checker) structMethod(def *StructDef, name string) (*FunctionDef, bool) {
+	if def == nil {
+		return nil, false
+	}
+	owner := StructMethodOwner(def)
+	if method, ok := c.program.StructMethod(owner, name); ok {
+		return method, true
+	}
+	for _, mod := range c.program.Imports {
+		if mod == nil || mod.Program() == nil {
+			continue
+		}
+		if method, ok := mod.Program().StructMethod(owner, name); ok {
+			return method, true
+		}
+	}
+	return nil, false
+}
+
+func (c *Checker) structMethods(def *StructDef) map[string]*FunctionDef {
+	if def == nil {
+		return nil
+	}
+	owner := StructMethodOwner(def)
+	if methods := c.program.StructMethodsFor(owner); methods != nil {
+		return methods
+	}
+	for _, mod := range c.program.Imports {
+		if mod == nil || mod.Program() == nil {
+			continue
+		}
+		if methods := mod.Program().StructMethodsFor(owner); methods != nil {
+			return methods
+		}
+	}
+	return nil
+}
+
+func (c *Checker) structDefinition(def *StructDef) *StructDef {
+	if def == nil {
+		return nil
+	}
+	if sym, ok := c.scope.get(def.Name); ok {
+		if structDef, ok := sym.Type.(*StructDef); ok && structDef.Name == def.Name && !namedTypeOwnersDiffer(structDef.ModulePath, def.ModulePath) {
+			return structDef
+		}
+	}
+	for _, mod := range c.program.Imports {
+		if mod == nil {
+			continue
+		}
+		if def.ModulePath != "" && mod.Path() != def.ModulePath {
+			continue
+		}
+		if sym := mod.Get(def.Name); !sym.IsZero() {
+			if structDef, ok := sym.Type.(*StructDef); ok && structDef.Name == def.Name && !namedTypeOwnersDiffer(structDef.ModulePath, def.ModulePath) {
+				return structDef
+			}
+		}
+	}
+	return def
+}

--- a/compiler/checker/methods.go
+++ b/compiler/checker/methods.go
@@ -47,6 +47,106 @@ func (p *Program) StructMethodsFor(owner MethodOwner) map[string]*FunctionDef {
 	return p.StructMethods[owner]
 }
 
+func StructMethodInModules(modules map[string]Module, owner MethodOwner, name string) (*FunctionDef, bool) {
+	return structMethodInModulesSeen(modules, owner, name, map[string]bool{})
+}
+
+func StructMethodsInModules(modules map[string]Module, owner MethodOwner) map[string]*FunctionDef {
+	return structMethodsInModulesSeen(modules, owner, map[string]bool{})
+}
+
+func StructDefinitionInModules(modules map[string]Module, owner MethodOwner) (*StructDef, bool) {
+	return structDefinitionInModulesSeen(modules, owner, map[string]bool{})
+}
+
+func structMethodInModulesSeen(modules map[string]Module, owner MethodOwner, name string, seen map[string]bool) (*FunctionDef, bool) {
+	for _, mod := range modules {
+		if method, ok := structMethodInModuleSeen(mod, owner, name, seen); ok {
+			return method, true
+		}
+	}
+	return nil, false
+}
+
+func structMethodInModuleSeen(mod Module, owner MethodOwner, name string, seen map[string]bool) (*FunctionDef, bool) {
+	if mod == nil {
+		return nil, false
+	}
+	path := mod.Path()
+	if seen[path] {
+		return nil, false
+	}
+	seen[path] = true
+	program := mod.Program()
+	if program == nil {
+		return nil, false
+	}
+	if method, ok := program.StructMethod(owner, name); ok {
+		return method, true
+	}
+	return structMethodInModulesSeen(program.Imports, owner, name, seen)
+}
+
+func structMethodsInModulesSeen(modules map[string]Module, owner MethodOwner, seen map[string]bool) map[string]*FunctionDef {
+	for _, mod := range modules {
+		if methods := structMethodsInModuleSeen(mod, owner, seen); methods != nil {
+			return methods
+		}
+	}
+	return nil
+}
+
+func structMethodsInModuleSeen(mod Module, owner MethodOwner, seen map[string]bool) map[string]*FunctionDef {
+	if mod == nil {
+		return nil
+	}
+	path := mod.Path()
+	if seen[path] {
+		return nil
+	}
+	seen[path] = true
+	program := mod.Program()
+	if program == nil {
+		return nil
+	}
+	if methods := program.StructMethodsFor(owner); methods != nil {
+		return methods
+	}
+	return structMethodsInModulesSeen(program.Imports, owner, seen)
+}
+
+func structDefinitionInModulesSeen(modules map[string]Module, owner MethodOwner, seen map[string]bool) (*StructDef, bool) {
+	for _, mod := range modules {
+		if def, ok := structDefinitionInModuleSeen(mod, owner, seen); ok {
+			return def, true
+		}
+	}
+	return nil, false
+}
+
+func structDefinitionInModuleSeen(mod Module, owner MethodOwner, seen map[string]bool) (*StructDef, bool) {
+	if mod == nil {
+		return nil, false
+	}
+	path := mod.Path()
+	if seen[path] {
+		return nil, false
+	}
+	seen[path] = true
+	if owner.ModulePath == "" || path == owner.ModulePath {
+		if sym := mod.Get(owner.TypeName); !sym.IsZero() {
+			if def, ok := sym.Type.(*StructDef); ok && def.Name == owner.TypeName && !namedTypeOwnersDiffer(def.ModulePath, owner.ModulePath) {
+				return def, true
+			}
+		}
+	}
+	program := mod.Program()
+	if program == nil {
+		return nil, false
+	}
+	return structDefinitionInModulesSeen(program.Imports, owner, seen)
+}
+
 func (c *Checker) addStructMethod(def *StructDef, method *FunctionDef) {
 	if def == nil || method == nil {
 		return
@@ -62,15 +162,7 @@ func (c *Checker) structMethod(def *StructDef, name string) (*FunctionDef, bool)
 	if method, ok := c.program.StructMethod(owner, name); ok {
 		return method, true
 	}
-	for _, mod := range c.program.Imports {
-		if mod == nil || mod.Program() == nil {
-			continue
-		}
-		if method, ok := mod.Program().StructMethod(owner, name); ok {
-			return method, true
-		}
-	}
-	return nil, false
+	return StructMethodInModules(c.program.Imports, owner, name)
 }
 
 func (c *Checker) structMethods(def *StructDef) map[string]*FunctionDef {
@@ -81,15 +173,7 @@ func (c *Checker) structMethods(def *StructDef) map[string]*FunctionDef {
 	if methods := c.program.StructMethodsFor(owner); methods != nil {
 		return methods
 	}
-	for _, mod := range c.program.Imports {
-		if mod == nil || mod.Program() == nil {
-			continue
-		}
-		if methods := mod.Program().StructMethodsFor(owner); methods != nil {
-			return methods
-		}
-	}
-	return nil
+	return StructMethodsInModules(c.program.Imports, owner)
 }
 
 func (c *Checker) structDefinition(def *StructDef) *StructDef {
@@ -101,18 +185,8 @@ func (c *Checker) structDefinition(def *StructDef) *StructDef {
 			return structDef
 		}
 	}
-	for _, mod := range c.program.Imports {
-		if mod == nil {
-			continue
-		}
-		if def.ModulePath != "" && mod.Path() != def.ModulePath {
-			continue
-		}
-		if sym := mod.Get(def.Name); !sym.IsZero() {
-			if structDef, ok := sym.Type.(*StructDef); ok && structDef.Name == def.Name && !namedTypeOwnersDiffer(structDef.ModulePath, def.ModulePath) {
-				return structDef
-			}
-		}
+	if structDef, ok := StructDefinitionInModules(c.program.Imports, StructMethodOwner(def)); ok {
+		return structDef
 	}
 	return def
 }

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -1268,7 +1268,6 @@ type StructDef struct {
 	Name          string
 	ModulePath    string
 	Fields        map[string]Type
-	Methods       map[string]*FunctionDef
 	Self          string
 	Traits        []*Trait
 	GenericParams []string
@@ -1285,13 +1284,10 @@ func (def StructDef) String() string {
 	return def.name()
 }
 func (def StructDef) get(name string) Type {
-	// Check data fields first
+	// Struct type identity describes value shape. Method namespaces live on the
+	// checked Program side table and are resolved by the checker with module context.
 	if field, ok := def.Fields[name]; ok {
 		return field
-	}
-	// Check methods
-	if method, ok := def.Methods[name]; ok {
-		return method
 	}
 	return nil
 }

--- a/compiler/checker/scope.go
+++ b/compiler/checker/scope.go
@@ -346,21 +346,13 @@ func replaceGeneric(t Type, genericName string, concreteType Type) Type {
 			Private:                 t.Private,
 		}
 	case *StructDef:
-		// Check if any fields or methods actually need specialization
+		// Struct value identity is fields/generics, not method signatures.
 		anyChanged := false
 		newFields := make(map[string]Type)
 		for fieldName, fieldType := range t.Fields {
 			newFieldType := replaceGeneric(fieldType, genericName, concreteType)
 			newFields[fieldName] = newFieldType
 			if newFieldType != fieldType {
-				anyChanged = true
-			}
-		}
-		newMethods := make(map[string]*FunctionDef)
-		for methodName, methodDef := range t.Methods {
-			newMethodDef := replaceGeneric(methodDef, genericName, concreteType).(*FunctionDef)
-			newMethods[methodName] = newMethodDef
-			if newMethodDef != methodDef {
 				anyChanged = true
 			}
 		}
@@ -372,7 +364,6 @@ func replaceGeneric(t Type, genericName string, concreteType Type) Type {
 			Name:       t.Name,
 			ModulePath: t.ModulePath,
 			Fields:     newFields,
-			Methods:    newMethods,
 			Self:       t.Self,
 			Traits:     t.Traits,
 			Private:    t.Private,
@@ -466,7 +457,6 @@ func copyStructWithTypeVarMapSeen(structDef *StructDef, typeVarMap map[string]*T
 		Name:       structDef.Name,
 		ModulePath: structDef.ModulePath,
 		Fields:     newFields,
-		Methods:    structDef.Methods, // Methods are not copied; they're shared
 		Self:       structDef.Self,
 		Traits:     structDef.Traits,
 		Private:    structDef.Private,

--- a/compiler/checker/structs_test.go
+++ b/compiler/checker/structs_test.go
@@ -51,7 +51,6 @@ func TestStructs(t *testing.T) {
 								"age":      checker.Int,
 								"employed": checker.Bool,
 							},
-							Methods: map[string]*checker.FunctionDef{},
 						},
 					},
 					{

--- a/compiler/checker/top_level_types.go
+++ b/compiler/checker/top_level_types.go
@@ -32,7 +32,6 @@ func (c *Checker) hoistTopLevelTypeDeclarations() {
 				Name:          s.Name.Name,
 				ModulePath:    c.typeOwnerPath(),
 				Fields:        make(map[string]Type),
-				Methods:       make(map[string]*FunctionDef),
 				GenericParams: genericParams,
 				Private:       s.Private,
 			}, false)
@@ -248,9 +247,6 @@ func (c *Checker) populateStructDefinition(def *StructDef, decl *parse.StructDef
 	def.Name = decl.Name.Name
 	def.ModulePath = c.typeOwnerPath()
 	def.Fields = make(map[string]Type)
-	if def.Methods == nil {
-		def.Methods = make(map[string]*FunctionDef)
-	}
 	def.GenericParams = declaredGenericParams
 	def.Private = decl.Private
 	resolvedGenericParams := []string{}

--- a/compiler/checker/type_equal.go
+++ b/compiler/checker/type_equal.go
@@ -200,18 +200,12 @@ func equalExternalFunctionDefSeen(left ExternalFunctionDef, right Type, seen map
 
 func equalStructDefSeen(left StructDef, right Type, seen map[typeEqualKey]struct{}) bool {
 	r, ok := right.(*StructDef)
-	if !ok || left.Name != r.Name || namedTypeOwnersDiffer(left.ModulePath, r.ModulePath) || len(left.Fields) != len(r.Fields) || len(left.Methods) != len(r.Methods) {
+	if !ok || left.Name != r.Name || namedTypeOwnersDiffer(left.ModulePath, r.ModulePath) || len(left.Fields) != len(r.Fields) {
 		return false
 	}
 	for name, fieldType := range left.Fields {
 		otherFieldType, ok := r.Fields[name]
 		if !ok || !equalTypesSeen(fieldType, otherFieldType, seen) {
-			return false
-		}
-	}
-	for name, methodType := range left.Methods {
-		otherMethodType, ok := r.Methods[name]
-		if !ok || !equalTypesSeen(methodType, otherMethodType, seen) {
 			return false
 		}
 	}

--- a/compiler/lsp/completion.go
+++ b/compiler/lsp/completion.go
@@ -269,7 +269,7 @@ func importedInstanceCompletionItems(ownerType string, prog *parse.Program, file
 				InsertText: name,
 			})
 		}
-		items = append(items, checkerMethodCompletionItems(ownerType, def.Methods, importedType, prog, filePath)...)
+		items = append(items, checkerMethodCompletionItems(ownerType, importedStructMethodsForDisplay(ownerType, def, prog, filePath), importedType, prog, filePath)...)
 	case *checker.Enum:
 		items = append(items, checkerMethodCompletionItems(ownerType, def.Methods, importedType, prog, filePath)...)
 	case *checker.Trait:

--- a/compiler/lsp/hover.go
+++ b/compiler/lsp/hover.go
@@ -335,19 +335,45 @@ func importedPublicTypeNames(imp parse.Import, filePath string) []string {
 }
 
 func importedTypeForDisplay(typeName string, prog *parse.Program, filePath string) (checker.Type, bool) {
+	importedType, _, _, ok := importedTypeAndModuleForDisplay(typeName, prog, filePath)
+	return importedType, ok
+}
+
+func importedTypeAndModuleForDisplay(typeName string, prog *parse.Program, filePath string) (checker.Type, checker.Module, string, bool) {
 	alias, memberName, ok := importedTypeDisplayParts(typeName)
 	if !ok {
-		return nil, false
+		return nil, nil, "", false
 	}
 	mod, ok := importedModuleForAlias(alias, prog, filePath)
 	if !ok {
-		return nil, false
+		return nil, nil, "", false
 	}
 	sym := mod.Get(memberName)
 	if sym.IsZero() {
-		return nil, false
+		return nil, nil, "", false
 	}
-	return sym.Type, true
+	return sym.Type, mod, memberName, true
+}
+
+func importedStructMethodsForDisplay(ownerType string, def *checker.StructDef, prog *parse.Program, filePath string) map[string]*checker.FunctionDef {
+	if def == nil {
+		return nil
+	}
+	_, mod, memberName, ok := importedTypeAndModuleForDisplay(ownerType, prog, filePath)
+	if !ok || mod == nil || mod.Program() == nil {
+		return nil
+	}
+	owner := checker.StructMethodOwner(def)
+	if owner.ModulePath == "" {
+		owner.ModulePath = mod.Path()
+	}
+	if owner.TypeName == "" {
+		owner.TypeName = memberName
+	}
+	if methods := mod.Program().StructMethodsFor(owner); methods != nil {
+		return methods
+	}
+	return nil
 }
 
 func importedTypeDisplayParts(typeName string) (alias string, memberName string, ok bool) {
@@ -986,15 +1012,25 @@ func resolveFromChecker(name string, prog *parse.Program, filePath string) strin
 	if checkerProg == nil {
 		return ""
 	}
-	return qualifyTypeDisplay(findTypeInCheckerProg(name, checkerProg.Statements), prog, filePath)
+	return qualifyTypeDisplay(findTypeInCheckerProg(name, checkerProg), prog, filePath)
 }
 
 // findTypeInCheckerProg walks checker statements to find a variable by name.
-func findTypeInCheckerProg(name string, stmts []checker.Statement) string {
-	for _, stmt := range stmts {
+func findTypeInCheckerProg(name string, prog *checker.Program) string {
+	if prog == nil {
+		return ""
+	}
+	for _, stmt := range prog.Statements {
 		// Check NonProducing variants
 		if t := findTypeInNonProducing(name, stmt.Stmt); t != "" {
 			return t
+		}
+		if def, ok := stmt.Stmt.(*checker.StructDef); ok {
+			for _, method := range prog.StructMethodsFor(checker.StructMethodOwner(def)) {
+				if t := findTypeInExpr(name, method); t != "" {
+					return t
+				}
+			}
 		}
 		// Check Expression variants (includes FunctionDef, If, Block, etc.)
 		if t := findTypeInExpr(name, stmt.Expr); t != "" {
@@ -1088,11 +1124,6 @@ func findTypeInNonProducing(name string, stmt checker.NonProducing) string {
 	case *checker.StructDef:
 		if s.Name == name {
 			return checkerTypeString(s)
-		}
-		for _, method := range s.Methods {
-			if t := findTypeInExpr(name, method); t != "" {
-				return t
-			}
 		}
 	case *checker.Union:
 		// Type definitions without method bodies — skip
@@ -1537,7 +1568,7 @@ func findImportedInstanceMethodSignature(ownerType string, methodName string, pr
 	var method *checker.FunctionDef
 	switch def := importedType.(type) {
 	case *checker.StructDef:
-		method = def.Methods[methodName]
+		method = importedStructMethodsForDisplay(ownerType, def, prog, filePath)[methodName]
 	case *checker.Enum:
 		method = def.Methods[methodName]
 	case *checker.Trait:

--- a/compiler/lsp/hover.go
+++ b/compiler/lsp/hover.go
@@ -370,10 +370,7 @@ func importedStructMethodsForDisplay(ownerType string, def *checker.StructDef, p
 	if owner.TypeName == "" {
 		owner.TypeName = memberName
 	}
-	if methods := mod.Program().StructMethodsFor(owner); methods != nil {
-		return methods
-	}
-	return nil
+	return checker.StructMethodsInModules(map[string]checker.Module{mod.Path(): mod}, owner)
 }
 
 func importedTypeDisplayParts(typeName string) (alias string, memberName string, ok bool) {


### PR DESCRIPTION
## Summary
- move struct methods out of StructDef identity into Program.StructMethods keyed by module/type owner
- update checker, AIR, and LSP lookups to resolve side-table methods through module import graphs
- add regressions for transitive struct method lookup, generic method bindings, and AIR lowering of owner-module globals

## Validation
- cd compiler && go generate ./std_lib/ffi && go test ./... -count=1
- cd ../ranger/server && /tmp/ard-branch check main.ard