### PR TITLE
perf(test): build go test modules once

### DIFF
--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -21,9 +21,19 @@ func LowerWithTests(module checker.Module) (*Program, error) {
 }
 
 func LowerWithOptions(module checker.Module, options LowerOptions) (*Program, error) {
+	return LowerModulesWithOptions([]checker.Module{module}, options)
+}
+
+func LowerModulesWithTests(modules []checker.Module) (*Program, error) {
+	return LowerModulesWithOptions(modules, LowerOptions{IncludeTests: true})
+}
+
+func LowerModulesWithOptions(modules []checker.Module, options LowerOptions) (*Program, error) {
 	l := newLowerer(options)
-	if err := l.lowerModule(module); err != nil {
-		return nil, err
+	for _, module := range modules {
+		if err := l.lowerModule(module); err != nil {
+			return nil, err
+		}
 	}
 	if err := l.lowerAllModuleGlobals(); err != nil {
 		return nil, err

--- a/compiler/air/lower.go
+++ b/compiler/air/lower.go
@@ -507,7 +507,7 @@ func (fl *functionLowerer) declareAndLowerFunctionCall(module ModuleID, def *che
 	return id, nil
 }
 
-func (l *lowerer) declareClosureFunction(module ModuleID, def *checker.FunctionDef, typeID TypeID) (FunctionID, error) {
+func (l *lowerer) declareClosureFunction(module ModuleID, keyName string, def *checker.FunctionDef, typeID TypeID) (FunctionID, error) {
 	typeInfo, ok := l.typeInfo(typeID)
 	if !ok || typeInfo.Kind != TypeFunction {
 		return NoFunction, fmt.Errorf("closure %s lowered with non-function AIR type %d", def.Name, typeID)
@@ -520,7 +520,7 @@ func (l *lowerer) declareClosureFunction(module ModuleID, def *checker.FunctionD
 		params[i] = Param{Name: param.Name, Type: typeInfo.Params[i], Mutable: param.Mutable}
 	}
 	signature := Signature{Params: params, Return: typeInfo.Return}
-	key := concreteFunctionKey(module, def.Name, signature, "")
+	key := concreteFunctionKey(module, keyName, signature, "")
 	if id, ok := l.functions[key]; ok {
 		return id, nil
 	}
@@ -830,8 +830,62 @@ func (fl *functionLowerer) contextualType(typeID TypeID) (TypeID, error) {
 	}
 }
 
+func (fl *functionLowerer) internStructType(typ *checker.StructDef) (TypeID, error) {
+	return fl.internStructTypeWithInterner(typ, fl.internType)
+}
+
+func (fl *functionLowerer) internResolvedStructType(typ *checker.StructDef) (TypeID, error) {
+	return fl.internStructTypeWithInterner(typ, fl.internResolvedType)
+}
+
+func (fl *functionLowerer) internStructTypeWithInterner(typ *checker.StructDef, intern func(checker.Type) (TypeID, error)) (TypeID, error) {
+	if typ.Name == "Fiber" {
+		return fl.l.internType(typ)
+	}
+	fields := sortedFieldNames(typ.Fields)
+	info := TypeInfo{Kind: TypeStruct, ModulePath: typ.ModulePath}
+	info.Fields = make([]FieldInfo, len(fields))
+	for i, name := range fields {
+		fieldTypeValue := typ.Fields[name]
+		fieldMutable := false
+		if ref, ok := fieldTypeValue.(*checker.MutableRef); ok {
+			fieldTypeValue = ref.Of()
+			fieldMutable = true
+		}
+		fieldType, err := intern(fieldTypeValue)
+		if err != nil {
+			return NoType, err
+		}
+		info.Fields[i] = FieldInfo{Name: name, Type: fieldType, Index: i, Mutable: fieldMutable}
+	}
+	name := typ.Name
+	if len(typ.TypeArgs) > 0 {
+		parts := make([]string, len(typ.TypeArgs))
+		for i, typeArg := range typ.TypeArgs {
+			typeID, err := intern(typeArg)
+			if err != nil {
+				return NoType, err
+			}
+			parts[i] = fl.l.typeName(typeID)
+		}
+		name += "<" + strings.Join(parts, ",") + ">"
+	}
+	key := "struct " + typ.ModulePath + "::" + name
+	if id, ok := fl.l.typeByKey[key]; ok {
+		return id, nil
+	}
+	id := TypeID(len(fl.l.program.Types) + 1)
+	info.ID = id
+	info.Name = name
+	fl.l.typeByKey[key] = id
+	fl.l.program.Types = append(fl.l.program.Types, info)
+	return id, nil
+}
+
 func (fl *functionLowerer) internResolvedCompositeType(t checker.Type) (TypeID, error) {
 	switch typ := t.(type) {
+	case *checker.StructDef:
+		return fl.internResolvedStructType(typ)
 	case *checker.List:
 		elem, err := fl.internResolvedType(typ.Of())
 		if err != nil {
@@ -904,6 +958,8 @@ func (fl *functionLowerer) internResolvedCompositeType(t checker.Type) (TypeID, 
 
 func (fl *functionLowerer) internCompositeType(t checker.Type) (TypeID, error) {
 	switch typ := t.(type) {
+	case *checker.StructDef:
+		return fl.internStructType(typ)
 	case *checker.List:
 		elem, err := fl.internType(typ.Of())
 		if err != nil {
@@ -1883,6 +1939,11 @@ func typeContainsTypeVarSeen(t checker.Type, seen map[checker.Type]struct{}) boo
 		}
 		return false
 	case *checker.StructDef:
+		for _, typeArg := range typ.TypeArgs {
+			if typeContainsTypeVarSeen(typeArg, seen) {
+				return true
+			}
+		}
 		for _, fieldType := range typ.Fields {
 			if typeContainsTypeVarSeen(fieldType, seen) {
 				return true
@@ -1951,6 +2012,11 @@ func typeHasUnresolvedTypeVarSeen(t checker.Type, seen map[checker.Type]struct{}
 		}
 		return false
 	case *checker.StructDef:
+		for _, typeArg := range typ.TypeArgs {
+			if typeHasUnresolvedTypeVarSeen(typeArg, seen) {
+				return true
+			}
+		}
 		for _, fieldType := range typ.Fields {
 			if typeHasUnresolvedTypeVarSeen(fieldType, seen) {
 				return true
@@ -2067,7 +2133,18 @@ func airStructKey(typ *checker.StructDef) string {
 
 func airStructKeySeen(typ *checker.StructDef, seen map[checker.Type]struct{}) string {
 	fields := sortedFieldNames(typ.Fields)
-	key := "struct " + typ.ModulePath + "::" + typ.Name + "{"
+	key := "struct " + typ.ModulePath + "::" + typ.Name
+	if len(typ.TypeArgs) > 0 {
+		key += "<"
+		for i, typeArg := range typ.TypeArgs {
+			if i > 0 {
+				key += ","
+			}
+			key += airTypeKeySeen(typeArg, seen)
+		}
+		key += ">"
+	}
+	key += "{"
 	for i, name := range fields {
 		if i > 0 {
 			key += ","
@@ -4386,7 +4463,8 @@ func (fl *functionLowerer) lowerFieldAssignment(prop *checker.InstanceProperty, 
 }
 
 func (fl *functionLowerer) lowerClosure(typeID TypeID, def *checker.FunctionDef) (*Expr, error) {
-	id, err := fl.l.declareClosureFunction(fl.fn.Module, def, typeID)
+	keyName := fmt.Sprintf("closure/%d/%s", fl.fn.ID, def.Name)
+	id, err := fl.l.declareClosureFunction(fl.fn.Module, keyName, def, typeID)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/air/lower_test.go
+++ b/compiler/air/lower_test.go
@@ -948,7 +948,7 @@ func TestLowerGenericStructMethodBodyUsesReceiverBindings(t *testing.T) {
 		}
 	`)
 
-	get := findFunction(t, program, "Box.get")
+	get := findFunction(t, program, "Box<Int>.get")
 	if typeKind(t, program, get.Signature.Return) != TypeInt {
 		t.Fatalf("get return kind = %v, want TypeInt", typeKind(t, program, get.Signature.Return))
 	}
@@ -1410,4 +1410,46 @@ func TestLowerReceiverGenericUsedOnlyInMethodBody(t *testing.T) {
 		}
 	}
 	t.Fatalf("raw extern specialization with explicit type arg not found: %#v", program.Externs)
+}
+func TestLowerGenericFunctionAdapterClosureCapturesSpecializedCallback(t *testing.T) {
+	_ = lowerSource(t, `
+		struct StateHandle { id: Int }
+		struct BuildContextHandle { id: Int }
+		struct BuildContext {}
+		struct Widget {}
+
+		struct State<$T> {
+			handle: StateHandle,
+		}
+
+		extern fn stateful_raw_init_key<$T>(key: Str, init: fn(BuildContextHandle, StateHandle) $T, build: fn(BuildContextHandle, StateHandle) Widget) Widget = "StatefulRawInitKey"
+
+		fn stateful<$T>(key: Str, init: fn(BuildContext) $T, build: fn(BuildContext, State<$T>) Widget) Widget {
+			stateful_raw_init_key(
+				key: key,
+				init: fn(_build_ctx: BuildContextHandle, _state_handle: StateHandle) $T {
+					init(BuildContext{})
+				},
+				build: fn(_build_ctx: BuildContextHandle, state_handle: StateHandle) Widget {
+					build(BuildContext{}, State{handle: state_handle})
+				},
+			)
+		}
+
+		struct One { n: Int }
+		struct Two { s: Str }
+
+		fn main() {
+			let _ = stateful(
+				key: "one",
+				init: fn(_ctx: BuildContext) One { One{n: 1} },
+				build: fn(_ctx: BuildContext, _state: State<One>) Widget { Widget{} },
+			)
+			let _ = stateful(
+				key: "two",
+				init: fn(_ctx: BuildContext) Two { Two{s: "two"} },
+				build: fn(_ctx: BuildContext, _state: State<Two>) Widget { Widget{} },
+			)
+		}
+	`)
 }

--- a/compiler/air/lower_test.go
+++ b/compiler/air/lower_test.go
@@ -153,6 +153,32 @@ func TestLowerOmitsTestsByDefault(t *testing.T) {
 	}
 }
 
+func TestLowerModulesWithTestsIncludesEachRootModuleTest(t *testing.T) {
+	left := checkedModuleWithPath(t, "demo/left", `
+		test fn same() Void!Str { Result::ok(()) }
+	`)
+	right := checkedModuleWithPath(t, "demo/right", `
+		test fn same() Void!Str { Result::ok(()) }
+	`)
+
+	program, err := LowerModulesWithTests([]checker.Module{left, right})
+	if err != nil {
+		t.Fatalf("lower modules with tests: %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, test := range program.Tests {
+		fn := program.Functions[test.Function]
+		module := program.Modules[fn.Module]
+		seen[module.Path+"::"+test.Name] = true
+	}
+	for _, want := range []string{"demo/left::same", "demo/right::same"} {
+		if !seen[want] {
+			t.Fatalf("lowered tests missing %s: %#v", want, seen)
+		}
+	}
+}
+
 func TestLowerMainEntrypoint(t *testing.T) {
 	program := lowerSource(t, `
 		fn main() Int {
@@ -1190,6 +1216,20 @@ func TestValidateRejectsBadTypeReference(t *testing.T) {
 	if err := Validate(program); err == nil {
 		t.Fatalf("Validate succeeded, want invalid type error")
 	}
+}
+
+func checkedModuleWithPath(t *testing.T, modulePath string, input string) checker.Module {
+	t.Helper()
+	result := parse.Parse([]byte(input), modulePath+".ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	c := checker.New(modulePath+".ard", result.Program, nil, checker.CheckOptions{ModulePath: modulePath})
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+	return c.Module()
 }
 
 func lowerSource(t *testing.T, input string) *Program {

--- a/compiler/checker/check_options.go
+++ b/compiler/checker/check_options.go
@@ -4,18 +4,27 @@ import "github.com/akonwi/ard/backend"
 
 type CheckOptions struct {
 	Target string
+	// ModulePath overrides the checked module identity while keeping filePath for diagnostics.
+	ModulePath string
 }
 
 func normalizeCheckOptions(moduleResolver *ModuleResolver, options []CheckOptions) CheckOptions {
-	if len(options) > 0 && options[0].Target != "" {
-		return options[0]
+	normalized := CheckOptions{}
+	if len(options) > 0 {
+		normalized = options[0]
+	}
+
+	if normalized.Target != "" {
+		return normalized
 	}
 
 	if moduleResolver != nil {
 		if project := moduleResolver.GetProjectInfo(); project != nil && project.Target != "" {
-			return CheckOptions{Target: project.Target}
+			normalized.Target = project.Target
+			return normalized
 		}
 	}
 
-	return CheckOptions{Target: backend.DefaultTarget}
+	normalized.Target = backend.DefaultTarget
+	return normalized
 }

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -273,13 +273,18 @@ type Checker struct {
 
 func New(filePath string, input *parse.Program, moduleResolver *ModuleResolver, options ...CheckOptions) *Checker {
 	rootScope := makeScope(nil)
+	checkOptions := normalizeCheckOptions(moduleResolver, options)
+	modulePath := filePath
+	if checkOptions.ModulePath != "" {
+		modulePath = checkOptions.ModulePath
+	}
 	c := &Checker{
 		diagnostics:    []Diagnostic{},
 		input:          input,
 		filePath:       filePath,
-		modulePath:     filePath,
+		modulePath:     modulePath,
 		moduleResolver: moduleResolver,
-		options:        normalizeCheckOptions(moduleResolver, options),
+		options:        checkOptions,
 		program: &Program{
 			Imports:       map[string]Module{},
 			Statements:    []Statement{},

--- a/compiler/checker/checker.go
+++ b/compiler/checker/checker.go
@@ -164,7 +164,15 @@ func derefTypeSeen(t Type, seen map[Type]bool) Type {
 				fieldsChanged = true
 			}
 		}
-		if !fieldsChanged {
+		newTypeArgs := make([]Type, len(typ.TypeArgs))
+		typeArgsChanged := false
+		for i, typeArg := range typ.TypeArgs {
+			newTypeArgs[i] = derefTypeSeen(typeArg, seen)
+			if newTypeArgs[i] != typeArg {
+				typeArgsChanged = true
+			}
+		}
+		if !fieldsChanged && !typeArgsChanged {
 			return typ
 		}
 		return &StructDef{
@@ -174,6 +182,7 @@ func derefTypeSeen(t Type, seen map[Type]bool) Type {
 			Self:          typ.Self,
 			Traits:        typ.Traits,
 			GenericParams: append([]string(nil), typ.GenericParams...),
+			TypeArgs:      newTypeArgs,
 			Private:       typ.Private,
 		}
 	case *FunctionDef:
@@ -205,6 +214,7 @@ func derefTypeSeen(t Type, seen map[Type]bool) Type {
 			Mutates:                 typ.Mutates,
 			IsTest:                  typ.IsTest,
 			Private:                 typ.Private,
+			GenericBindings:         cloneTypeMap(typ.GenericBindings),
 		}
 	case *ExternType:
 		if len(typ.TypeArgs) == 0 {
@@ -494,7 +504,7 @@ func (c *Checker) findModuleByPath(path string) Module {
 func namedTypeRequiresTypeArguments(t Type) bool {
 	switch typ := t.(type) {
 	case *StructDef:
-		return len(typ.GenericParams) > 0 || hasGenericsInType(typ)
+		return (len(typ.GenericParams) > 0 && len(typ.TypeArgs) == 0) || hasGenericsInType(typ)
 	case *ExternType:
 		return len(typ.GenericParams) > 0 || hasGenericsInType(typ)
 	default:
@@ -527,11 +537,16 @@ func collectGenericsFromType(t Type, params *[]string, seen map[string]bool) {
 		collectGenericsFromType(t.val, params, seen)
 		collectGenericsFromType(t.err, params, seen)
 	case *StructDef:
-		for _, genericName := range t.GenericParams {
-			if !seen[genericName] {
-				*params = append(*params, genericName)
-				seen[genericName] = true
+		if len(t.TypeArgs) == 0 {
+			for _, genericName := range t.GenericParams {
+				if !seen[genericName] {
+					*params = append(*params, genericName)
+					seen[genericName] = true
+				}
 			}
+		}
+		for _, typeArg := range t.TypeArgs {
+			collectGenericsFromType(typeArg, params, seen)
 		}
 	case *ExternType:
 		for _, genericName := range t.GenericParams {
@@ -852,6 +867,9 @@ func (c *Checker) explicitMethodGenericParams(fnDef *FunctionDef, subject Type) 
 func formatTypeForDisplay(t Type) string {
 	// For StructDef with generic fields, show type parameters
 	if structDef, ok := t.(*StructDef); ok {
+		if len(structDef.TypeArgs) > 0 {
+			return structDef.String()
+		}
 		if resultType, hasResult := structDef.Fields["result"]; hasResult {
 			// The result field's type indicates the generic parameter
 			return fmt.Sprintf("%s<%s>", structDef.String(), resultType.String())
@@ -2000,15 +2018,15 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 	var structDefCopy *StructDef
 	var genericScope *SymbolTable
 	if structType.hasGenerics() {
-		// Extract generic parameter names from struct fields
-		genericNames := make(map[string]bool)
-		for _, fieldType := range structType.Fields {
-			extractGenericNames(fieldType, genericNames)
-		}
-
-		genericParams := make([]string, 0, len(genericNames))
-		for name := range genericNames {
-			genericParams = append(genericParams, name)
+		genericParams := append([]string(nil), structType.GenericParams...)
+		if len(genericParams) == 0 {
+			genericNames := make(map[string]bool)
+			for _, fieldType := range structType.Fields {
+				extractGenericNames(fieldType, genericNames)
+			}
+			for name := range genericNames {
+				genericParams = append(genericParams, name)
+			}
 		}
 
 		// Create generic scope and fresh struct copy
@@ -2153,13 +2171,22 @@ func (c *Checker) validateStructInstance(structType *StructDef, properties []par
 	instance.Fields = fields
 	instance.FieldTypes = fieldTypes
 	// Store the refined struct definition (with resolved generics) as the instance's type
+	typeArgs := make([]Type, len(structDefCopy.TypeArgs))
+	for i, typeArg := range structDefCopy.TypeArgs {
+		typeArgs[i] = derefType(typeArg)
+	}
+	genericParams := append([]string(nil), structDefCopy.GenericParams...)
+	if len(genericParams) == 0 {
+		genericParams = nil
+	}
 	instance._type = &StructDef{
 		Name:          structDefCopy.Name,
 		ModulePath:    structDefCopy.ModulePath,
 		Fields:        fieldTypes,
 		Self:          structDefCopy.Self,
 		Traits:        structDefCopy.Traits,
-		GenericParams: structDefCopy.GenericParams,
+		GenericParams: genericParams,
+		TypeArgs:      typeArgs,
 		Private:       structDefCopy.Private,
 	}
 	instance.StructType = instance._type
@@ -2446,6 +2473,12 @@ func (c *Checker) extractGenericBindingsFromSpecializedStruct(originalDef, speci
 		return bindings
 	}
 
+	for i, param := range originalDef.GenericParams {
+		if i < len(specializedDef.TypeArgs) {
+			bindings[param] = derefType(specializedDef.TypeArgs[i])
+		}
+	}
+
 	// Now compare original field types with specialized field types
 	// For each field that contains a generic in the original, extract its resolved type
 	for fieldName, originalFieldType := range originalDef.Fields {
@@ -2499,6 +2532,11 @@ func bindGenericTypes(original Type, specialized Type, bindings map[string]Type)
 		}
 	case *StructDef:
 		if spec, ok := specialized.(*StructDef); ok {
+			for i, originalArg := range orig.TypeArgs {
+				if i < len(spec.TypeArgs) {
+					bindGenericTypes(originalArg, spec.TypeArgs[i], bindings)
+				}
+			}
 			for name, originalField := range orig.Fields {
 				if specializedField, ok := spec.Fields[name]; ok {
 					bindGenericTypes(originalField, specializedField, bindings)
@@ -4681,6 +4719,13 @@ func bindInferredTypeVars(expected Type, actual Type) {
 		}
 	case *StructDef:
 		if act, ok := actual.(*StructDef); ok && exp.Name == act.Name && !namedTypeOwnersDiffer(exp.ModulePath, act.ModulePath) {
+			limit := len(exp.TypeArgs)
+			if len(act.TypeArgs) < limit {
+				limit = len(act.TypeArgs)
+			}
+			for i := 0; i < limit; i++ {
+				bindInferredTypeVars(exp.TypeArgs[i], act.TypeArgs[i])
+			}
 			for fieldName, expectedField := range exp.Fields {
 				if actualField, ok := act.Fields[fieldName]; ok {
 					bindInferredTypeVars(expectedField, actualField)
@@ -5273,6 +5318,19 @@ func inferGenericBindingsFromTypes(original, specialized Type, bindings map[stri
 			inferGenericBindingsFromTypes(orig.Key(), spec.Key(), bindings)
 			inferGenericBindingsFromTypes(orig.Value(), spec.Value(), bindings)
 		}
+	case *StructDef:
+		if spec, ok := specialized.(*StructDef); ok && orig.Name == spec.Name && !namedTypeOwnersDiffer(orig.ModulePath, spec.ModulePath) {
+			for i, typeArg := range orig.TypeArgs {
+				if i < len(spec.TypeArgs) {
+					inferGenericBindingsFromTypes(typeArg, spec.TypeArgs[i], bindings)
+				}
+			}
+			for fieldName, fieldType := range orig.Fields {
+				if specializedField, ok := spec.Fields[fieldName]; ok {
+					inferGenericBindingsFromTypes(fieldType, specializedField, bindings)
+				}
+			}
+		}
 	case *FunctionDef:
 		if spec, ok := specialized.(*FunctionDef); ok {
 			for i, param := range orig.Parameters {
@@ -5613,6 +5671,9 @@ func (c *Checker) resolveGenericFunction(fnDef *FunctionDef, args []Expression, 
 // with the concrete type, making the binding immediately visible to all callers.
 // This enables single-pass argument checking where later arguments see bindings from earlier ones.
 func (c *Checker) unifyTypes(expected Type, actual Type, genericScope *SymbolTable) error {
+	expected = deref(expected)
+	actual = deref(actual)
+
 	switch expectedType := expected.(type) {
 	case *TypeVar:
 		// Generic type - bind it to the actual type using in-place mutation.
@@ -5667,8 +5728,13 @@ func (c *Checker) unifyTypes(expected Type, actual Type, genericScope *SymbolTab
 		return fmt.Errorf("expected list type, got %T", actual)
 	case *StructDef:
 		actualStruct, ok := actual.(*StructDef)
-		if !ok || expectedType.Name != actualStruct.Name || namedTypeOwnersDiffer(expectedType.ModulePath, actualStruct.ModulePath) {
+		if !ok || expectedType.Name != actualStruct.Name || namedTypeOwnersDiffer(expectedType.ModulePath, actualStruct.ModulePath) || len(expectedType.TypeArgs) != len(actualStruct.TypeArgs) {
 			return fmt.Errorf("type mismatch: expected %s, got %s", expected.String(), actual.String())
+		}
+		for i := range expectedType.TypeArgs {
+			if err := c.unifyTypes(expectedType.TypeArgs[i], actualStruct.TypeArgs[i], genericScope); err != nil {
+				return err
+			}
 		}
 		for fieldName, expectedField := range expectedType.Fields {
 			actualField, ok := actualStruct.Fields[fieldName]

--- a/compiler/checker/checker_test.go
+++ b/compiler/checker/checker_test.go
@@ -2467,6 +2467,16 @@ func TestGenerics(t *testing.T) {
 			},
 		},
 		{
+			name: "Explicit type arguments reject mismatched arguments",
+			input: `
+			  fn identity(of: $T) $T { of }
+				identity<Str>(1)
+			`,
+			diagnostics: []checker.Diagnostic{
+				{Kind: checker.Error, Message: "type mismatch: expected Str, got Int"},
+			},
+		},
+		{
 			name: "Providing type arguments to methods",
 			input: `
 				use ard/json

--- a/compiler/checker/functions.go
+++ b/compiler/checker/functions.go
@@ -177,6 +177,7 @@ func (c *Checker) validateAsyncEval(fnNode parse.Expression) *FiberEval {
 					ModulePath:    fiberStructDef.ModulePath,
 					Fields:        make(map[string]Type),
 					GenericParams: append([]string(nil), fiberStructDef.GenericParams...),
+					TypeArgs:      []Type{returnType},
 					Private:       fiberStructDef.Private,
 				}
 

--- a/compiler/checker/method_identity_test.go
+++ b/compiler/checker/method_identity_test.go
@@ -285,3 +285,205 @@ func TestClosureCannotUseOuterGenericAsExplicitTypeArg(t *testing.T) {
 		t.Fatalf("first diagnostic = %q, want unbound generic type arg", got)
 	}
 }
+
+func TestGenericStructReceiverBindingInExplicitCallbackParameter(t *testing.T) {
+	result := parse.Parse([]byte(`
+		struct State {
+			_type: fn($T) Void
+		}
+
+		struct Widget {}
+		struct Ctx {}
+
+		impl State {
+			fn value() $T {
+				panic("x")
+			}
+		}
+
+		fn make<$T>(init: fn(Ctx, State<$T>) $T, build: fn(Ctx, State<$T>) Widget) Widget {
+			Widget{}
+		}
+
+		struct Model { n: Int }
+
+		fn main() {
+			let _ = make<Model>(
+				init: fn(_ctx: Ctx, _state: State<Model>) Model { Model{n: 0} },
+				build: fn(_ctx: Ctx, state: State<Model>) Widget {
+					let m: Model = state.value()
+					Widget{}
+				},
+			)
+		}
+	`), "test.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	c := New("test.ard", result.Program, nil)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+}
+
+func TestGenericStructReceiverBindingInInferredCallbackParameter(t *testing.T) {
+	result := parse.Parse([]byte(`
+		struct State {
+			_type: fn($T) Void
+		}
+
+		struct Widget {}
+		struct Ctx {}
+
+		impl State {
+			fn value() $T {
+				panic("x")
+			}
+		}
+
+		fn make<$T>(init: fn(Ctx, State<$T>) $T, build: fn(Ctx, State<$T>) Widget) Widget {
+			Widget{}
+		}
+
+		struct Model { n: Int }
+
+		fn main() {
+			let _ = make<Model>(
+				init: fn(_ctx, _state) { Model{n: 0} },
+				build: fn(_ctx, state) {
+					let m: Model = state.value()
+					Widget{}
+				},
+			)
+		}
+	`), "test.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	c := New("test.ard", result.Program, nil)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+}
+
+func TestGenericStructReceiverBindingInCallbackParameterStillRejectsMismatch(t *testing.T) {
+	result := parse.Parse([]byte(`
+		struct State {
+			_type: fn($T) Void
+		}
+
+		struct Widget {}
+		struct Ctx {}
+
+		impl State {
+			fn value() $T {
+				panic("x")
+			}
+		}
+
+		fn make<$T>(init: fn(Ctx, State<$T>) $T, build: fn(Ctx, State<$T>) Widget) Widget {
+			Widget{}
+		}
+
+		struct Model { n: Int }
+		struct Other { s: Str }
+
+		fn main() {
+			let _ = make<Model>(
+				init: fn(_ctx: Ctx, _state: State<Model>) Model { Model{n: 0} },
+				build: fn(_ctx: Ctx, state: State<Other>) Widget {
+					Widget{}
+				},
+			)
+		}
+	`), "test.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	c := New("test.ard", result.Program, nil)
+	c.Check()
+	if !c.HasErrors() {
+		t.Fatal("checker succeeded; expected callback state type mismatch")
+	}
+	if got := c.Diagnostics()[0].Message; got != "type mismatch: expected Model, got Other" {
+		t.Fatalf("first diagnostic = %q, want callback state type mismatch", got)
+	}
+}
+
+func TestExplicitGenericStructCanUseTypeParamOnlyInMethods(t *testing.T) {
+	result := parse.Parse([]byte(`
+		struct State<$T> {
+			handle: Int
+		}
+
+		struct Widget {}
+		struct Ctx {}
+
+		impl State {
+			fn value() $T {
+				panic("x")
+			}
+
+			fn set(mutate: fn(mut $T)) {
+			}
+		}
+
+		fn make<$T>(init: fn(Ctx, State<$T>) $T, build: fn(Ctx, State<$T>) Widget) Widget {
+			Widget{}
+		}
+
+		struct Model { n: Int }
+
+		fn main() {
+			let _ = make<Model>(
+				init: fn(_ctx: Ctx, _state: State<Model>) Model { Model{n: 0} },
+				build: fn(_ctx: Ctx, state: State<Model>) Widget {
+					let model = state.value()
+					state.set(fn(mut next: Model) {
+						next.n = model.n + 1
+					})
+					Widget{}
+				},
+			)
+		}
+	`), "test.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	c := New("test.ard", result.Program, nil)
+	c.Check()
+	if c.HasErrors() {
+		t.Fatalf("checker diagnostics: %v", c.Diagnostics())
+	}
+}
+
+func TestExplicitGenericStructTypeArgumentsRemainDistinctWithoutGenericFields(t *testing.T) {
+	result := parse.Parse([]byte(`
+		struct State<$T> {
+			handle: Int
+		}
+
+		struct Model { n: Int }
+		struct Other { s: Str }
+
+		fn consume(state: State<Model>) {}
+
+		fn main() {
+			let other: State<Other> = State{handle: 1}
+			consume(other)
+		}
+	`), "test.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("parse error: %s", result.Errors[0].Message)
+	}
+	c := New("test.ard", result.Program, nil)
+	c.Check()
+	if !c.HasErrors() {
+		t.Fatal("checker succeeded; expected distinct explicit struct type arguments to mismatch")
+	}
+	if got := c.Diagnostics()[0].Message; got != "Type mismatch: Expected State<Model>, got State<Other>" {
+		t.Fatalf("first diagnostic = %q, want State<Model>/State<Other> mismatch", got)
+	}
+}

--- a/compiler/checker/nodes.go
+++ b/compiler/checker/nodes.go
@@ -1281,6 +1281,7 @@ type StructDef struct {
 	Self          string
 	Traits        []*Trait
 	GenericParams []string
+	TypeArgs      []Type
 	Private       bool
 }
 
@@ -1291,7 +1292,14 @@ func (def *StructDef) name() string {
 }
 
 func (def StructDef) String() string {
-	return def.name()
+	if len(def.TypeArgs) == 0 || strings.Contains(def.Name, "<") {
+		return def.name()
+	}
+	parts := make([]string, len(def.TypeArgs))
+	for i, arg := range def.TypeArgs {
+		parts[i] = arg.String()
+	}
+	return fmt.Sprintf("%s<%s>", def.name(), strings.Join(parts, ", "))
 }
 func (def StructDef) get(name string) Type {
 	// Struct type identity describes value shape. Method namespaces live on the
@@ -1306,6 +1314,14 @@ func (def StructDef) equal(other Type) bool {
 }
 
 func (def StructDef) hasGenerics() bool {
+	if len(def.GenericParams) > 0 {
+		return true
+	}
+	for _, typeArg := range def.TypeArgs {
+		if hasGenericsInType(typeArg) {
+			return true
+		}
+	}
 	for _, fieldType := range def.Fields {
 		if hasGenericsInType(fieldType) {
 			return true

--- a/compiler/checker/scope.go
+++ b/compiler/checker/scope.go
@@ -1,8 +1,9 @@
 package checker
 
-import "slices"
-
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 type SymbolTable struct {
 	parent  *SymbolTable
@@ -253,6 +254,11 @@ func hasGenericsInTypeSeen(t Type, seen map[Type]struct{}) bool {
 	case *Union:
 		return slices.ContainsFunc(t.Types, func(member Type) bool { return hasGenericsInTypeSeen(member, seen) })
 	case *StructDef:
+		for _, typeArg := range t.TypeArgs {
+			if hasGenericsInTypeSeen(typeArg, seen) {
+				return true
+			}
+		}
 		for _, fieldType := range t.Fields {
 			if hasGenericsInTypeSeen(fieldType, seen) {
 				return true
@@ -361,13 +367,19 @@ func replaceGeneric(t Type, genericName string, concreteType Type) Type {
 		if !anyChanged {
 			return t
 		}
+		newTypeArgs := make([]Type, len(t.TypeArgs))
+		for i, typeArg := range t.TypeArgs {
+			newTypeArgs[i] = replaceGeneric(typeArg, genericName, concreteType)
+		}
 		return &StructDef{
-			Name:       t.Name,
-			ModulePath: t.ModulePath,
-			Fields:     newFields,
-			Self:       t.Self,
-			Traits:     t.Traits,
-			Private:    t.Private,
+			Name:          t.Name,
+			ModulePath:    t.ModulePath,
+			Fields:        newFields,
+			Self:          t.Self,
+			Traits:        t.Traits,
+			GenericParams: append([]string(nil), t.GenericParams...),
+			TypeArgs:      newTypeArgs,
+			Private:       t.Private,
 		}
 	case *ExternType:
 		if len(t.TypeArgs) == 0 {
@@ -406,6 +418,11 @@ func hasGeneric(t Type, genericName string) bool {
 	case *MutableRef:
 		return hasGeneric(t.of, genericName)
 	case *StructDef:
+		for _, typeArg := range t.TypeArgs {
+			if hasGeneric(typeArg, genericName) {
+				return true
+			}
+		}
 		for _, fieldType := range t.Fields {
 			if hasGeneric(fieldType, genericName) {
 				return true
@@ -461,25 +478,39 @@ func copyStructWithTypeVarMapSeen(structDef *StructDef, typeVarMap map[string]*T
 	}
 	newFields := make(map[string]Type)
 	structCopy := &StructDef{
-		Name:       structDef.Name,
-		ModulePath: structDef.ModulePath,
-		Fields:     newFields,
-		Self:       structDef.Self,
-		Traits:     structDef.Traits,
-		Private:    structDef.Private,
+		Name:          structDef.Name,
+		ModulePath:    structDef.ModulePath,
+		Fields:        newFields,
+		Self:          structDef.Self,
+		Traits:        structDef.Traits,
+		GenericParams: append([]string(nil), structDef.GenericParams...),
+		Private:       structDef.Private,
 	}
 	seen[structDef] = structCopy
 	for name, fieldType := range structDef.Fields {
 		newFields[name] = copyTypeWithTypeVarMapSeen(fieldType, typeVarMap, seen)
 	}
-	genericParams := []string{}
-	seenGenerics := map[string]bool{}
-	seenTypes := map[Type]bool{}
-	for _, fieldType := range newFields {
-		collectUnboundGenericsFromType(fieldType, &genericParams, seenGenerics, seenTypes)
-	}
-	structCopy.GenericParams = genericParams
+	structCopy.TypeArgs = copyStructTypeArgsWithTypeVarMap(structDef, typeVarMap, seen)
 	return structCopy
+}
+
+func copyStructTypeArgsWithTypeVarMap(structDef *StructDef, typeVarMap map[string]*TypeVar, seenStructs map[*StructDef]*StructDef) []Type {
+	if len(structDef.GenericParams) == 0 {
+		return nil
+	}
+	out := make([]Type, len(structDef.GenericParams))
+	for i, param := range structDef.GenericParams {
+		if i < len(structDef.TypeArgs) {
+			out[i] = copyTypeWithTypeVarMapSeen(structDef.TypeArgs[i], typeVarMap, seenStructs)
+			continue
+		}
+		if typeVar, ok := typeVarMap[param]; ok {
+			out[i] = derefType(typeVar)
+		} else {
+			out[i] = &TypeVar{name: param}
+		}
+	}
+	return out
 }
 
 func collectUnboundGenericsFromType(t Type, params *[]string, seenGenerics map[string]bool, seenTypes map[Type]bool) {

--- a/compiler/checker/top_level_types.go
+++ b/compiler/checker/top_level_types.go
@@ -123,6 +123,12 @@ func topLevelTypeDeclarationName(stmt parse.Statement) (string, parse.Location, 
 func genericParamsFromStructDeclaration(decl *parse.StructDefinition) []string {
 	params := []string{}
 	seen := map[string]bool{}
+	for _, param := range decl.TypeParams {
+		if !seen[param] {
+			params = append(params, param)
+			seen[param] = true
+		}
+	}
 	for _, field := range decl.Fields {
 		collectGenericParamsFromDeclaredType(field.Type, &params, seen)
 	}
@@ -264,10 +270,9 @@ func (c *Checker) populateStructDefinition(def *StructDef, decl *parse.StructDef
 		def.Fields[field.Name.Name] = fieldType
 		collectGenericsFromType(fieldType, &resolvedGenericParams, seenGenerics)
 	}
-	if len(resolvedGenericParams) == 0 {
+	def.GenericParams = appendUniqueStrings(declaredGenericParams, resolvedGenericParams...)
+	if len(def.GenericParams) == 0 {
 		def.GenericParams = nil
-	} else {
-		def.GenericParams = resolvedGenericParams
 	}
 	if c.resolvedTopLevelStructs == nil {
 		c.resolvedTopLevelStructs = map[string]bool{}

--- a/compiler/checker/type_equal.go
+++ b/compiler/checker/type_equal.go
@@ -200,8 +200,13 @@ func equalExternalFunctionDefSeen(left ExternalFunctionDef, right Type, seen map
 
 func equalStructDefSeen(left StructDef, right Type, seen map[typeEqualKey]struct{}) bool {
 	r, ok := right.(*StructDef)
-	if !ok || left.Name != r.Name || namedTypeOwnersDiffer(left.ModulePath, r.ModulePath) || len(left.Fields) != len(r.Fields) {
+	if !ok || left.Name != r.Name || namedTypeOwnersDiffer(left.ModulePath, r.ModulePath) || len(left.Fields) != len(r.Fields) || len(left.TypeArgs) != len(r.TypeArgs) {
 		return false
+	}
+	for i := range left.TypeArgs {
+		if !equalTypesSeen(left.TypeArgs[i], r.TypeArgs[i], seen) {
+			return false
+		}
 	}
 	for name, fieldType := range left.Fields {
 		otherFieldType, ok := r.Fields[name]

--- a/compiler/formatter/formatter_test.go
+++ b/compiler/formatter/formatter_test.go
@@ -105,6 +105,11 @@ func TestFormat(t *testing.T) {
 			output: "extern type Promise<$T>\n",
 		},
 		{
+			name:   "formats generic struct declaration",
+			input:  "struct State<$T>{handle:Int}\n",
+			output: "struct State<$T> {\n  handle: Int,\n}\n",
+		},
+		{
 			name:   "formats private extern type declaration",
 			input:  "private extern type ConnectionPtr\n",
 			output: "private extern type ConnectionPtr\n",

--- a/compiler/formatter/printer.go
+++ b/compiler/formatter/printer.go
@@ -388,7 +388,7 @@ func (p printer) renderStructDefinitionDoc(node *parse.StructDefinition) doc {
 	if node.Private {
 		prefix = "private "
 	}
-	header := prefix + "struct " + node.Name.Name
+	header := prefix + "struct " + node.Name.Name + p.renderTypeParams(node.TypeParams)
 	if len(node.Fields) == 0 && len(node.Comments) == 0 {
 		return dText(header + " {}")
 	}

--- a/compiler/go/backend.go
+++ b/compiler/go/backend.go
@@ -334,7 +334,7 @@ func writeProjectFFICompanions(dir string, program *air.Program, projectInfo *ch
 	if rootExists && len(dirMatches) > 0 {
 		return fmt.Errorf("project Go FFI must use either %s or %s, not both", rootFile, filepath.Join(projectInfo.RootPath, "ffi", "*.go"))
 	}
-	ffiDir := filepath.Join(dir, "projectffi")
+	ffiDir := filepath.Join(dir, projectFFIPackageAlias(projectInfo))
 	if rootExists {
 		if err := copyProjectFFIFile(rootFile, filepath.Join(ffiDir, filepath.Base(rootFile))); err != nil {
 			return err
@@ -458,50 +458,70 @@ func programUsesProjectFFI(program *air.Program, projectInfo *checker.ProjectInf
 		if _, ok := dependencyAliasForModulePath(typ.ModulePath, projectInfo); ok {
 			continue
 		}
-		if strings.Contains(typ.ExternBinding, "projectffi.") || externBindingUsesUnqualifiedProjectFFIType(typ.ExternBinding) {
+		if externBindingUsesProjectFFIType(typ.ExternBinding, projectInfo) {
 			return true
 		}
 	}
 	return false
 }
 
-func externBindingUsesUnqualifiedProjectFFIType(binding string) bool {
+func externBindingUsesProjectFFIType(binding string, projectInfo *checker.ProjectInfo) bool {
 	expr, err := parser.ParseExpr(binding)
 	if err != nil {
 		return false
 	}
-	return exprUsesUnqualifiedProjectFFIType(expr)
+	return exprUsesProjectFFIType(expr, projectFFIPackageAlias(projectInfo))
 }
 
-func exprUsesUnqualifiedProjectFFIType(expr ast.Expr) bool {
+func exprUsesProjectFFIType(expr ast.Expr, projectAlias string) bool {
 	switch node := expr.(type) {
 	case *ast.Ident:
 		return ast.IsExported(node.Name) && !isPredeclaredGoTypeName(node.Name)
 	case *ast.StarExpr:
-		return exprUsesUnqualifiedProjectFFIType(node.X)
+		return exprUsesProjectFFIType(node.X, projectAlias)
 	case *ast.ArrayType:
-		return exprUsesUnqualifiedProjectFFIType(node.Elt)
+		return exprUsesProjectFFIType(node.Elt, projectAlias)
 	case *ast.MapType:
-		return exprUsesUnqualifiedProjectFFIType(node.Key) || exprUsesUnqualifiedProjectFFIType(node.Value)
+		return exprUsesProjectFFIType(node.Key, projectAlias) || exprUsesProjectFFIType(node.Value, projectAlias)
 	case *ast.IndexExpr:
-		return exprUsesUnqualifiedProjectFFIType(node.X) || exprUsesUnqualifiedProjectFFIType(node.Index)
+		return exprUsesProjectFFIType(node.X, projectAlias) || exprUsesProjectFFIType(node.Index, projectAlias)
 	case *ast.IndexListExpr:
-		if exprUsesUnqualifiedProjectFFIType(node.X) {
+		if exprUsesProjectFFIType(node.X, projectAlias) {
 			return true
 		}
 		for _, index := range node.Indices {
-			if exprUsesUnqualifiedProjectFFIType(index) {
+			if exprUsesProjectFFIType(index, projectAlias) {
 				return true
 			}
 		}
 		return false
 	case *ast.ParenExpr:
-		return exprUsesUnqualifiedProjectFFIType(node.X)
+		return exprUsesProjectFFIType(node.X, projectAlias)
 	case *ast.SelectorExpr:
-		return false
+		ident, ok := node.X.(*ast.Ident)
+		return ok && ident.Name == projectAlias
 	default:
 		return false
 	}
+}
+
+func projectFFIPackageAlias(projectInfo *checker.ProjectInfo) string {
+	name := "project"
+	if projectInfo != nil {
+		name = sanitizeName(projectInfo.ProjectName)
+	}
+	if !token.IsIdentifier(name) {
+		return "project"
+	}
+	return name
+}
+
+func projectFFIImportPath(projectInfo *checker.ProjectInfo) string {
+	return "generated/" + projectFFIPackageAlias(projectInfo)
+}
+
+func registerProjectFFIImports(imports map[string]string, projectInfo *checker.ProjectInfo) {
+	imports[projectFFIPackageAlias(projectInfo)] = projectFFIImportPath(projectInfo)
 }
 
 func projectHasFFICompanions(projectInfo *checker.ProjectInfo) bool {

--- a/compiler/go/backend.go
+++ b/compiler/go/backend.go
@@ -476,7 +476,7 @@ func externBindingUsesProjectFFIType(binding string, projectInfo *checker.Projec
 func exprUsesProjectFFIType(expr ast.Expr, projectAlias string) bool {
 	switch node := expr.(type) {
 	case *ast.Ident:
-		return ast.IsExported(node.Name) && !isPredeclaredGoTypeName(node.Name)
+		return false
 	case *ast.StarExpr:
 		return exprUsesProjectFFIType(node.X, projectAlias)
 	case *ast.ArrayType:

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -2,10 +2,11 @@ package gotarget
 
 import (
 	"fmt"
+	"go/ast"
+	"go/token"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -17,7 +18,274 @@ import (
 	"github.com/akonwi/ard/version"
 )
 
-func TestGenerateSourcesKeepsCrossModuleNestedStructLiteralFields(t *testing.T) {
+func lowerProgramAST(t testing.TB, program *air.Program, options Options) map[string]*ast.File {
+	t.Helper()
+	files, err := lowerProgram(program, options)
+	if err != nil {
+		t.Fatalf("lower program: %v", err)
+	}
+	return files
+}
+
+func astFilesHaveImport(files map[string]*ast.File, alias string, importPath string) bool {
+	for _, file := range files {
+		if astFileHasImport(file, alias, importPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func astFileHasImport(file *ast.File, alias string, importPath string) bool {
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.IMPORT {
+			continue
+		}
+		for _, specNode := range gen.Specs {
+			spec, ok := specNode.(*ast.ImportSpec)
+			if !ok || spec.Path == nil || strings.Trim(spec.Path.Value, "\"") != importPath {
+				continue
+			}
+			actualAlias := ""
+			if spec.Name != nil {
+				actualAlias = spec.Name.Name
+			}
+			if actualAlias == alias {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func astFilesContain(files map[string]*ast.File, match func(ast.Node) bool) bool {
+	for _, file := range files {
+		found := false
+		ast.Inspect(file, func(node ast.Node) bool {
+			if match(node) {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
+func astFilesHaveSelector(files map[string]*ast.File, qualifier string, selectorName string) bool {
+	for _, file := range files {
+		found := false
+		ast.Inspect(file, func(node ast.Node) bool {
+			selector, ok := node.(*ast.SelectorExpr)
+			if !ok || selector.Sel == nil || selector.Sel.Name != selectorName {
+				return true
+			}
+			ident, ok := selector.X.(*ast.Ident)
+			if ok && ident.Name == qualifier {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
+func astFilesHaveCall(files map[string]*ast.File, name string) bool {
+	return astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		return astCallName(call) == name
+	})
+}
+
+func astFilesHaveFuncWithPrefix(files map[string]*ast.File, prefix string) bool {
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if ok && fn.Name != nil && strings.HasPrefix(fn.Name.Name, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func astFilesHaveFuncContaining(files map[string]*ast.File, part string) bool {
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if ok && fn.Name != nil && strings.Contains(fn.Name.Name, part) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func astFilesHaveTypeSpec(files map[string]*ast.File, name string) bool {
+	return astFilesContain(files, func(node ast.Node) bool {
+		typ, ok := node.(*ast.TypeSpec)
+		return ok && typ.Name != nil && typ.Name.Name == name
+	})
+}
+
+func astFilesHaveTypeSwitchCase(files map[string]*ast.File, typeName string) bool {
+	return astFilesContain(files, func(node ast.Node) bool {
+		clause, ok := node.(*ast.CaseClause)
+		if !ok {
+			return false
+		}
+		for _, expr := range clause.List {
+			if astExprName(expr) == typeName {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func astFilesHaveValueSpec(files map[string]*ast.File, name string) bool {
+	return astFilesContain(files, func(node ast.Node) bool {
+		value, ok := node.(*ast.ValueSpec)
+		if !ok {
+			return false
+		}
+		for _, ident := range value.Names {
+			if ident.Name == name {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func astCallName(call *ast.CallExpr) string {
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return fun.Name
+	case *ast.SelectorExpr:
+		if ident, ok := fun.X.(*ast.Ident); ok {
+			return ident.Name + "." + fun.Sel.Name
+		}
+		return fun.Sel.Name
+	case *ast.IndexExpr:
+		return astExprName(fun.X)
+	case *ast.IndexListExpr:
+		return astExprName(fun.X)
+	}
+	return ""
+}
+
+func astExprName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		if ident, ok := e.X.(*ast.Ident); ok {
+			return ident.Name + "." + e.Sel.Name
+		}
+		return e.Sel.Name
+	case *ast.IndexExpr:
+		return astExprName(e.X)
+	case *ast.IndexListExpr:
+		return astExprName(e.X)
+	case *ast.StarExpr:
+		return "*" + astExprName(e.X)
+	case *ast.ArrayType:
+		return "[]" + astExprName(e.Elt)
+	}
+	return ""
+}
+
+func astFilesFunc(files map[string]*ast.File, name string) (*ast.FuncDecl, bool) {
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if ok && fn.Name != nil && fn.Name.Name == name {
+				return fn, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func astFuncHasBlankAssignString(fn *ast.FuncDecl, value string) bool {
+	if fn == nil || fn.Body == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, lhs := range assign.Lhs {
+			ident, ok := lhs.(*ast.Ident)
+			if !ok || ident.Name != "_" || i >= len(assign.Rhs) {
+				continue
+			}
+			lit, ok := assign.Rhs[i].(*ast.BasicLit)
+			if ok && lit.Kind == token.STRING && lit.Value == value {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func astFuncHasReturnString(fn *ast.FuncDecl, value string) bool {
+	if fn == nil || fn.Body == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		ret, ok := node.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+		for _, result := range ret.Results {
+			lit, ok := result.(*ast.BasicLit)
+			if ok && lit.Kind == token.STRING && lit.Value == value {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func astFilesHaveEmptyStructType(files map[string]*ast.File) bool {
+	for _, file := range files {
+		found := false
+		ast.Inspect(file, func(node ast.Node) bool {
+			structType, ok := node.(*ast.StructType)
+			if ok && (structType.Fields == nil || len(structType.Fields.List) == 0) {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
+func TestLowerProgramKeepsCrossModuleNestedStructLiteralFields(t *testing.T) {
 	tempDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"nestlit\"\nard = \">= 0.13.0\"\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -71,29 +339,42 @@ fn main() {
 	if err != nil {
 		t.Fatalf("lower error: %v", err)
 	}
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesHaveFuncContaining(files, "__main") {
+		t.Fatal("generated AST missing main body")
 	}
-	source := ""
-	for _, data := range sources {
-		if strings.Contains(string(data), "x_0 :=") {
-			source = string(data)
-			break
+	if !astFilesContain(files, func(node ast.Node) bool {
+		kv, ok := node.(*ast.KeyValueExpr)
+		if !ok {
+			return false
 		}
+		key, keyOK := kv.Key.(*ast.Ident)
+		call, callOK := kv.Value.(*ast.CallExpr)
+		if !keyOK || key.Name != "padding" || !callOK || astCallName(call) != "ardruntime.Some" {
+			return false
+		}
+		indexed, ok := call.Fun.(*ast.IndexExpr)
+		return ok && astExprName(indexed.Index) == "nestlit_inner_types__Inner"
+	}) {
+		t.Fatal("generated AST missing cross-module nested optional struct literal field")
 	}
-	if source == "" {
-		t.Fatalf("generated sources missing main body: %#v", mapsKeys(sources))
-	}
-	if !strings.Contains(source, "padding:") || !strings.Contains(source, "runtime.Some[nestlit_inner_types__Inner]") {
-		t.Fatalf("generated source missing cross-module nested optional struct literal field:\n%s", source)
-	}
-	if !strings.Contains(source, `ard_io__print(any("after 2"))`) {
-		t.Fatalf("generated source truncated statements after nested struct literal:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !strings.Contains(astCallName(call), "ard_io__print") || len(call.Args) == 0 {
+			return false
+		}
+		inner, ok := call.Args[0].(*ast.CallExpr)
+		if !ok || astCallName(inner) != "any" || len(inner.Args) == 0 {
+			return false
+		}
+		lit, ok := inner.Args[0].(*ast.BasicLit)
+		return ok && lit.Value == `"after 2"`
+	}) {
+		t.Fatal("generated AST truncated statements after nested struct literal")
 	}
 }
 
-func TestGenerateSourcesTakesAddressOfLocalMutTraitArgs(t *testing.T) {
+func TestLowerProgramTakesAddressOfLocalMutTraitArgs(t *testing.T) {
 	program := lowerSource(t, `
 		struct Counter { value: Int }
 
@@ -121,17 +402,24 @@ func TestGenerateSourcesTakesAddressOfLocalMutTraitArgs(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
-	}
-	source := string(sources["test.go"])
-	if !regexp.MustCompile(`Doubler_Bumpable_poke\(_tmp_[0-9]+, &c_0\)`).MatchString(source) {
-		t.Fatalf("generated source missing address-of for local mutable trait dispatch arg:\n%s", source)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !strings.Contains(astCallName(call), "Doubler_Bumpable_poke") || len(call.Args) < 2 {
+			return false
+		}
+		addr, ok := call.Args[1].(*ast.UnaryExpr)
+		if !ok || addr.Op != token.AND {
+			return false
+		}
+		ident, identOK := addr.X.(*ast.Ident)
+		return identOK && ident.Name == "c_0"
+	}) {
+		t.Fatal("generated AST missing address-of for local mutable trait dispatch arg")
 	}
 }
 
-func TestGenerateSourcesPassesMutTraitArgsByPointer(t *testing.T) {
+func TestLowerProgramPassesMutTraitArgsByPointer(t *testing.T) {
 	program := lowerSource(t, `
 		struct Counter { value: Int }
 
@@ -157,20 +445,34 @@ func TestGenerateSourcesPassesMutTraitArgsByPointer(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !strings.Contains(astCallName(call), "Doubler_Bumpable_poke") || len(call.Args) < 2 {
+			return false
+		}
+		ident, ok := call.Args[1].(*ast.Ident)
+		return ok && ident.Name == "c"
+	}) {
+		t.Fatal("generated AST missing pointer trait dispatch arg")
 	}
-	source := string(sources["test.go"])
-	if !regexp.MustCompile(`Doubler_Bumpable_poke\(_tmp_[0-9]+, c\)`).MatchString(source) {
-		t.Fatalf("generated source missing pointer trait dispatch arg:\n%s", source)
-	}
-	if regexp.MustCompile(`Doubler_Bumpable_poke\(_tmp_[0-9]+, \*c\)`).MatchString(source) {
-		t.Fatalf("generated source dereferences mutable trait dispatch arg:\n%s", source)
+	if astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !strings.Contains(astCallName(call), "Doubler_Bumpable_poke") || len(call.Args) < 2 {
+			return false
+		}
+		star, ok := call.Args[1].(*ast.StarExpr)
+		if !ok {
+			return false
+		}
+		ident, identOK := star.X.(*ast.Ident)
+		return identOK && ident.Name == "c"
+	}) {
+		t.Fatal("generated AST dereferences mutable trait dispatch arg")
 	}
 }
 
-func TestGenerateSourcesDereferencesMutParamForNonMutMethodCall(t *testing.T) {
+func TestLowerProgramDereferencesMutParamForNonMutMethodCall(t *testing.T) {
 	program := lowerSource(t, `
 		struct Box {
 			value: Int,
@@ -192,16 +494,30 @@ func TestGenerateSourcesDereferencesMutParamForNonMutMethodCall(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !strings.Contains(astCallName(call), "Box_bump") || len(call.Args) == 0 {
+			return false
+		}
+		ident, ok := call.Args[0].(*ast.Ident)
+		return ok && ident.Name == "b"
+	}) {
+		t.Fatal("generated AST missing mut method pointer call")
 	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "Box_bump(b)") {
-		t.Fatalf("generated source missing mut method pointer call:\n%s", source)
-	}
-	if !strings.Contains(source, "Box_peek(*b)") {
-		t.Fatalf("generated source missing deref for non-mut method call on mut param:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !strings.Contains(astCallName(call), "Box_peek") || len(call.Args) == 0 {
+			return false
+		}
+		star, ok := call.Args[0].(*ast.StarExpr)
+		if !ok {
+			return false
+		}
+		ident, identOK := star.X.(*ast.Ident)
+		return identOK && ident.Name == "b"
+	}) {
+		t.Fatal("generated AST missing deref for non-mut method call on mut param")
 	}
 }
 
@@ -239,7 +555,7 @@ func TestGenerateSourcesFormatsSimpleProgram(t *testing.T) {
 	}
 }
 
-func TestGenerateSourcesOmitsTestsUnlessIncluded(t *testing.T) {
+func TestLowerProgramOmitsTestsUnlessIncluded(t *testing.T) {
 	result := parse.Parse([]byte(`
 		fn main() Int { 1 }
 		test fn check() Void!Str { Result::ok(()) }
@@ -257,49 +573,43 @@ func TestGenerateSourcesOmitsTestsUnlessIncluded(t *testing.T) {
 		t.Fatalf("lower with tests: %v", err)
 	}
 
-	productionSources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources production error = %v", err)
-	}
-	if strings.Contains(string(productionSources["test.go"]), "__check") {
-		t.Fatalf("production source includes test function:\n%s", productionSources["test.go"])
+	productionFiles := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if _, ok := astFilesFunc(productionFiles, "test_ard__check"); ok {
+		t.Fatal("production AST includes test function")
 	}
 
-	testSources, err := GenerateSources(program, Options{PackageName: "main", IncludeTests: true, SuppressMain: true})
-	if err != nil {
-		t.Fatalf("GenerateSources tests error = %v", err)
-	}
-	if !strings.Contains(string(testSources["test.go"]), "__check") {
-		t.Fatalf("test source missing test function:\n%s", testSources["test.go"])
+	testFiles := lowerProgramAST(t, program, Options{PackageName: "main", IncludeTests: true, SuppressMain: true})
+	if _, ok := astFilesFunc(testFiles, "test_ard__check"); !ok {
+		t.Fatal("test AST missing test function")
 	}
 }
 
-func TestGenerateSourcesDiscardsFinalExprInVoidFunction(t *testing.T) {
+func TestLowerProgramDiscardsFinalExprInVoidFunction(t *testing.T) {
 	program := lowerSource(t, `
 		fn main() {
 			"Hello"
 		}
 	`)
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	fn, ok := astFilesFunc(files, "test_ard__main")
+	if !ok {
+		t.Fatal("generated AST missing main function")
 	}
-	source := string(sources["test.go"])
-	if !regexp.MustCompile(`func test_ard__main\(\) \{`).MatchString(source) {
-		t.Fatalf("generated source gives void main a return type:\n%s", source)
+	if fn.Type.Results != nil && len(fn.Type.Results.List) > 0 {
+		t.Fatalf("generated AST gives void main a return type: %#v", fn.Type.Results)
 	}
-	if !strings.Contains(source, `_ = "Hello"`) {
-		t.Fatalf("generated source does not discard final expression:\n%s", source)
+	if !astFuncHasBlankAssignString(fn, `"Hello"`) {
+		t.Fatalf("generated AST does not discard final expression: %#v", fn.Body)
 	}
-	if strings.Contains(source, `return "Hello"`) {
-		t.Fatalf("generated source returns final expression from void function:\n%s", source)
+	if astFuncHasReturnString(fn, `"Hello"`) {
+		t.Fatalf("generated AST returns final expression from void function: %#v", fn.Body)
 	}
-	if strings.Contains(source, "struct{}") || strings.Contains(source, "struct {}") {
-		t.Fatalf("generated source still uses anonymous empty struct for Void:\n%s", source)
+	if astFilesHaveEmptyStructType(files) {
+		t.Fatal("generated AST still uses anonymous empty struct for Void")
 	}
 }
 
-func TestGenerateSourcesUsesRuntimeVoidForVoidResultValues(t *testing.T) {
+func TestLowerProgramUsesRuntimeVoidForVoidResultValues(t *testing.T) {
 	program := lowerSource(t, `
 		fn ok() Void!Str {
 			Result::ok(())
@@ -309,38 +619,65 @@ func TestGenerateSourcesUsesRuntimeVoidForVoidResultValues(t *testing.T) {
 			ok()
 		}
 	`)
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	fn, ok := astFilesFunc(files, "test_ard__ok")
+	if !ok || fn.Type.Results == nil || len(fn.Type.Results.List) != 1 {
+		t.Fatalf("generated AST missing ok return type: %#v", fn)
 	}
-	source := string(sources["test.go"])
-	if !regexp.MustCompile(`func test_ard__ok\(\) ardruntime\.Result\[ardruntime\.Void, string\]`).MatchString(source) {
-		t.Fatalf("generated source missing void result container return type using ardruntime.Void:\n%s", source)
+	resultType, ok := fn.Type.Results.List[0].Type.(*ast.IndexListExpr)
+	if !ok || astExprName(resultType.X) != "ardruntime.Result" || len(resultType.Indices) != 2 || astExprName(resultType.Indices[0]) != "ardruntime.Void" || astExprName(resultType.Indices[1]) != "string" {
+		t.Fatalf("generated AST missing void result container return type using ardruntime.Void: %#v", fn.Type.Results.List[0].Type)
 	}
-	if !strings.Contains(source, "Value: ardruntime.Void{}") {
-		t.Fatalf("generated source missing ardruntime.Void value:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		kv, ok := node.(*ast.KeyValueExpr)
+		if !ok {
+			return false
+		}
+		key, keyOK := kv.Key.(*ast.Ident)
+		lit, litOK := kv.Value.(*ast.CompositeLit)
+		return keyOK && key.Name == "Value" && litOK && astExprName(lit.Type) == "ardruntime.Void"
+	}) {
+		t.Fatal("generated AST missing ardruntime.Void value")
 	}
-	if strings.Contains(source, "struct{}") || strings.Contains(source, "struct {}") {
-		t.Fatalf("generated source still uses anonymous empty struct for Void:\n%s", source)
+	if astFilesHaveEmptyStructType(files) {
+		t.Fatal("generated AST still uses anonymous empty struct for Void")
 	}
 }
 
-func TestGenerateSourcesMaterializesVoidGlobalInitializers(t *testing.T) {
+func TestLowerProgramMaterializesVoidGlobalInitializers(t *testing.T) {
 	program := lowerSource(t, `
 		fn touch() Void { () }
 		let saved = touch()
 		fn main() Void { saved }
 	`)
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if astFilesContain(files, func(node ast.Node) bool {
+		value, ok := node.(*ast.ValueSpec)
+		if !ok {
+			return false
+		}
+		for _, expr := range value.Values {
+			call, ok := expr.(*ast.CallExpr)
+			if ok && strings.Contains(astCallName(call), "test_ard__touch") {
+				return true
+			}
+		}
+		return false
+	}) {
+		t.Fatal("generated AST uses no-value Void call as global initializer")
 	}
-	source := string(sources["test.go"])
-	if strings.Contains(source, "= test_ard__touch()") {
-		t.Fatalf("generated source uses no-value Void call as global initializer:\n%s", source)
+	if !astFilesHaveCall(files, "test_ard__touch") {
+		t.Fatal("generated AST does not materialize Void global initializer call")
 	}
-	if !strings.Contains(source, "test_ard__touch()") || !strings.Contains(source, "return ardruntime.Void{}") {
-		t.Fatalf("generated source does not materialize Void global initializer:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		ret, ok := node.(*ast.ReturnStmt)
+		if !ok || len(ret.Results) != 1 {
+			return false
+		}
+		lit, ok := ret.Results[0].(*ast.CompositeLit)
+		return ok && astExprName(lit.Type) == "ardruntime.Void"
+	}) {
+		t.Fatal("generated AST does not return ardruntime.Void{} for materialized global")
 	}
 }
 
@@ -924,7 +1261,7 @@ func TestRunProgramAllowsModuleWithoutEntry(t *testing.T) {
 	}
 }
 
-func TestGenerateSourcesSupportsStructsAndEnums(t *testing.T) {
+func TestLowerProgramSupportsStructsAndEnums(t *testing.T) {
 	program := lowerSource(t, `
 		enum Direction {
 			Up, Down
@@ -949,32 +1286,58 @@ func TestGenerateSourcesSupportsStructsAndEnums(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesHaveTypeSpec(files, "test_ard__Direction") {
+		t.Fatal("generated AST missing enum type")
 	}
-	combined := ""
-	for _, source := range sources {
-		combined += string(source)
+	if !astFilesHaveValueSpec(files, "test_ard__Direction__Down") {
+		t.Fatal("generated AST missing enum constants")
 	}
-	if !strings.Contains(combined, `type test_ard__Direction int`) {
-		t.Fatalf("generated source missing enum type:\n%s", combined)
+	if !astFilesHaveTypeSpec(files, "test_ard__User") {
+		t.Fatal("generated AST missing struct type")
 	}
-	if !strings.Contains(combined, `test_ard__Direction__Down`) {
-		t.Fatalf("generated source missing enum constants:\n%s", combined)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		lit, ok := node.(*ast.CompositeLit)
+		if !ok || astExprName(lit.Type) != "test_ard__User" {
+			return false
+		}
+		hasName := false
+		hasAge := false
+		for _, elem := range lit.Elts {
+			kv, ok := elem.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, keyOK := kv.Key.(*ast.Ident)
+			if !keyOK {
+				continue
+			}
+			if key.Name == "name" {
+				value, ok := kv.Value.(*ast.BasicLit)
+				hasName = ok && value.Value == `"Ada"`
+			}
+			if key.Name == "age" {
+				value, ok := kv.Value.(*ast.BasicLit)
+				hasAge = ok && value.Value == "41"
+			}
+		}
+		return hasName && hasAge
+	}) {
+		t.Fatal("generated AST missing struct literal lowering")
 	}
-	if !strings.Contains(combined, `type test_ard__User struct`) {
-		t.Fatalf("generated source missing struct type:\n%s", combined)
-	}
-	if !strings.Contains(combined, `test_ard__User{age: 41, name: "Ada"}`) {
-		t.Fatalf("generated source missing struct literal lowering:\n%s", combined)
-	}
-	if !strings.Contains(combined, ".age + 1") {
-		t.Fatalf("generated source missing field access lowering:\n%s", combined)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		binary, ok := node.(*ast.BinaryExpr)
+		if !ok || binary.Op != token.ADD {
+			return false
+		}
+		selector, ok := binary.X.(*ast.SelectorExpr)
+		return ok && selector.Sel.Name == "age"
+	}) {
+		t.Fatal("generated AST missing field access lowering")
 	}
 }
 
-func TestGenerateSourcesSupportsTryMaybeCatchAndEarlyReturn(t *testing.T) {
+func TestLowerProgramSupportsTryMaybeCatchAndEarlyReturn(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/maybe
 
@@ -997,20 +1360,35 @@ func TestGenerateSourcesSupportsTryMaybeCatchAndEarlyReturn(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		ret, ok := node.(*ast.ReturnStmt)
+		if !ok || len(ret.Results) != 1 {
+			return false
+		}
+		ident, ok := ret.Results[0].(*ast.Ident)
+		return ok && strings.HasPrefix(ident.Name, "_tmp_")
+	}) {
+		t.Fatal("generated AST missing try early return lowering")
 	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "return _tmp_") {
-		t.Fatalf("generated source missing try early return lowering:\n%s", source)
-	}
-	if !strings.Contains(source, "= 42") {
-		t.Fatalf("generated source missing try catch lowering:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok {
+			return false
+		}
+		for _, rhs := range assign.Rhs {
+			lit, ok := rhs.(*ast.BasicLit)
+			if ok && lit.Value == "42" {
+				return true
+			}
+		}
+		return false
+	}) {
+		t.Fatal("generated AST missing try catch lowering")
 	}
 }
 
-func TestGenerateSourcesPropagatesTryResultAcrossDifferentResultValueTypes(t *testing.T) {
+func TestLowerProgramPropagatesTryResultAcrossDifferentResultValueTypes(t *testing.T) {
 	program := lowerSource(t, `
 		fn read_text() Str!Str {
 			Result::err("bad")
@@ -1027,13 +1405,37 @@ func TestGenerateSourcesPropagatesTryResultAcrossDifferentResultValueTypes(t *te
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
-	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "return ardruntime.Result[int, string]{Err: _tmp_") {
-		t.Fatalf("generated source missing result error propagation conversion:\n%s", source)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		ret, ok := node.(*ast.ReturnStmt)
+		if !ok || len(ret.Results) != 1 {
+			return false
+		}
+		lit, ok := ret.Results[0].(*ast.CompositeLit)
+		if !ok || astExprName(lit.Type) != "ardruntime.Result" {
+			return false
+		}
+		for _, elem := range lit.Elts {
+			kv, ok := elem.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, keyOK := kv.Key.(*ast.Ident)
+			if !keyOK || key.Name != "Err" {
+				continue
+			}
+			if value, ok := kv.Value.(*ast.Ident); ok && strings.HasPrefix(value.Name, "_tmp_") {
+				return true
+			}
+			if selector, ok := kv.Value.(*ast.SelectorExpr); ok {
+				if ident, ok := selector.X.(*ast.Ident); ok && strings.HasPrefix(ident.Name, "_tmp_") && selector.Sel.Name == "Err" {
+					return true
+				}
+			}
+		}
+		return false
+	}) {
+		t.Fatal("generated AST missing result error propagation conversion")
 	}
 }
 
@@ -1066,7 +1468,7 @@ func TestRunProgramSupportsCommonStdlibExterns(t *testing.T) {
 	}
 }
 
-func TestGenerateSourcesReusesJSONGlueHelpers(t *testing.T) {
+func TestLowerProgramReusesJSONGlueHelpers(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/json
 
@@ -1080,23 +1482,13 @@ func TestGenerateSourcesReusesJSONGlueHelpers(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
-	}
-	source := string(sources["test.go"])
-	for _, want := range []string{
-		"func ardJSONDecodeMaybe[T any]",
-		"return ardJSONDecodeMaybe(dec, path,",
-		"func ardJSONDecodeList[T any]",
-		"return ardJSONDecodeList(dec, path,",
-		"func ardJSONEncodeMaybe[T any]",
-		"return ardJSONEncodeMaybe(enc, value,",
-		"func ardJSONEncodeList[T any]",
-		"return ardJSONEncodeList(enc, value,",
-	} {
-		if !strings.Contains(source, want) {
-			t.Fatalf("generated source missing reusable JSON glue %q:\n%s", want, source)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	for _, name := range []string{"ardJSONDecodeMaybe", "ardJSONDecodeList", "ardJSONEncodeMaybe", "ardJSONEncodeList"} {
+		if _, ok := astFilesFunc(files, name); !ok {
+			t.Fatalf("generated AST missing reusable JSON glue function %q", name)
+		}
+		if !astFilesHaveCall(files, name) {
+			t.Fatalf("generated AST missing reusable JSON glue call %q", name)
 		}
 	}
 }
@@ -1205,7 +1597,7 @@ fn main() {}
 	}
 }
 
-func TestGenerateSourcesUsesProjectNameForProjectFFI(t *testing.T) {
+func TestLowerProgramUsesProjectNameForProjectFFI(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo_app\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -1241,24 +1633,13 @@ fn main() {
 	if err != nil {
 		t.Fatalf("lower: %v", err)
 	}
-	sources, err := GenerateSources(program, Options{PackageName: "main", ProjectInfo: loaded.ProjectInfo})
-	if err != nil {
-		t.Fatalf("generate sources: %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main", ProjectInfo: loaded.ProjectInfo})
+	if !astFilesHaveImport(files, "demo_app", "generated/demo_app") {
+		t.Fatalf("generated AST missing project-name FFI import")
 	}
-	combined := ""
-	for _, source := range sources {
-		combined += string(source)
+	if !astFilesHaveSelector(files, "demo_app", "Handle") || !astFilesHaveSelector(files, "demo_app", "MakeHandle") {
+		t.Fatalf("generated AST did not qualify project FFI with project name")
 	}
-	if !strings.Contains(combined, `demo_app "generated/demo_app"`) {
-		t.Fatalf("generated source missing project-name FFI import:\n%s", combined)
-	}
-	if !strings.Contains(combined, "demo_app.Handle") || !strings.Contains(combined, "demo_app.MakeHandle") {
-		t.Fatalf("generated source did not qualify project FFI with project name:\n%s", combined)
-	}
-	if strings.Contains(combined, "projectffi") {
-		t.Fatalf("generated source still uses projectffi:\n%s", combined)
-	}
-
 	workspace := filepath.Join(dir, "workspace")
 	if err := os.MkdirAll(workspace, 0o755); err != nil {
 		t.Fatal(err)
@@ -1274,7 +1655,7 @@ fn main() {
 	}
 }
 
-func TestGenerateSourcesRejectsUnqualifiedProjectFFIExternType(t *testing.T) {
+func TestLowerProgramRejectsUnqualifiedProjectFFIExternType(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -1304,7 +1685,7 @@ fn main() {}
 	if err != nil {
 		t.Fatalf("lower: %v", err)
 	}
-	_, err = GenerateSources(program, Options{PackageName: "main", ProjectInfo: loaded.ProjectInfo})
+	_, err = lowerProgram(program, Options{PackageName: "main", ProjectInfo: loaded.ProjectInfo})
 	if err == nil || !strings.Contains(err.Error(), `must qualify Handle with package demo`) {
 		t.Fatalf("GenerateSources error = %v, want unqualified project FFI type rejection", err)
 	}
@@ -1955,7 +2336,7 @@ fn close(db: sql::Database) Void!Str {
 	}
 }
 
-func TestGenerateSourcesUsesRuntimeMaybeForRecursiveNullableFields(t *testing.T) {
+func TestLowerProgramUsesRuntimeMaybeForRecursiveNullableFields(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/maybe
 
@@ -1968,20 +2349,30 @@ func TestGenerateSourcesUsesRuntimeMaybeForRecursiveNullableFields(t *testing.T)
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		field, ok := node.(*ast.Field)
+		if !ok || len(field.Names) != 1 || field.Names[0].Name != "parent" {
+			return false
+		}
+		indexed, ok := field.Type.(*ast.IndexExpr)
+		return ok && astExprName(indexed.X) == "ardruntime.Maybe" && astExprName(indexed.Index) == "test_ard__Node"
+	}) {
+		t.Fatal("generated AST missing runtime Maybe recursive nullable field")
 	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "parent ardruntime.Maybe[test_ard__Node]") {
-		t.Fatalf("generated source missing runtime Maybe recursive nullable field:\n%s", source)
-	}
-	if strings.Contains(source, "parent *test_ard__Node") {
-		t.Fatalf("generated source lowered recursive nullable field as pointer:\n%s", source)
+	if astFilesContain(files, func(node ast.Node) bool {
+		field, ok := node.(*ast.Field)
+		if !ok || len(field.Names) != 1 || field.Names[0].Name != "parent" {
+			return false
+		}
+		star, ok := field.Type.(*ast.StarExpr)
+		return ok && astExprName(star.X) == "test_ard__Node"
+	}) {
+		t.Fatal("generated AST lowered recursive nullable field as pointer")
 	}
 }
 
-func TestGenerateSourcesUsesExpectedLocalTypeForMaybeNone(t *testing.T) {
+func TestLowerProgramUsesExpectedLocalTypeForMaybeNone(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/maybe
 
@@ -1991,20 +2382,23 @@ func TestGenerateSourcesUsesExpectedLocalTypeForMaybeNone(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || astCallName(call) != "ardruntime.None" {
+			return false
+		}
+		indexed, ok := call.Fun.(*ast.IndexExpr)
+		return ok && astExprName(indexed.Index) == "int"
+	}) {
+		t.Fatal("generated AST missing typed maybe none")
 	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "runtime.None[int]()") {
-		t.Fatalf("generated source missing typed maybe none:\n%s", source)
-	}
-	if strings.Contains(source, "ardruntime.Maybe[struct {") {
-		t.Fatalf("generated source used untyped maybe none:\n%s", source)
+	if astFilesHaveEmptyStructType(files) {
+		t.Fatal("generated AST used untyped maybe none")
 	}
 }
 
-func TestGenerateSourcesUsesExpectedDefaultTypeForResultOr(t *testing.T) {
+func TestLowerProgramUsesExpectedDefaultTypeForResultOr(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/maybe
 
@@ -2019,17 +2413,13 @@ func TestGenerateSourcesUsesExpectedDefaultTypeForResultOr(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
-	}
-	source := string(sources["test.go"])
-	if strings.Contains(source, "ardruntime.Maybe[struct {") {
-		t.Fatalf("generated source used untyped maybe default:\n%s", source)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if astFilesHaveEmptyStructType(files) {
+		t.Fatal("generated AST used untyped maybe default")
 	}
 }
 
-func TestGenerateSourcesSkipsVoidAssignmentForStatementMatchBranches(t *testing.T) {
+func TestLowerProgramSkipsVoidAssignmentForStatementMatchBranches(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/maybe
 
@@ -2042,13 +2432,21 @@ func TestGenerateSourcesSkipsVoidAssignmentForStatementMatchBranches(t *testing.
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
-	}
-	source := string(sources["test.go"])
-	if strings.Contains(source, "= nil") {
-		t.Fatalf("generated source assigned nil in statement match lowering:\n%s", source)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if astFilesContain(files, func(node ast.Node) bool {
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok {
+			return false
+		}
+		for _, rhs := range assign.Rhs {
+			ident, ok := rhs.(*ast.Ident)
+			if ok && ident.Name == "nil" {
+				return true
+			}
+		}
+		return false
+	}) {
+		t.Fatal("generated AST assigned nil in statement match lowering")
 	}
 }
 
@@ -2085,7 +2483,7 @@ func TestTypeNameUsesModulePathAndUniqueFallback(t *testing.T) {
 	}
 }
 
-func TestGenerateSourcesSupportsResultExpectAndStringPredicates(t *testing.T) {
+func TestLowerProgramSupportsResultExpectAndStringPredicates(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/io
 
@@ -2095,32 +2493,31 @@ func TestGenerateSourcesSupportsResultExpectAndStringPredicates(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		indexed, ok := node.(*ast.IndexListExpr)
+		return ok && astExprName(indexed.X) == "ardruntime.Result" && len(indexed.Indices) == 2 && astExprName(indexed.Indices[0]) == "string" && astExprName(indexed.Indices[1]) == "string"
+	}) {
+		t.Fatal("generated AST missing runtime.Result usage")
 	}
-	combined := ""
-	for _, source := range sources {
-		combined += string(source)
+	if !astFilesHaveCall(files, "stdlibffi.ReadLine") {
+		t.Fatal("generated AST missing ReadLine lowering")
 	}
-	if !strings.Contains(combined, "ardruntime.Result[string, string]") {
-		t.Fatalf("generated source missing runtime.Result usage:\n%s", combined)
+	if astFilesHaveCall(files, "ardReadLine") {
+		t.Fatal("generated AST should not use legacy ReadLine helper")
 	}
-	if !strings.Contains(combined, "stdlibffi.ReadLine()") {
-		t.Fatalf("generated source missing ReadLine lowering:\n%s", combined)
+	if !astFilesHaveCall(files, "panic") || !astFilesContain(files, func(node ast.Node) bool {
+		lit, ok := node.(*ast.BasicLit)
+		return ok && lit.Kind == token.STRING && strings.Contains(lit.Value, "no line")
+	}) {
+		t.Fatal("generated AST missing Result.expect lowering")
 	}
-	if strings.Contains(combined, "ardReadLine") {
-		t.Fatalf("generated source should not use legacy ReadLine helper:\n%s", combined)
-	}
-	if !strings.Contains(combined, "panic(\"no line\"") {
-		t.Fatalf("generated source missing Result.expect lowering:\n%s", combined)
-	}
-	if !strings.Contains(combined, "len(line") {
-		t.Fatalf("generated source missing is_empty lowering:\n%s", combined)
+	if !astFilesHaveCall(files, "len") {
+		t.Fatal("generated AST missing is_empty lowering")
 	}
 }
 
-func TestGenerateSourcesUsesDirectStdlibMaybeCalls(t *testing.T) {
+func TestLowerProgramUsesDirectStdlibMaybeCalls(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/dynamic
 		use ard/env
@@ -2136,23 +2533,21 @@ func TestGenerateSourcesUsesDirectStdlibMaybeCalls(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	for _, name := range []string{"stdlibffi.EnvGet", "stdlibffi.FloatFromStr", "stdlibffi.IntFromStr"} {
+		if !astFilesHaveCall(files, name) {
+			t.Fatalf("generated AST missing direct stdlib maybe call %s", name)
+		}
 	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "stdlibffi.EnvGet(") || !strings.Contains(source, "stdlibffi.FloatFromStr(") || !strings.Contains(source, "stdlibffi.IntFromStr(") {
-		t.Fatalf("generated source missing direct stdlib maybe calls:\n%s", source)
+	if astFilesHaveCall(files, "ardIntFromStr") {
+		t.Fatal("generated AST should not use legacy IntFromStr helper")
 	}
-	if strings.Contains(source, "ardIntFromStr") {
-		t.Fatalf("generated source should not use legacy IntFromStr helper:\n%s", source)
-	}
-	if strings.Contains(source, "ardMapToDynamic") {
-		t.Fatalf("generated source should not use legacy MapToDynamic helper:\n%s", source)
+	if astFilesHaveCall(files, "ardMapToDynamic") {
+		t.Fatal("generated AST should not use legacy MapToDynamic helper")
 	}
 }
 
-func TestGenerateSourcesUsesPointersForMutableStructParams(t *testing.T) {
+func TestLowerProgramUsesPointersForMutableStructParams(t *testing.T) {
 	program := lowerSource(t, `
 		struct Response {
 			body: Str,
@@ -2168,20 +2563,32 @@ func TestGenerateSourcesUsesPointersForMutableStructParams(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	fn, ok := astFilesFunc(files, "test_ard__set_body")
+	if !ok || fn.Type.Params == nil || len(fn.Type.Params.List) == 0 {
+		t.Fatalf("generated AST missing set_body function")
 	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, `func test_ard__set_body(res *test_ard__Response)`) {
-		t.Fatalf("generated source missing pointer mutable param lowering:\n%s", source)
+	paramType, ok := fn.Type.Params.List[0].Type.(*ast.StarExpr)
+	if !ok || astExprName(paramType.X) != "test_ard__Response" {
+		t.Fatalf("generated AST missing pointer mutable param lowering: %#v", fn.Type.Params.List[0].Type)
 	}
-	if !strings.Contains(source, "test_ard__set_body(&res_0)") {
-		t.Fatalf("generated source missing pointer call lowering:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || astCallName(call) != "test_ard__set_body" || len(call.Args) == 0 {
+			return false
+		}
+		addr, ok := call.Args[0].(*ast.UnaryExpr)
+		if !ok || addr.Op != token.AND {
+			return false
+		}
+		ident, ok := addr.X.(*ast.Ident)
+		return ok && ident.Name == "res_0"
+	}) {
+		t.Fatal("generated AST missing pointer call lowering")
 	}
 }
 
-func TestGenerateSourcesSupportsCapturedClosureSort(t *testing.T) {
+func TestLowerProgramSupportsCapturedClosureSort(t *testing.T) {
 	program := lowerSource(t, `
 		fn main() Int {
 			mut items = [3, 1, 2]
@@ -2193,26 +2600,28 @@ func TestGenerateSourcesSupportsCapturedClosureSort(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesHaveCall(files, "sort.SliceStable") {
+		t.Fatal("generated AST missing list sort lowering")
 	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "sort.SliceStable") {
-		t.Fatalf("generated source missing list sort lowering:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		lit, ok := node.(*ast.FuncLit)
+		return ok && lit.Type.Params != nil && len(lit.Type.Params.List) == 2 && lit.Type.Results != nil && len(lit.Type.Results.List) == 1 && astExprName(lit.Type.Results.List[0].Type) == "bool"
+	}) {
+		t.Fatal("generated AST missing closure literal lowering")
 	}
-	if !strings.Contains(source, "func(a int, b int) bool") {
-		t.Fatalf("generated source missing closure literal lowering:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		ident, ok := node.(*ast.Ident)
+		return ok && strings.HasPrefix(ident.Name, "bias")
+	}) {
+		t.Fatal("generated AST missing closure capture usage")
 	}
-	if !strings.Contains(source, "bias") {
-		t.Fatalf("generated source missing closure capture usage:\n%s", source)
-	}
-	if strings.Contains(source, "anon_func") {
-		t.Fatalf("generated source should inline local closure body instead of emitting an anon helper:\n%s", source)
+	if astFilesHaveFuncContaining(files, "anon_func") {
+		t.Fatal("generated AST should inline local closure body instead of emitting an anon helper")
 	}
 }
 
-func TestGenerateSourcesInlinesNestedImmediateClosures(t *testing.T) {
+func TestLowerProgramInlinesNestedImmediateClosures(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/maybe
 
@@ -2225,20 +2634,23 @@ func TestGenerateSourcesInlinesNestedImmediateClosures(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if astFilesHaveFuncContaining(files, "anon_func") {
+		t.Fatal("generated AST should inline nested immediate closures instead of emitting anon helpers")
 	}
-	source := string(sources["test.go"])
-	if strings.Contains(source, "anon_func") {
-		t.Fatalf("generated source should inline nested immediate closures instead of emitting anon helpers:\n%s", source)
-	}
-	if count := strings.Count(source, "func(value int) int") + strings.Count(source, "func(inner int) int"); count < 2 {
-		t.Fatalf("generated source missing nested function literals:\n%s", source)
+	funcLits := 0
+	astFilesContain(files, func(node ast.Node) bool {
+		if _, ok := node.(*ast.FuncLit); ok {
+			funcLits++
+		}
+		return false
+	})
+	if funcLits < 2 {
+		t.Fatalf("generated AST missing nested function literals: got %d", funcLits)
 	}
 }
 
-func TestGenerateSourcesKeepsHelperForMutableCaptureClosure(t *testing.T) {
+func TestLowerProgramKeepsHelperForMutableCaptureClosure(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/maybe
 
@@ -2252,17 +2664,13 @@ func TestGenerateSourcesKeepsHelperForMutableCaptureClosure(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
-	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "anon_func") {
-		t.Fatalf("generated source should keep helper for mutable capture closure:\n%s", source)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesHaveFuncContaining(files, "anon_func") {
+		t.Fatal("generated AST should keep helper for mutable capture closure")
 	}
 }
 
-func TestGenerateSourcesKeepsHelperForRetainedClosure(t *testing.T) {
+func TestLowerProgramKeepsHelperForRetainedClosure(t *testing.T) {
 	program := lowerSource(t, `
 		fn make_adder(offset: Int) fn(Int) Int {
 			fn(value: Int) Int {
@@ -2276,17 +2684,13 @@ func TestGenerateSourcesKeepsHelperForRetainedClosure(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
-	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "anon_func") {
-		t.Fatalf("generated source should keep helper for retained closure:\n%s", source)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesHaveFuncContaining(files, "anon_func") {
+		t.Fatal("generated AST should keep helper for retained closure")
 	}
 }
 
-func TestGenerateSourcesPassesPointerReceiverForMutatingTraitImpl(t *testing.T) {
+func TestLowerProgramPassesPointerReceiverForMutatingTraitImpl(t *testing.T) {
 	program := lowerSource(t, `
 		trait Writer {
 			fn write(text: Str)
@@ -2307,20 +2711,37 @@ func TestGenerateSourcesPassesPointerReceiverForMutatingTraitImpl(t *testing.T) 
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		fn, ok := node.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || !strings.Contains(fn.Name.Name, "Buffer_Writer_write") || fn.Type.Params == nil || len(fn.Type.Params.List) == 0 {
+			return false
+		}
+		if len(fn.Type.Params.List[0].Names) == 0 || fn.Type.Params.List[0].Names[0].Name != "self" {
+			return false
+		}
+		_, ok = fn.Type.Params.List[0].Type.(*ast.StarExpr)
+		return ok
+	}) {
+		t.Fatal("generated AST missing pointer receiver for mutating trait impl")
 	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "_Buffer_Writer_write(self *") {
-		t.Fatalf("generated source missing pointer receiver for mutating trait impl:\n%s", source)
-	}
-	if !regexp.MustCompile(`_Buffer_Writer_write\(&_tmp_[0-9]+, "hi"\)`).MatchString(source) {
-		t.Fatalf("generated source missing address-of for mutating trait dispatch receiver:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !strings.Contains(astCallName(call), "Buffer_Writer_write") || len(call.Args) < 2 {
+			return false
+		}
+		addr, ok := call.Args[0].(*ast.UnaryExpr)
+		if !ok || addr.Op != token.AND {
+			return false
+		}
+		lit, ok := call.Args[1].(*ast.BasicLit)
+		return ok && lit.Value == `"hi"`
+	}) {
+		t.Fatal("generated AST missing address-of for mutating trait dispatch receiver")
 	}
 }
 
-func TestGenerateSourcesSupportsUserTraitObjectDispatch(t *testing.T) {
+func TestLowerProgramSupportsUserTraitObjectDispatch(t *testing.T) {
 	program := lowerSource(t, `
 		trait Renderable {
 			fn render() Str
@@ -2355,26 +2776,27 @@ func TestGenerateSourcesSupportsUserTraitObjectDispatch(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		_, ok := node.(*ast.TypeSwitchStmt)
+		return ok
+	}) {
+		t.Fatal("generated AST missing trait object dispatch lowering")
 	}
-	source := string(sources["test.go"])
-	if !regexp.MustCompile(`switch _tmp_[0-9]+ := r\.\(type\)`).MatchString(source) {
-		t.Fatalf("generated source missing trait object dispatch lowering:\n%s", source)
+	for _, name := range []string{"Block_Renderable_render", "Para_Renderable_render"} {
+		if !astFilesContain(files, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			return ok && strings.Contains(astCallName(call), name)
+		}) {
+			t.Fatalf("generated AST missing %s trait dispatch call", name)
+		}
 	}
-	if !regexp.MustCompile(`Block_Renderable_render\(_tmp_[0-9]+\)`).MatchString(source) {
-		t.Fatalf("generated source missing Block trait dispatch call:\n%s", source)
-	}
-	if !regexp.MustCompile(`Para_Renderable_render\(_tmp_[0-9]+\)`).MatchString(source) {
-		t.Fatalf("generated source missing Para trait dispatch call:\n%s", source)
-	}
-	if !strings.Contains(source, "panic(") {
-		t.Fatalf("generated source missing trait dispatch fallback panic:\n%s", source)
+	if !astFilesHaveCall(files, "panic") {
+		t.Fatal("generated AST missing trait dispatch fallback panic")
 	}
 }
 
-func TestGenerateSourcesSupportsCrossModuleTraitObjectDispatch(t *testing.T) {
+func TestLowerProgramSupportsCrossModuleTraitObjectDispatch(t *testing.T) {
 	tempDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"checkprobe\"\nard = \">= 0.13.0\"\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -2424,29 +2846,25 @@ fn main() {
 	if err != nil {
 		t.Fatalf("lower error: %v", err)
 	}
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		_, ok := node.(*ast.TypeSwitchStmt)
+		return ok
+	}) {
+		t.Fatal("generated AST missing trait dispatch")
 	}
-	source := ""
-	for _, data := range sources {
-		if regexp.MustCompile(`switch _tmp_[0-9]+ := t_1\.\(type\)`).MatchString(string(data)) {
-			source = string(data)
-			break
-		}
+	if !astFilesHaveTypeSwitchCase(files, "checkprobe_widget__Text") {
+		t.Fatal("generated AST missing cross-module trait dispatch case")
 	}
-	if source == "" {
-		t.Fatalf("generated sources missing trait dispatch: %#v", mapsKeys(sources))
-	}
-	if !strings.Contains(source, "case checkprobe_widget__Text:") {
-		t.Fatalf("generated source missing cross-module trait dispatch case:\n%s", source)
-	}
-	if !regexp.MustCompile(`checkprobe_widget__Text_Widget_render\(_tmp_[0-9]+, f_0\)`).MatchString(source) {
-		t.Fatalf("generated source missing cross-module trait dispatch call:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		return ok && strings.Contains(astCallName(call), "checkprobe_widget__Text_Widget_render") && len(call.Args) >= 2 && astExprName(call.Args[1]) == "f_0"
+	}) {
+		t.Fatal("generated AST missing cross-module trait dispatch call")
 	}
 }
 
-func TestGenerateSourcesUsesCallSiteImportsForCrossModuleTraitObjectDispatch(t *testing.T) {
+func TestLowerProgramUsesCallSiteImportsForCrossModuleTraitObjectDispatch(t *testing.T) {
 	tempDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"nestprobe\"\nard = \">= 0.13.0\"\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -2533,29 +2951,22 @@ fn main() {
 	if err != nil {
 		t.Fatalf("lower error: %v", err)
 	}
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	generatedFiles := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(generatedFiles, func(node ast.Node) bool {
+		_, ok := node.(*ast.TypeSwitchStmt)
+		return ok
+	}) {
+		t.Fatal("generated AST missing call-site trait dispatch")
 	}
-	source := ""
-	for _, data := range sources {
-		if regexp.MustCompile(`switch _tmp_[0-9]+ := demo_1\.\(type\)`).MatchString(string(data)) {
-			source = string(data)
-			break
-		}
+	if !astFilesHaveTypeSwitchCase(generatedFiles, "nestprobe_tui_core_box__Box") {
+		t.Fatal("generated AST missing Box dispatch case from call-site imports")
 	}
-	if source == "" {
-		t.Fatalf("generated sources missing call-site trait dispatch: %#v", mapsKeys(sources))
-	}
-	if !strings.Contains(source, "case nestprobe_tui_core_box__Box:") {
-		t.Fatalf("generated source missing Box dispatch case from call-site imports:\n%s", source)
-	}
-	if !strings.Contains(source, "case nestprobe_tui_core_text__Text:") {
-		t.Fatalf("generated source missing Text dispatch case from call-site imports:\n%s", source)
+	if !astFilesHaveTypeSwitchCase(generatedFiles, "nestprobe_tui_core_text__Text") {
+		t.Fatal("generated AST missing Text dispatch case from call-site imports")
 	}
 }
 
-func TestGenerateSourcesUsesAliasOriginImportsForTraitObjectDispatch(t *testing.T) {
+func TestLowerProgramUsesAliasOriginImportsForTraitObjectDispatch(t *testing.T) {
 	tempDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tempDir, "ard.toml"), []byte("name = \"aliasprobe\"\nard = \">= 0.13.0\"\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -2642,29 +3053,22 @@ fn main() { demo::run() }
 	if err != nil {
 		t.Fatalf("lower error: %v", err)
 	}
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	generatedFiles := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(generatedFiles, func(node ast.Node) bool {
+		_, ok := node.(*ast.TypeSwitchStmt)
+		return ok
+	}) {
+		t.Fatal("generated AST missing aliased-constructor trait dispatch")
 	}
-	source := ""
-	for _, data := range sources {
-		if regexp.MustCompile(`switch _tmp_[0-9]+ := w_1\.\(type\)`).MatchString(string(data)) {
-			source = string(data)
-			break
-		}
+	if !astFilesHaveTypeSwitchCase(generatedFiles, "aliasprobe_widgets_box__Box") {
+		t.Fatal("generated AST missing Box dispatch case through let alias")
 	}
-	if source == "" {
-		t.Fatalf("generated sources missing aliased-constructor trait dispatch: %#v", mapsKeys(sources))
-	}
-	if !strings.Contains(source, "case aliasprobe_widgets_box__Box:") {
-		t.Fatalf("generated source missing Box dispatch case through let alias:\n%s", source)
-	}
-	if !strings.Contains(source, "case aliasprobe_widgets_text__Text:") {
-		t.Fatalf("generated source missing Text dispatch case through let alias:\n%s", source)
+	if !astFilesHaveTypeSwitchCase(generatedFiles, "aliasprobe_widgets_text__Text") {
+		t.Fatal("generated AST missing Text dispatch case through let alias")
 	}
 }
 
-func TestGenerateSourcesSupportsVoidTraitObjectDispatch(t *testing.T) {
+func TestLowerProgramSupportsVoidTraitObjectDispatch(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/io
 
@@ -2691,26 +3095,40 @@ func TestGenerateSourcesSupportsVoidTraitObjectDispatch(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		_, ok := node.(*ast.TypeSwitchStmt)
+		return ok
+	}) {
+		t.Fatal("generated AST missing void trait object dispatch lowering")
 	}
-	source := string(sources["test.go"])
-	if !regexp.MustCompile(`switch _tmp_[0-9]+ := g\.\(type\)`).MatchString(source) {
-		t.Fatalf("generated source missing void trait object dispatch lowering:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		return ok && strings.Contains(astCallName(call), "Cat_Greet_say")
+	}) {
+		t.Fatal("generated AST missing void trait dispatch call")
 	}
-	if !regexp.MustCompile(`Cat_Greet_say\(_tmp_[0-9]+\)`).MatchString(source) {
-		t.Fatalf("generated source missing void trait dispatch call:\n%s", source)
+	if astFilesContain(files, func(node ast.Node) bool {
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok {
+			return false
+		}
+		for _, rhs := range assign.Rhs {
+			call, ok := rhs.(*ast.CallExpr)
+			if ok && strings.Contains(astCallName(call), "Cat_Greet_say") {
+				return true
+			}
+		}
+		return false
+	}) {
+		t.Fatal("generated AST assigns void trait dispatch result")
 	}
-	if regexp.MustCompile(`= .*Cat_Greet_say\(_tmp_[0-9]+\)`).MatchString(source) {
-		t.Fatalf("generated source assigns void trait dispatch result:\n%s", source)
-	}
-	if !strings.Contains(source, "invoke(any(") {
-		t.Fatalf("generated source missing trait upcast for call argument:\n%s", source)
+	if !astFilesHaveCall(files, "any") {
+		t.Fatal("generated AST missing trait upcast for call argument")
 	}
 }
 
-func TestGenerateSourcesSupportsStoredTraitObjectDispatch(t *testing.T) {
+func TestLowerProgramSupportsStoredTraitObjectDispatch(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/io
 
@@ -2748,32 +3166,59 @@ func TestGenerateSourcesSupportsStoredTraitObjectDispatch(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesHaveCall(files, "any") {
+		t.Fatal("generated AST missing trait-object upcast")
 	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "d_0 := any(") {
-		t.Fatalf("generated source missing local trait-object upcast:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		kv, ok := node.(*ast.KeyValueExpr)
+		if !ok {
+			return false
+		}
+		key, keyOK := kv.Key.(*ast.Ident)
+		call, callOK := kv.Value.(*ast.CallExpr)
+		return keyOK && key.Name == "child" && callOK && astCallName(call) == "any"
+	}) {
+		t.Fatal("generated AST missing struct field trait-object upcast")
 	}
-	if !strings.Contains(source, "child: any(") {
-		t.Fatalf("generated source missing struct field trait-object upcast:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		lit, ok := node.(*ast.CompositeLit)
+		if !ok || astExprName(lit.Type) != "[]any" {
+			return false
+		}
+		for _, elem := range lit.Elts {
+			call, ok := elem.(*ast.CallExpr)
+			if ok && astCallName(call) == "any" {
+				return true
+			}
+		}
+		return false
+	}) {
+		t.Fatal("generated AST missing list element trait-object upcast")
 	}
-	if !strings.Contains(source, "[]any{any(") {
-		t.Fatalf("generated source missing list element trait-object upcast:\n%s", source)
+	typeSwitches := 0
+	astFilesContain(files, func(node ast.Node) bool {
+		if _, ok := node.(*ast.TypeSwitchStmt); ok {
+			typeSwitches++
+		}
+		return false
+	})
+	if typeSwitches < 2 {
+		t.Fatalf("generated AST missing trait-object dispatches: got %d", typeSwitches)
 	}
-	if !regexp.MustCompile(`switch _tmp_[0-9]+ := d_0\.\(type\)`).MatchString(source) {
-		t.Fatalf("generated source missing local trait-object dispatch:\n%s", source)
-	}
-	if !regexp.MustCompile(`switch _tmp_[0-9]+ := c_1\.child\.\(type\)`).MatchString(source) {
-		t.Fatalf("generated source missing struct field trait-object dispatch:\n%s", source)
-	}
-	if !strings.Contains(source, "show(items_2[0])") {
-		t.Fatalf("generated source missing list element trait-object use:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !strings.Contains(astCallName(call), "show") || len(call.Args) != 1 {
+			return false
+		}
+		_, ok = call.Args[0].(*ast.IndexExpr)
+		return ok
+	}) {
+		t.Fatal("generated AST missing list element trait-object use")
 	}
 }
 
-func TestGenerateSourcesSupportsTraitObjectDispatch(t *testing.T) {
+func TestLowerProgramSupportsTraitObjectDispatch(t *testing.T) {
 	program := lowerSource(t, `
 		use ard/io
 
@@ -2796,20 +3241,22 @@ func TestGenerateSourcesSupportsTraitObjectDispatch(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		_, ok := node.(*ast.TypeSwitchStmt)
+		return ok
+	}) {
+		t.Fatal("generated AST missing trait object dispatch lowering")
 	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "type switch") && !regexp.MustCompile(`switch _tmp_[0-9]+ := item\.\(type\)`).MatchString(source) {
-		t.Fatalf("generated source missing trait object dispatch lowering:\n%s", source)
-	}
-	if !regexp.MustCompile(`Book_ToString_to_str\(_tmp_[0-9]+\)`).MatchString(source) {
-		t.Fatalf("generated source missing concrete trait dispatch call:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		return ok && strings.Contains(astCallName(call), "Book_ToString_to_str")
+	}) {
+		t.Fatal("generated AST missing concrete trait dispatch call")
 	}
 }
 
-func TestGenerateSourcesSupportsListSwapAndMapKeys(t *testing.T) {
+func TestLowerProgramSupportsListSwapAndMapKeys(t *testing.T) {
 	program := lowerSource(t, `
 		fn main() Int {
 			mut items = [1, 2, 3]
@@ -2820,37 +3267,38 @@ func TestGenerateSourcesSupportsListSwapAndMapKeys(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) == 0 {
+			return false
+		}
+		_, ok = assign.Lhs[0].(*ast.IndexExpr)
+		return ok
+	}) {
+		t.Fatal("generated AST missing list swap lowering")
 	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "items_0[local_") && !strings.Contains(source, "items_0[_tmp_") {
-		t.Fatalf("generated source missing list swap lowering:\n%s", source)
-	}
-	if !strings.Contains(source, "ardSortedStringKeys(values_1)") {
-		t.Fatalf("generated source missing map keys lowering:\n%s", source)
+	if !astFilesHaveCall(files, "ardSortedStringKeys") {
+		t.Fatal("generated AST missing map keys lowering")
 	}
 }
 
-func TestGenerateSourcesEmitsOnlyUsedImports(t *testing.T) {
+func TestLowerProgramEmitsOnlyUsedImports(t *testing.T) {
 	program := lowerSource(t, `
 		fn main() Int {
 			1
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
-	}
-	source := string(sources["test.go"])
-	if strings.Contains(source, "bufio \"bufio\"") || strings.Contains(source, "strconv \"strconv\"") || strings.Contains(source, "strings \"strings\"") {
-		t.Fatalf("generated source included unused runtime imports:\n%s", source)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	for _, importPath := range []string{"bufio", "strconv", "strings"} {
+		if astFilesHaveImport(files, "", importPath) {
+			t.Fatalf("generated AST included unused runtime import %q", importPath)
+		}
 	}
 }
 
-func TestGenerateSourcesSupportsFieldMutation(t *testing.T) {
+func TestLowerProgramSupportsFieldMutation(t *testing.T) {
 	program := lowerSource(t, `
 		struct Counter {
 			value: Int,
@@ -2867,17 +3315,29 @@ func TestGenerateSourcesSupportsFieldMutation(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
-	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "current_1.value = current_1.value + 1") {
-		t.Fatalf("generated source missing field mutation lowering:\n%s", source)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+			return false
+		}
+		lhs, ok := assign.Lhs[0].(*ast.SelectorExpr)
+		if !ok || lhs.Sel.Name != "value" {
+			return false
+		}
+		binary, ok := assign.Rhs[0].(*ast.BinaryExpr)
+		if !ok || binary.Op != token.ADD {
+			return false
+		}
+		rhsSelector, ok := binary.X.(*ast.SelectorExpr)
+		lit, litOK := binary.Y.(*ast.BasicLit)
+		return ok && rhsSelector.Sel.Name == "value" && litOK && lit.Value == "1"
+	}) {
+		t.Fatal("generated AST missing field mutation lowering")
 	}
 }
 
-func TestGenerateSourcesSupportsIfAndWhile(t *testing.T) {
+func TestLowerProgramSupportsIfAndWhile(t *testing.T) {
 	program := lowerSource(t, `
 		fn main() Int {
 			mut count = 0
@@ -2892,19 +3352,42 @@ func TestGenerateSourcesSupportsIfAndWhile(t *testing.T) {
 		}
 	`)
 
-	sources, err := GenerateSources(program, Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("GenerateSources error = %v", err)
+	files := lowerProgramAST(t, program, Options{PackageName: "main"})
+	if !astFilesContain(files, func(node ast.Node) bool {
+		stmt, ok := node.(*ast.ForStmt)
+		if !ok {
+			return false
+		}
+		cond, ok := stmt.Cond.(*ast.BinaryExpr)
+		lit, litOK := cond.Y.(*ast.BasicLit)
+		return ok && cond.Op == token.LSS && litOK && lit.Value == "3"
+	}) {
+		t.Fatal("generated AST missing while lowering")
 	}
-	source := string(sources["test.go"])
-	if !strings.Contains(source, "< 3 {") {
-		t.Fatalf("generated source missing while lowering:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		stmt, ok := node.(*ast.IfStmt)
+		if !ok {
+			return false
+		}
+		cond, ok := stmt.Cond.(*ast.BinaryExpr)
+		lit, litOK := cond.Y.(*ast.BasicLit)
+		return ok && cond.Op == token.EQL && litOK && lit.Value == "3"
+	}) {
+		t.Fatal("generated AST missing if lowering")
 	}
-	if !strings.Contains(source, "== 3 {") {
-		t.Fatalf("generated source missing if lowering:\n%s", source)
-	}
-	if !strings.Contains(source, "var _tmp_0 int") {
-		t.Fatalf("generated source missing expression temp lowering:\n%s", source)
+	if !astFilesContain(files, func(node ast.Node) bool {
+		value, ok := node.(*ast.ValueSpec)
+		if !ok || astExprName(value.Type) != "int" {
+			return false
+		}
+		for _, name := range value.Names {
+			if strings.HasPrefix(name.Name, "_tmp_") {
+				return true
+			}
+		}
+		return false
+	}) {
+		t.Fatal("generated AST missing expression temp lowering")
 	}
 }
 

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -1205,6 +1205,120 @@ fn main() {}
 	}
 }
 
+func TestGenerateSourcesUsesProjectNameForProjectFFI(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo_app\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ffi.go"), []byte(`package ffi
+
+type Handle struct{}
+
+func MakeHandle() Handle { return Handle{} }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`extern type Handle = "Handle"
+extern fn make_handle() Handle = "MakeHandle"
+
+struct Box {
+  handle: Handle,
+}
+
+fn main() {
+  let handle: Handle = make_handle()
+  let _ = Box{handle: handle}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetGo)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	sources, err := GenerateSources(program, Options{PackageName: "main", ProjectInfo: loaded.ProjectInfo})
+	if err != nil {
+		t.Fatalf("generate sources: %v", err)
+	}
+	combined := ""
+	for _, source := range sources {
+		combined += string(source)
+	}
+	if !strings.Contains(combined, `demo_app "generated/demo_app"`) {
+		t.Fatalf("generated source missing project-name FFI import:\n%s", combined)
+	}
+	if !strings.Contains(combined, "demo_app.Handle") || !strings.Contains(combined, "demo_app.MakeHandle") {
+		t.Fatalf("generated source did not qualify project FFI with project name:\n%s", combined)
+	}
+	if strings.Contains(combined, "projectffi") {
+		t.Fatalf("generated source still uses projectffi:\n%s", combined)
+	}
+
+	workspace := filepath.Join(dir, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeProgram(workspace, program, Options{PackageName: "main", ProjectInfo: loaded.ProjectInfo}); err != nil {
+		t.Fatalf("write program: %v", err)
+	}
+	if !fileExists(filepath.Join(workspace, "demo_app", "ffi.go")) {
+		t.Fatalf("project FFI companion was not copied to project-named package")
+	}
+	if fileExists(filepath.Join(workspace, "projectffi", "ffi.go")) {
+		t.Fatalf("project FFI companion was copied to legacy projectffi package")
+	}
+}
+
+func TestWriteProgramCopiesProjectQualifiedExternTypeFFI(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ffi.go"), []byte(`package ffi
+
+type Handle struct{}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`extern type Handle = "demo.Handle"
+
+struct Box {
+  handle: Handle,
+}
+
+fn main() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetGo)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	workspace := filepath.Join(dir, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeProgram(workspace, program, Options{PackageName: "main", ProjectInfo: loaded.ProjectInfo}); err != nil {
+		t.Fatalf("write program: %v", err)
+	}
+	if !fileExists(filepath.Join(workspace, "demo", "ffi.go")) {
+		t.Fatalf("project-qualified extern type did not cause project FFI companion copy")
+	}
+	if err := buildGeneratedProgram(workspace, filepath.Join(dir, "app")); err != nil {
+		t.Fatalf("build generated program: %v", err)
+	}
+}
+
 func TestBuildProgramImportsProjectFFIForExternTypesOnlyUsedAsTypes(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {

--- a/compiler/go/backend_test.go
+++ b/compiler/go/backend_test.go
@@ -1219,7 +1219,7 @@ func MakeHandle() Handle { return Handle{} }
 		t.Fatal(err)
 	}
 	mainPath := filepath.Join(dir, "main.ard")
-	if err := os.WriteFile(mainPath, []byte(`extern type Handle = "Handle"
+	if err := os.WriteFile(mainPath, []byte(`extern type Handle = "demo_app.Handle"
 extern fn make_handle() Handle = "MakeHandle"
 
 struct Box {
@@ -1271,6 +1271,42 @@ fn main() {
 	}
 	if fileExists(filepath.Join(workspace, "projectffi", "ffi.go")) {
 		t.Fatalf("project FFI companion was copied to legacy projectffi package")
+	}
+}
+
+func TestGenerateSourcesRejectsUnqualifiedProjectFFIExternType(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ffi.go"), []byte(`package ffi
+
+type Handle struct{}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(dir, "main.ard")
+	if err := os.WriteFile(mainPath, []byte(`extern type Handle = "Handle"
+
+struct Box {
+  handle: Handle,
+}
+
+fn main() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := frontend.LoadModule(mainPath, backend.TargetGo)
+	if err != nil {
+		t.Fatalf("load module: %v", err)
+	}
+	program, err := air.Lower(loaded.Module)
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	_, err = GenerateSources(program, Options{PackageName: "main", ProjectInfo: loaded.ProjectInfo})
+	if err == nil || !strings.Contains(err.Error(), `must qualify Handle with package demo`) {
+		t.Fatalf("GenerateSources error = %v, want unqualified project FFI type rejection", err)
 	}
 }
 
@@ -1347,7 +1383,7 @@ func HandleName(h *Handle) string {
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "lib.ard"), []byte(`extern type Handle = "*Handle"
+	if err := os.WriteFile(filepath.Join(dir, "lib.ard"), []byte(`extern type Handle = "*demo.Handle"
 
 extern fn make_handle_raw(name: Str) Handle!Str = "MakeHandle"
 extern fn handle_name(h: Handle) Str = "HandleName"
@@ -1504,7 +1540,7 @@ func TestBuildProgramEmitsTypeArgsForReturnOnlyGenericProjectExtern(t *testing.T
 	}
 	mainPath := filepath.Join(dir, "main.ard")
 	if err := os.WriteFile(mainPath, []byte(`
-extern type RawState = "StateContext"
+extern type RawState = "demo.StateContext"
 extern fn new_raw_state() RawState = "NewRawState"
 extern fn get_raw<$T>(state: RawState, key: Str) $T? = "GetRaw"
 
@@ -1637,7 +1673,7 @@ func TestBuildProgramWrapsProjectFFIRawChannelReturn(t *testing.T) {
 use ard/async/channel
 use ard/io
 
-extern type RawEvent = "Event"
+extern type RawEvent = "demo.Event"
 extern fn events() channel::Channel<RawEvent> = "Events"
 extern fn event_value(e: RawEvent) Int = "EventValue"
 

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -320,49 +320,50 @@ func (l *lowerer) registerImportsForGoType(expr ast.Expr, imports map[string]str
 	})
 }
 
-func (l *lowerer) qualifyProjectFFIExternType(expr ast.Expr) ast.Expr {
+func (l *lowerer) validateProjectFFIExternTypeBinding(binding string, expr ast.Expr) error {
 	if !projectHasFFICompanions(l.projectInfo) {
-		return expr
+		return nil
 	}
-	return l.qualifyProjectFFIExternTypeExpr(expr)
+	if name, ok := unqualifiedExternTypeIdent(expr); ok {
+		return fmt.Errorf("project go extern type binding %q must qualify %s with package %s", binding, name, projectFFIPackageAlias(l.projectInfo))
+	}
+	return nil
 }
 
-func (l *lowerer) qualifyProjectFFIExternTypeExpr(expr ast.Expr) ast.Expr {
+func unqualifiedExternTypeIdent(expr ast.Expr) (string, bool) {
 	switch node := expr.(type) {
 	case *ast.Ident:
-		if ast.IsExported(node.Name) && !isPredeclaredGoTypeName(node.Name) {
-			alias := projectFFIPackageAlias(l.projectInfo)
-			l.currentImports[alias] = projectFFIImportPath(l.projectInfo)
-			return &ast.SelectorExpr{X: ast.NewIdent(alias), Sel: ast.NewIdent(node.Name)}
-		}
-		return node
+		return node.Name, ast.IsExported(node.Name) && !isPredeclaredGoTypeName(node.Name)
 	case *ast.StarExpr:
-		node.X = l.qualifyProjectFFIExternTypeExpr(node.X)
-		return node
+		return unqualifiedExternTypeIdent(node.X)
 	case *ast.ArrayType:
-		node.Elt = l.qualifyProjectFFIExternTypeExpr(node.Elt)
-		return node
+		return unqualifiedExternTypeIdent(node.Elt)
 	case *ast.MapType:
-		node.Key = l.qualifyProjectFFIExternTypeExpr(node.Key)
-		node.Value = l.qualifyProjectFFIExternTypeExpr(node.Value)
-		return node
-	case *ast.IndexExpr:
-		node.X = l.qualifyProjectFFIExternTypeExpr(node.X)
-		node.Index = l.qualifyProjectFFIExternTypeExpr(node.Index)
-		return node
-	case *ast.IndexListExpr:
-		node.X = l.qualifyProjectFFIExternTypeExpr(node.X)
-		for i := range node.Indices {
-			node.Indices[i] = l.qualifyProjectFFIExternTypeExpr(node.Indices[i])
+		if name, ok := unqualifiedExternTypeIdent(node.Key); ok {
+			return name, true
 		}
-		return node
+		return unqualifiedExternTypeIdent(node.Value)
+	case *ast.IndexExpr:
+		if name, ok := unqualifiedExternTypeIdent(node.X); ok {
+			return name, true
+		}
+		return unqualifiedExternTypeIdent(node.Index)
+	case *ast.IndexListExpr:
+		if name, ok := unqualifiedExternTypeIdent(node.X); ok {
+			return name, true
+		}
+		for _, index := range node.Indices {
+			if name, ok := unqualifiedExternTypeIdent(index); ok {
+				return name, true
+			}
+		}
+		return "", false
 	case *ast.ParenExpr:
-		node.X = l.qualifyProjectFFIExternTypeExpr(node.X)
-		return node
+		return unqualifiedExternTypeIdent(node.X)
 	case *ast.SelectorExpr:
-		return node
+		return "", false
 	default:
-		return node
+		return "", false
 	}
 }
 
@@ -2137,7 +2138,9 @@ func (l *lowerer) goType(typeID air.TypeID) (ast.Expr, error) {
 			if err != nil {
 				return nil, fmt.Errorf("invalid go extern type binding %q for %s: %w", info.ExternBinding, info.Name, err)
 			}
-			typ = l.qualifyProjectFFIExternType(typ)
+			if err := l.validateProjectFFIExternTypeBinding(info.ExternBinding, typ); err != nil {
+				return nil, err
+			}
 			l.registerFFIImportsForGoType(typ)
 			return typ, nil
 		}

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -83,11 +83,11 @@ func collectFFIGoImports(projectInfo *checker.ProjectInfo) map[string]string {
 	for alias, path := range collectGoImportsFromPaths(stdlibFFIGoPaths()) {
 		imports[alias] = path
 	}
-	if projectHasFFICompanions(projectInfo) {
-		imports["projectffi"] = "generated/projectffi"
-	}
 	for alias, path := range collectGoImportsFromPaths(projectFFIGoPaths(projectInfo)) {
 		imports[alias] = path
+	}
+	if projectHasFFICompanions(projectInfo) {
+		registerProjectFFIImports(imports, projectInfo)
 	}
 	for alias, path := range collectGoImportsFromPaths(dependencyFFIGoPaths(projectInfo)) {
 		imports[alias] = path
@@ -331,8 +331,9 @@ func (l *lowerer) qualifyProjectFFIExternTypeExpr(expr ast.Expr) ast.Expr {
 	switch node := expr.(type) {
 	case *ast.Ident:
 		if ast.IsExported(node.Name) && !isPredeclaredGoTypeName(node.Name) {
-			l.currentImports["projectffi"] = "generated/projectffi"
-			return &ast.SelectorExpr{X: ast.NewIdent("projectffi"), Sel: ast.NewIdent(node.Name)}
+			alias := projectFFIPackageAlias(l.projectInfo)
+			l.currentImports[alias] = projectFFIImportPath(l.projectInfo)
+			return &ast.SelectorExpr{X: ast.NewIdent(alias), Sel: ast.NewIdent(node.Name)}
 		}
 		return node
 	case *ast.StarExpr:
@@ -5470,7 +5471,7 @@ func (l *lowerer) projectFFIBindingExpr(binding string) (ast.Expr, error) {
 	if !token.IsIdentifier(binding) {
 		return nil, fmt.Errorf("project go extern binding %q must be an unqualified function name in package ffi", binding)
 	}
-	return l.qualified("projectffi", "generated/projectffi", binding), nil
+	return l.qualified(projectFFIPackageAlias(l.projectInfo), projectFFIImportPath(l.projectInfo), binding), nil
 }
 
 func isVoidExpr(expr ast.Expr) bool {

--- a/compiler/go/lower.go
+++ b/compiler/go/lower.go
@@ -73,7 +73,7 @@ func lowerProgram(program *air.Program, options Options) (map[string]*ast.File, 
 		if err != nil {
 			return nil, err
 		}
-		files[moduleFileName(module)] = file
+		files[moduleFileName(program, module)] = file
 	}
 	return files, nil
 }

--- a/compiler/go/names.go
+++ b/compiler/go/names.go
@@ -9,24 +9,50 @@ import (
 	"github.com/akonwi/ard/air"
 )
 
-func moduleFileName(module air.Module) string {
-	name := strings.TrimSuffix(module.Path, filepath.Ext(module.Path))
-	name = sanitizeName(name)
-	if name == "" {
-		name = fmt.Sprintf("module_%d", module.ID)
-	}
+func moduleFileName(program *air.Program, module air.Module) string {
+	name := moduleFileBaseName(program, module.ID)
 	if strings.HasSuffix(name, "_test") {
 		name += "_ard"
 	}
 	return name + ".go"
 }
 
-func globalName(program *air.Program, global air.Global) string {
-	moduleName := sanitizeName(program.Modules[global.Module].Path)
-	name := sanitizeName(global.Name)
-	if moduleName == "" {
-		moduleName = fmt.Sprintf("module_%d", global.Module)
+func moduleFileBaseName(program *air.Program, module air.ModuleID) string {
+	return moduleNameWithPath(program, module, func(path string) string {
+		return strings.TrimSuffix(path, filepath.Ext(path))
+	})
+}
+
+func moduleName(program *air.Program, module air.ModuleID) string {
+	return moduleNameWithPath(program, module, func(path string) string { return path })
+}
+
+func moduleNameWithPath(program *air.Program, module air.ModuleID, pathName func(string) string) string {
+	if program == nil || module < 0 || int(module) >= len(program.Modules) {
+		return fmt.Sprintf("module_%d", module)
 	}
+	base := sanitizeName(pathName(program.Modules[module].Path))
+	if base == "" {
+		base = fmt.Sprintf("module_%d", module)
+	}
+	for _, other := range program.Modules {
+		if other.ID == module {
+			continue
+		}
+		otherBase := sanitizeName(pathName(other.Path))
+		if otherBase == "" {
+			otherBase = fmt.Sprintf("module_%d", other.ID)
+		}
+		if otherBase == base {
+			return fmt.Sprintf("%s_m%d", base, module)
+		}
+	}
+	return base
+}
+
+func globalName(program *air.Program, global air.Global) string {
+	moduleName := moduleName(program, global.Module)
+	name := sanitizeName(global.Name)
 	if name == "" {
 		name = fmt.Sprintf("global_%d", global.ID)
 	}
@@ -34,13 +60,10 @@ func globalName(program *air.Program, global air.Global) string {
 }
 
 func functionName(program *air.Program, fn air.Function) string {
-	moduleName := sanitizeName(program.Modules[fn.Module].Path)
+	moduleName := moduleName(program, fn.Module)
 	suffix := sanitizeName(fn.Name)
 	if fn.IsScript {
 		suffix = "script"
-	}
-	if moduleName == "" {
-		moduleName = fmt.Sprintf("module_%d", fn.Module)
 	}
 	if suffix == "" {
 		suffix = fmt.Sprintf("fn_%d", fn.ID)

--- a/compiler/main.go
+++ b/compiler/main.go
@@ -20,6 +20,7 @@ import (
 	gotarget "github.com/akonwi/ard/go"
 	"github.com/akonwi/ard/javascript"
 	"github.com/akonwi/ard/lsp"
+	"github.com/akonwi/ard/parse"
 	"github.com/akonwi/ard/version"
 )
 
@@ -715,9 +716,14 @@ func formatFile(inputPath string, checkOnly bool) (bool, error) {
 }
 
 type discoveredTest struct {
-	filePath    string
 	displayPath string
+	modulePath  string
 	name        string
+}
+
+type loadedGoTestModule struct {
+	module checker.Module
+	tests  []discoveredTest
 }
 
 type testStatus string
@@ -766,77 +772,72 @@ func runGoTests(inputPath, filter string, failFast bool) bool {
 		return false
 	}
 
-	outcomes := make([]testOutcome, 0)
-	for _, path := range files {
-		loaded, err := frontend.LoadModule(path, backend.TargetGo)
-		if err != nil {
-			return false
-		}
-		tests := collectTests(loaded.Module, path, filter)
-		if len(tests) == 0 {
-			continue
-		}
-
-		program, err := air.LowerWithTests(loaded.Module)
-		if err != nil {
-			fmt.Println(err)
-			return false
-		}
-		if err := air.Validate(program); err != nil {
-			fmt.Println(err)
-			return false
-		}
-		goTests := make([]gotarget.TestCase, 0, len(tests))
-		for _, test := range tests {
-			fnID := air.NoFunction
-			for _, airTest := range program.Tests {
-				if airTest.Name == test.name {
-					fnID = airTest.Function
-					break
-				}
-			}
-			if fnID == air.NoFunction {
-				fmt.Printf("test not found: %s\n", test.displayName())
-				return false
-			}
-			goTests = append(goTests, gotarget.TestCase{Name: test.name, DisplayName: test.displayName(), Function: fnID})
-		}
-		goOutcomes, err := gotarget.RunTests(program, []string{"ard", "test", path}, goTests, failFast, loaded.ProjectInfo)
-		if err != nil {
-			fmt.Println(err)
-			return false
-		}
-		byName := map[string]discoveredTest{}
-		for _, test := range tests {
-			byName[test.displayName()] = test
-		}
-		for _, goOutcome := range goOutcomes {
-			test, ok := byName[goOutcome.DisplayName]
-			if !ok {
-				test = discoveredTest{filePath: path, displayPath: strings.TrimSuffix(filepath.Clean(path), filepath.Ext(path)), name: goOutcome.Name}
-			}
-			outcome := testOutcome{test: test, message: goOutcome.Message}
-			switch goOutcome.Status {
-			case "pass":
-				outcome.status = testPass
-			case "fail":
-				outcome.status = testFail
-			default:
-				outcome.status = testPanic
-			}
-			outcomes = append(outcomes, outcome)
-			reportTestOutcome(outcome)
-			if failFast && outcome.status != testPass {
-				reportTestSummary(outcomes)
-				return false
-			}
-		}
+	loadedModules, projectInfo, err := loadGoTestModules(inputPath, files, filter)
+	if err != nil {
+		return false
 	}
 
-	if len(outcomes) == 0 {
+	modules := make([]checker.Module, 0, len(loadedModules))
+	tests := make([]discoveredTest, 0)
+	for _, loaded := range loadedModules {
+		if len(loaded.tests) == 0 {
+			continue
+		}
+		modules = append(modules, loaded.module)
+		tests = append(tests, loaded.tests...)
+	}
+	if len(tests) == 0 {
 		fmt.Println("No tests found")
 		return true
 	}
+
+	program, err := air.LowerModulesWithTests(modules)
+	if err != nil {
+		fmt.Println(err)
+		return false
+	}
+	if err := air.Validate(program); err != nil {
+		fmt.Println(err)
+		return false
+	}
+	goTests, err := goTestCasesForDiscovered(program, tests)
+	if err != nil {
+		fmt.Println(err)
+		return false
+	}
+	goOutcomes, err := gotarget.RunTests(program, []string{"ard", "test", inputPath}, goTests, failFast, projectInfo)
+	if err != nil {
+		fmt.Println(err)
+		return false
+	}
+
+	outcomes := make([]testOutcome, 0, len(goOutcomes))
+	byName := map[string]discoveredTest{}
+	for _, test := range tests {
+		byName[test.displayName()] = test
+	}
+	for _, goOutcome := range goOutcomes {
+		test, ok := byName[goOutcome.DisplayName]
+		if !ok {
+			test = discoveredTest{displayPath: strings.TrimSuffix(filepath.Clean(inputPath), filepath.Ext(inputPath)), name: goOutcome.Name}
+		}
+		outcome := testOutcome{test: test, message: goOutcome.Message}
+		switch goOutcome.Status {
+		case "pass":
+			outcome.status = testPass
+		case "fail":
+			outcome.status = testFail
+		default:
+			outcome.status = testPanic
+		}
+		outcomes = append(outcomes, outcome)
+		reportTestOutcome(outcome)
+		if failFast && outcome.status != testPass {
+			reportTestSummary(outcomes)
+			return false
+		}
+	}
+
 	reportTestSummary(outcomes)
 	for _, outcome := range outcomes {
 		if outcome.status != testPass {
@@ -844,6 +845,113 @@ func runGoTests(inputPath, filter string, failFast bool) bool {
 		}
 	}
 	return true
+}
+
+func loadGoTestModules(inputPath string, files []string, filter string) ([]loadedGoTestModule, *checker.ProjectInfo, error) {
+	startDir := inputPath
+	if info, err := os.Stat(inputPath); err != nil || !info.IsDir() {
+		startDir = filepath.Dir(inputPath)
+	}
+	resolver, err := checker.NewModuleResolver(startDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	projectInfo := resolver.GetProjectInfo()
+	loaded := make([]loadedGoTestModule, 0, len(files))
+	for _, path := range files {
+		module, err := loadGoTestModule(path, resolver, projectInfo)
+		if err != nil {
+			return nil, projectInfo, err
+		}
+		loaded = append(loaded, loadedGoTestModule{
+			module: module,
+			tests:  collectTests(module, path, filter),
+		})
+	}
+	return loaded, projectInfo, nil
+}
+
+func loadGoTestModule(path string, resolver *checker.ModuleResolver, projectInfo *checker.ProjectInfo) (checker.Module, error) {
+	sourceCode, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file %s - %v", path, err)
+	}
+
+	result := parse.Parse(sourceCode, path)
+	if len(result.Errors) > 0 {
+		result.PrintErrors()
+		return nil, fmt.Errorf("parse errors")
+	}
+	modulePath := goTestModulePath(projectInfo, path)
+	filePath := path
+	if projectInfo != nil && projectInfo.RootPath != "" {
+		absPath, err := filepath.Abs(path)
+		if err == nil {
+			if rel, err := filepath.Rel(projectInfo.RootPath, absPath); err == nil {
+				filePath = rel
+			}
+		}
+	}
+	c := checker.New(filePath, result.Program, resolver, checker.CheckOptions{Target: backend.TargetGo, ModulePath: modulePath})
+	c.Check()
+	if c.HasErrors() {
+		for _, diagnostic := range c.Diagnostics() {
+			fmt.Println(diagnostic)
+		}
+		return nil, fmt.Errorf("type errors")
+	}
+	return c.Module(), nil
+}
+
+func goTestModulePath(projectInfo *checker.ProjectInfo, filePath string) string {
+	cleaned, err := filepath.Abs(filepath.Clean(filePath))
+	if err != nil {
+		cleaned = filepath.Clean(filePath)
+	}
+	if projectInfo == nil || projectInfo.RootPath == "" {
+		return strings.TrimSuffix(cleaned, filepath.Ext(cleaned))
+	}
+	if modulePath, ok := stdlibModulePathForTestFile(projectInfo.RootPath, cleaned); ok {
+		return modulePath
+	}
+	rel, err := filepath.Rel(projectInfo.RootPath, cleaned)
+	if err != nil {
+		return strings.TrimSuffix(cleaned, filepath.Ext(cleaned))
+	}
+	rel = filepath.ToSlash(strings.TrimSuffix(rel, filepath.Ext(rel)))
+	if rel == "" || strings.HasPrefix(rel, "../") {
+		return strings.TrimSuffix(cleaned, filepath.Ext(cleaned))
+	}
+	return projectInfo.ProjectName + "/" + rel
+}
+
+func goTestCasesForDiscovered(program *air.Program, tests []discoveredTest) ([]gotarget.TestCase, error) {
+	byModuleAndName := map[string]air.FunctionID{}
+	for _, airTest := range program.Tests {
+		if airTest.Function < 0 || int(airTest.Function) >= len(program.Functions) {
+			continue
+		}
+		fn := program.Functions[airTest.Function]
+		if fn.Module < 0 || int(fn.Module) >= len(program.Modules) {
+			continue
+		}
+		modulePath := program.Modules[fn.Module].Path
+		byModuleAndName[testLookupKey(modulePath, airTest.Name)] = airTest.Function
+	}
+
+	goTests := make([]gotarget.TestCase, 0, len(tests))
+	for _, test := range tests {
+		fnID, ok := byModuleAndName[testLookupKey(test.modulePath, test.name)]
+		if !ok {
+			return nil, fmt.Errorf("test not found: %s", test.displayName())
+		}
+		goTests = append(goTests, gotarget.TestCase{Name: test.name, DisplayName: test.displayName(), Function: fnID})
+	}
+	return goTests, nil
+}
+
+func testLookupKey(modulePath string, name string) string {
+	return modulePath + "\x00" + name
 }
 
 func stdlibModulePathForTestFile(root, filePath string) (string, bool) {
@@ -925,8 +1033,8 @@ func collectTests(module checker.Module, filePath string, filter string) []disco
 			continue
 		}
 		test := discoveredTest{
-			filePath:    filePath,
 			displayPath: displayPath,
+			modulePath:  module.Path(),
 			name:        fn.Name,
 		}
 		if filter != "" && !strings.Contains(test.displayName(), filter) {

--- a/compiler/main_test.go
+++ b/compiler/main_test.go
@@ -945,6 +945,93 @@ test fn panics() Void!Str {
 	})
 }
 
+func TestTestCommandDisambiguatesSameNamedTestsInSingleRun(t *testing.T) {
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	if err := os.MkdirAll(filepath.Join(projectDir, "test", "a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, "test", "b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "test", "a", "case.ard"), []byte(`use ard/testing
+
+test fn same() Void!Str {
+  testing::pass()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "test", "b", "case.ard"), []byte(`use ard/testing
+
+test fn same() Void!Str {
+  testing::fail("from b")
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var ok bool
+	output := captureStdout(t, func() {
+		ok = runTests(projectDir, "same", false)
+	})
+	if ok {
+		t.Fatalf("expected one same-named test to fail\n%s", output)
+	}
+	if !strings.Contains(output, "1 passed; 1 failed; 0 panicked") {
+		t.Fatalf("unexpected output:\n%s", output)
+	}
+	if !strings.Contains(output, filepath.Join(projectDir, "test", "a", "case")+"::same") || !strings.Contains(output, filepath.Join(projectDir, "test", "b", "case")+"::same") {
+		t.Fatalf("output missing same-named test display paths:\n%s", output)
+	}
+}
+
+func TestTestCommandSupportsImportedHelperWithCollidingGeneratedModuleName(t *testing.T) {
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	if err := os.MkdirAll(filepath.Join(projectDir, "ui"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "ard.toml"), []byte("name = \"demo\"\nard = \">= 0.1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "ui", "test.ard"), []byte(`
+struct App { value: Int }
+
+fn app() App { App{value: 1} }
+
+impl App {
+  fn contains() Bool { self.value == 1 }
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "ui_test.ard"), []byte(`use ard/testing
+use demo/ui/test as uitest
+
+test fn helper_module() Void!Str {
+  let app = uitest::app()
+  testing::assert(app.contains(), "helper should be callable")
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var ok bool
+	output := captureStdout(t, func() {
+		ok = runTests(projectDir, "helper_module", false)
+	})
+	if !ok {
+		t.Fatalf("expected colliding generated module names to pass\n%s", output)
+	}
+	if !strings.Contains(output, "1 passed; 0 failed; 0 panicked") {
+		t.Fatalf("unexpected output:\n%s", output)
+	}
+}
+
 func TestTestCommandGoTargetSupportsProjectFFI(t *testing.T) {
 	dir := t.TempDir()
 	projectDir := filepath.Join(dir, "project")

--- a/compiler/parse/ast.go
+++ b/compiler/parse/ast.go
@@ -412,10 +412,11 @@ func (a AnonymousFunction) String() string {
 
 type StructDefinition struct {
 	Location
-	Name     Identifier
-	Fields   []StructField
-	Private  bool
-	Comments []Comment // Comments found within the struct definition
+	Name       Identifier
+	TypeParams []string
+	Fields     []StructField
+	Private    bool
+	Comments   []Comment // Comments found within the struct definition
 }
 
 type StructField struct {

--- a/compiler/parse/parser.go
+++ b/compiler/parse/parser.go
@@ -842,10 +842,12 @@ func (p *parser) structDef(private bool) Statement {
 		return nil
 	}
 	nameToken := p.advance()
+	typeParams := p.parseGenericTypeParameters()
 	structDef := &StructDefinition{
-		Private: private,
-		Name:    Identifier{Name: nameToken.text},
-		Fields:  []StructField{},
+		Private:    private,
+		Name:       Identifier{Name: nameToken.text},
+		TypeParams: typeParams,
+		Fields:     []StructField{},
 		Location: Location{
 			Start: Point{Row: structToken.line, Col: structToken.column},
 		},

--- a/compiler/parse/structs_test.go
+++ b/compiler/parse/structs_test.go
@@ -61,6 +61,22 @@ func TestStructDefinitions(t *testing.T) {
 			},
 		},
 		{
+			name:  "A struct with explicit generic parameters",
+			input: `struct State<$T> { handle: StateHandle }`,
+			output: Program{
+				Imports: []Import{},
+				Statements: []Statement{
+					&StructDefinition{
+						Name:       Identifier{Name: "State"},
+						TypeParams: []string{"T"},
+						Fields: []StructField{
+							{Identifier{Name: "handle"}, &CustomType{Name: "StateHandle"}},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "A struct with mutable reference field",
 			input: `struct Context {
 					tree: mut ViewTree,

--- a/compiler/std_lib/ffi/generate.go
+++ b/compiler/std_lib/ffi/generate.go
@@ -248,6 +248,9 @@ func aliasGoType(alias *parse.TypeDeclaration) (string, bool) {
 func lowerStruct(node *parse.StructDefinition, aliases map[string]string, definedTypes map[string]struct{}) structDecl {
 	decl := structDecl{Name: goExportedName(node.Name.Name)}
 	generics := map[string]struct{}{}
+	for _, param := range node.TypeParams {
+		generics[param] = struct{}{}
+	}
 	for _, field := range node.Fields {
 		collectGenerics(field.Type, generics)
 	}

--- a/docs/adrs/0008-use-target-aware-extern-companions-for-ffi.md
+++ b/docs/adrs/0008-use-target-aware-extern-companions-for-ffi.md
@@ -54,11 +54,11 @@ Go project companions may provide project-local extern implementations in either
 - root `ffi.go`
 - `ffi/*.go`
 
-Companion files must use `package ffi`. The Go target copies project companion files into the generated workspace as a generated project FFI package and calls bindings directly. A project should not use both root `ffi.go` and `ffi/*.go` at once, so the companion layout remains unambiguous.
+Companion files must use `package ffi`. The Go target copies project companion files into the generated workspace as a generated project FFI package named after the Ard project (sanitized for Go identifiers) and calls bindings directly. A project should not use both root `ffi.go` and `ffi/*.go` at once, so the companion layout remains unambiguous.
 
 Project Go companion adaptation should use idiomatic generated Go values rather than a universal dynamic object layer. At the project FFI boundary, the current direct-call convention is:
 
-- `extern type Name = "GoType"` values pass as the bound Go type
+- `extern type Name = "project_name.GoType"` values pass as the bound Go type; project FFI type bindings must be qualified with the generated project package name
 - scalar/list/map/function arguments pass as generated Go values
 - `T?` arguments pass as `runtime.Maybe[T]`, preserving Ard's explicit nullable representation at the host boundary
 - `T` returns directly as `T`

--- a/website/src/content/docs/advanced/generics.md
+++ b/website/src/content/docs/advanced/generics.md
@@ -46,17 +46,25 @@ let ints = [1, 2, 3]
 let floats = map<Int, Float>(ints, Float::from_int)
 ```
 
-Type arguments correspond to the order of generics declared in the signature.
+Type arguments correspond to the order of generics introduced in the signature.
 
 ## Generic Structs
 
-Structs can also hold generics:
+Structs can also hold generics. Struct declarations do not write a `<$T>` parameter list; `$` types used in fields introduce the struct's generic parameters:
 
 ```ard
-struct Container<$T> {
-  value: $T
+struct Container {
+  value: $T,
 }
 
-let int_container = Container { value: 42 }
-let str_container = Container { value: "hello" }
+let int_container = Container{value: 42}
+let str_container = Container{value: "hello"}
+```
+
+When referencing the struct as a type, provide concrete type arguments:
+
+```ard
+fn get_value(container: Container<Int>) Int {
+  container.value
+}
 ```

--- a/website/src/content/docs/advanced/generics.md
+++ b/website/src/content/docs/advanced/generics.md
@@ -50,7 +50,7 @@ Type arguments correspond to the order of generics introduced in the signature.
 
 ## Generic Structs
 
-Structs can also hold generics. Struct declarations do not write a `<$T>` parameter list; `$` types used in fields introduce the struct's generic parameters:
+Structs can also hold generics. If a generic type appears in a field, that field introduces the struct's generic parameter:
 
 ```ard
 struct Container {
@@ -61,7 +61,21 @@ let int_container = Container{value: 42}
 let str_container = Container{value: "hello"}
 ```
 
-When referencing the struct as a type, provide concrete type arguments:
+When a generic parameter is used only by methods or other type-level behavior, declare it explicitly on the struct:
+
+```ard
+struct State<$T> {
+  handle: StateHandle,
+}
+
+impl State {
+  fn value() $T {
+    panic("not implemented")
+  }
+}
+```
+
+When referencing a generic struct as a type, provide concrete type arguments:
 
 ```ard
 fn get_value(container: Container<Int>) Int {

--- a/website/src/content/docs/stdlib/async-channel.md
+++ b/website/src/content/docs/stdlib/async-channel.md
@@ -152,7 +152,9 @@ If you refer to the `Channel` type directly, include its type argument:
 ```ard
 use ard/async/channel
 
-extern type RawEvent = "Event"
+// If the Ard project is named `demo`, project Go FFI types are qualified
+// with the generated project package name.
+extern type RawEvent = "demo.Event"
 extern fn events() channel::Channel<RawEvent> = "Events"
 ```
 
@@ -163,7 +165,9 @@ When an Ard extern function is declared as returning `channel::Channel<T>`, the 
 ```ard
 use ard/async/channel
 
-extern type RawEvent = "Event"
+// If the Ard project is named `demo`, project Go FFI types are qualified
+// with the generated project package name.
+extern type RawEvent = "demo.Event"
 extern fn events() channel::Channel<RawEvent> = "Events"
 ```
 

--- a/zed-plugin/extension.toml
+++ b/zed-plugin/extension.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/akonwi/ard"
 
 [grammars.ard]
 repository = "file:///Users/akonwi/Developer/agent/ard/tree-sitter-ard"
-commit = "4521b70fc47248751ead80fc6e9d702ff490d64a"
+commit = "112e646b6d5b91b444cb373d51a883c2bfcc8087"
 
 [language_servers.ard-lsp]
 name = "Ard Language Server"

--- a/zed-plugin/languages/ard/highlights.scm
+++ b/zed-plugin/languages/ard/highlights.scm
@@ -29,6 +29,7 @@
 ; Types
 (primitive_type) @type.builtin
 (type_parameter) @type.parameter
+(type_parameters "<" @punctuation.bracket ">" @punctuation.bracket)
 (type_arguments "<" @punctuation.bracket ">" @punctuation.bracket)
 (generic_type (qualified_identifier) @type)
 (generic_type (identifier) @type)


### PR DESCRIPTION
## Summary
- build Go-target `ard test` directory runs once by lowering matching test modules together
- add stable module identity override for root test files
- disambiguate generated Go names/files when sanitized module paths collide

## Validation
- cd compiler && go test ./... -count=1
- cd compiler && go run main.go test std_lib
- cd compiler && go run main.go test ../../tinear