### PR TITLE
fix(air): preserve declared non-generic method params

### DIFF
--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -1092,13 +1092,11 @@ func (l *lowerer) declareInstanceMethodFunction(module ModuleID, ownerName strin
 	params := make([]Param, 0, len(def.Parameters)+1)
 	params = append(params, Param{Name: receiver, Type: ownerType, Mutable: def.Mutates})
 	for i, param := range def.Parameters {
-		typeID := NoType
-		var err error
-		if i < len(args) {
-			typeID, err = l.internType(args[i].Type())
-		} else {
-			typeID, err = l.internType(param.Type)
+		paramType := param.Type
+		if typeHasUnresolvedTypeVar(paramType) && i < len(args) {
+			paramType = args[i].Type()
 		}
+		typeID, err := l.internType(paramType)
 		if err != nil {
 			return NoFunction, err
 		}

--- a/compiler/air/lower_test.go
+++ b/compiler/air/lower_test.go
@@ -1033,6 +1033,45 @@ func TestLowerGenericStructMethodOwnGenericSpecializationsDoNotCollapse(t *testi
 	}
 }
 
+func TestLowerInstanceMethodKeepsDeclaredTraitParameterType(t *testing.T) {
+	program := lowerSource(t, `
+		trait View {
+			fn render()
+		}
+
+		struct Node {
+			view: View
+		}
+
+		struct Context {}
+
+		impl Context {
+			fn add_child(child: View) {
+				let node = Node{view: child}
+			}
+		}
+
+		struct Child {}
+
+		impl View for Child {
+			fn render() {}
+		}
+
+		fn main() {
+			let ctx = Context{}
+			ctx.add_child(Child{})
+		}
+	`)
+
+	addChild := findFunction(t, program, "Context.add_child")
+	if len(addChild.Signature.Params) != 2 {
+		t.Fatalf("add_child param count = %d, want 2", len(addChild.Signature.Params))
+	}
+	if kind := typeKind(t, program, addChild.Signature.Params[1].Type); kind != TypeTraitObject {
+		t.Fatalf("add_child child param kind = %v, want trait object", kind)
+	}
+}
+
 func TestLowerSameShapeStructsWithDifferentMethodsStayDistinct(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "ard.toml"), []byte("name = \"app\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {


### PR DESCRIPTION
## Summary
- keep declared instance method parameter types when they do not contain unresolved generics
- only use call-site argument types to specialize method parameters that actually contain unresolved type variables
- add an AIR regression for trait-typed method parameters staying trait objects when called with concrete implementers

## Validation
- cd /private/tmp/ard-generic-specialization/compiler && go test ./... -count=1
- cd ../tinear && /tmp/ard-pr210-fixed test