### PR TITLE
fix(checker): avoid unresolved type method lookup panic

### DIFF
--- a/compiler/checker/functions_test.go
+++ b/compiler/checker/functions_test.go
@@ -9,6 +9,33 @@ import (
 	"github.com/akonwi/ard/parse"
 )
 
+func TestUnknownParameterTypeMethodLookupReportsDiagnostics(t *testing.T) {
+	result := parse.Parse([]byte(strings.Join([]string{
+		`fn stringify(x: Missing) Str {`,
+		`  x.to_str()`,
+		`}`,
+	}, "\n")), "test.ard")
+	if len(result.Errors) > 0 {
+		t.Fatalf("Parse errors: %v", result.Errors[0].Message)
+	}
+
+	c := checker.New("test.ard", result.Program, nil)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("checker panicked for method lookup on unresolved type: %v", r)
+		}
+	}()
+	c.Check()
+
+	diagnostics := diagnosticsString(c.Diagnostics())
+	if !strings.Contains(diagnostics, "Unrecognized type: Missing") {
+		t.Fatalf("diagnostics = %v, want unrecognized type diagnostic", c.Diagnostics())
+	}
+	if !strings.Contains(diagnostics, "Undefined: x.to_str") {
+		t.Fatalf("diagnostics = %v, want undefined method diagnostic", c.Diagnostics())
+	}
+}
+
 func TestFunctions(t *testing.T) {
 	run(t, []test{
 		{

--- a/compiler/checker/types.go
+++ b/compiler/checker/types.go
@@ -646,10 +646,10 @@ func (a *TypeVar) Actual() Type {
 }
 
 func (a TypeVar) get(name string) Type {
-	if a.actual != nil {
-		return a.actual.get(name)
+	if a.actual == nil {
+		return nil
 	}
-	panic(fmt.Errorf("Cannot look up symbols in unrefined %s", a.String()))
+	return a.actual.get(name)
 }
 func (a *TypeVar) equal(other Type) bool {
 	return equalTypes(a, other)

--- a/compiler/checker/types_test.go
+++ b/compiler/checker/types_test.go
@@ -2,6 +2,14 @@ package checker
 
 import "testing"
 
+func TestUnresolvedTypeVarGetReturnsNil(t *testing.T) {
+	unknown := &TypeVar{name: "unknown"}
+
+	if got := unknown.get("to_str"); got != nil {
+		t.Fatalf("unresolved TypeVar.get() = %v, want nil", got)
+	}
+}
+
 func TestTypeEquality(t *testing.T) {
 	var tests = []struct {
 		left   Type


### PR DESCRIPTION
## Summary
- return nil from unresolved TypeVar method/property lookup instead of panicking
- add regression coverage for unresolved type method lookup diagnostics

## Validation
- cd compiler && go test ./checker -run 'TestUnresolvedTypeVarGetReturnsNil|TestUnknownParameterTypeMethodLookupReportsDiagnostics' -count=1
- cd compiler && go test ./checker -count=1
- cd compiler && go generate ./std_lib/ffi && go test ./...

Fixes #222