### PR TITLE
fix(parser): disambiguate nullable function types

### DIFF
--- a/compiler/checker/functions_test.go
+++ b/compiler/checker/functions_test.go
@@ -870,6 +870,21 @@ func TestUsingValidTypesForUnionArguments(t *testing.T) {
 	})
 }
 
+func TestGroupedNullableFunctionTypes(t *testing.T) {
+	run(t, []test{
+		{
+			name: "Grouped nullable function type supports Maybe APIs",
+			input: `
+				use ard/maybe
+
+				let f: (fn(Int) Void)? = maybe::none()
+				f.is_none()
+			`,
+			diagnostics: []checker.Diagnostic{},
+		},
+	})
+}
+
 func TestTypeDoubleColonFunctionDefinition(t *testing.T) {
 	run(t, []test{
 		{

--- a/compiler/checker/types.go
+++ b/compiler/checker/types.go
@@ -659,7 +659,64 @@ func MakeMaybe(of Type) *Maybe {
 }
 
 func (m *Maybe) String() string {
-	return m.of.String() + "?"
+	switch m.of.(type) {
+	case *FunctionDef, FunctionDef, *ExternalFunctionDef, ExternalFunctionDef, *Result:
+		return "(" + typeSyntaxString(m.of) + ")?"
+	default:
+		return typeSyntaxString(m.of) + "?"
+	}
+}
+
+func typeSyntaxString(t Type) string {
+	switch typ := t.(type) {
+	case *FunctionDef:
+		return functionTypeString(*typ)
+	case FunctionDef:
+		return functionTypeString(typ)
+	case *ExternalFunctionDef:
+		return externalFunctionTypeString(*typ)
+	case ExternalFunctionDef:
+		return externalFunctionTypeString(typ)
+	case *Maybe:
+		return typ.String()
+	case *Result:
+		return resultOperandSyntax(typ.val) + "!" + resultOperandSyntax(typ.err)
+	case *List:
+		return "[" + typeSyntaxString(typ.of) + "]"
+	case *Map:
+		return "[" + typeSyntaxString(typ.key) + ":" + typeSyntaxString(typ.value) + "]"
+	default:
+		return t.String()
+	}
+}
+
+func resultOperandSyntax(t Type) string {
+	value := typeSyntaxString(t)
+	switch t.(type) {
+	case *FunctionDef, FunctionDef, *ExternalFunctionDef, ExternalFunctionDef, *Result:
+		return "(" + value + ")"
+	default:
+		return value
+	}
+}
+
+func functionTypeString(f FunctionDef) string {
+	return callableTypeString(f.Parameters, f.ReturnType)
+}
+
+func externalFunctionTypeString(f ExternalFunctionDef) string {
+	return callableTypeString(f.Parameters, f.ReturnType)
+}
+
+func callableTypeString(params []Parameter, returnType Type) string {
+	paramStrs := make([]string, len(params))
+	for i := range params {
+		paramStrs[i] = typeSyntaxString(params[i].Type)
+		if params[i].Mutable {
+			paramStrs[i] = "mut " + paramStrs[i]
+		}
+	}
+	return fmt.Sprintf("fn(%s) %s", strings.Join(paramStrs, ","), typeSyntaxString(returnType))
 }
 func (m *Maybe) get(name string) Type {
 	switch name {

--- a/compiler/checker/types_test.go
+++ b/compiler/checker/types_test.go
@@ -10,6 +10,42 @@ func TestUnresolvedTypeVarGetReturnsNil(t *testing.T) {
 	}
 }
 
+func TestMaybeStringParenthesizesCompositeTypes(t *testing.T) {
+	functionType := &FunctionDef{
+		Name: "<function>",
+		Parameters: []Parameter{
+			{Name: "arg0", Type: Int},
+		},
+		ReturnType: Void,
+	}
+	if got, want := MakeMaybe(functionType).String(), "(fn(Int) Void)?"; got != want {
+		t.Fatalf("function maybe string = %q, want %q", got, want)
+	}
+
+	if got, want := MakeMaybe(MakeResult(Int, Str)).String(), "(Int!Str)?"; got != want {
+		t.Fatalf("result maybe string = %q, want %q", got, want)
+	}
+	if got, want := MakeMaybe(MakeResult(functionType, Str)).String(), "((fn(Int) Void)!Str)?"; got != want {
+		t.Fatalf("function result maybe string = %q, want %q", got, want)
+	}
+	externalFunctionType := &ExternalFunctionDef{
+		Parameters: []Parameter{{Name: "arg0", Type: Int}},
+		ReturnType: Void,
+	}
+	if got, want := MakeMaybe(externalFunctionType).String(), "(fn(Int) Void)?"; got != want {
+		t.Fatalf("external function maybe string = %q, want %q", got, want)
+	}
+
+	nestedFunctionType := &FunctionDef{
+		Name:       "<function>",
+		Parameters: []Parameter{{Name: "callback", Type: functionType, Mutable: true}},
+		ReturnType: functionType,
+	}
+	if got, want := MakeMaybe(nestedFunctionType).String(), "(fn(mut fn(Int) Void) fn(Int) Void)?"; got != want {
+		t.Fatalf("nested function maybe string = %q, want %q", got, want)
+	}
+}
+
 func TestTypeEquality(t *testing.T) {
 	var tests = []struct {
 		left   Type

--- a/compiler/formatter/formatter_test.go
+++ b/compiler/formatter/formatter_test.go
@@ -225,6 +225,21 @@ func TestFormat(t *testing.T) {
 			output: "struct Request {\n  body: Dynamic?,\n\n  // inbound requests have the *http.Request\n  raw: Dynamic?,\n}\n",
 		},
 		{
+			name:   "formats nullable function type with explicit return using grouping",
+			input:  "let handler: (fn(Int) Void)? = maybe::none()\n",
+			output: "let handler: (fn(Int) Void)? = maybe::none()\n",
+		},
+		{
+			name:   "formats nullable function type with implicit void return",
+			input:  "let handler: fn(Int)? = maybe::none()\n",
+			output: "let handler: fn(Int)? = maybe::none()\n",
+		},
+		{
+			name:   "formats nullable result type with grouping",
+			input:  "let result: (Int!Str)? = maybe::none()\n",
+			output: "let result: (Int!Str)? = maybe::none()\n",
+		},
+		{
 			name:   "formats test function",
 			input:  "test fn my_test() Void!Str { Result::ok(()) }",
 			output: "test fn my_test() Void!Str {\n  Result::ok(())\n}\n",

--- a/compiler/formatter/printer.go
+++ b/compiler/formatter/printer.go
@@ -832,7 +832,10 @@ func (p printer) renderType(declared parse.DeclaredType) string {
 		return maybeNullable("["+p.renderType(node.Key)+": "+p.renderType(node.Value)+"]", node.IsNullable())
 	case *parse.ResultType:
 		name := p.renderType(node.Val) + "!" + p.renderType(node.Err)
-		return maybeNullable(name, node.IsNullable())
+		if node.IsNullable() {
+			return "(" + name + ")?"
+		}
+		return name
 	case *parse.FunctionType:
 		params := make([]string, 0, len(node.Params))
 		for i, item := range node.Params {
@@ -845,6 +848,9 @@ func (p printer) renderType(declared parse.DeclaredType) string {
 		name := "fn(" + strings.Join(params, ", ") + ")"
 		if node.Return != nil {
 			name += " " + p.renderType(node.Return)
+		}
+		if node.IsNullable() && node.Return != nil {
+			return "(" + name + ")?"
 		}
 		return maybeNullable(name, node.IsNullable())
 	default:

--- a/compiler/parse/expressions_test.go
+++ b/compiler/parse/expressions_test.go
@@ -6,6 +6,109 @@ import (
 	"time"
 )
 
+func TestGenericCallLookaheadDoesNotLeakTypeErrorsIntoComparisons(t *testing.T) {
+	runTests(t, []test{
+		{
+			name:  "Comparison against parenthesized expression",
+			input: "a < (b + c)",
+		},
+		{
+			name:  "Generic function type argument with grouped return parses without spaces",
+			input: "foo<fn(Int)(fn() Void)>()",
+		},
+		{
+			name:  "Static generic function type argument with grouped return parses without spaces",
+			input: "maybe::none<fn(Int)(Str)>()",
+		},
+		{
+			name:  "Nested function type argument with grouped return parses without hanging",
+			input: "maybe::none<[fn(Int)(Str)]>()",
+		},
+		{
+			name:  "Chained comparison against parenthesized expressions",
+			input: "a < (b + c) > (d)",
+		},
+		{
+			name:  "Chained comparison against parenthesized identifiers",
+			input: "a < (b) > (d)",
+		},
+		{
+			name:  "No-space comparison against function call is not a generic call",
+			input: "a<foo(2)",
+			output: Program{
+				Imports: []Import{},
+				Statements: []Statement{
+					&BinaryExpression{
+						Operator: LessThan,
+						Left:     &Identifier{Name: "a"},
+						Right: &FunctionCall{
+							Name:     "foo",
+							Args:     []Argument{{Name: "", Value: &NumLiteral{Value: "2"}}},
+							Comments: []Comment{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "No-space comparison against type-like function call is not a generic call",
+			input: "a<Int(2)",
+			output: Program{
+				Imports: []Import{},
+				Statements: []Statement{
+					&BinaryExpression{
+						Operator: LessThan,
+						Left:     &Identifier{Name: "a"},
+						Right: &FunctionCall{
+							Name:     "Int",
+							Args:     []Argument{{Name: "", Value: &NumLiteral{Value: "2"}}},
+							Comments: []Comment{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "No-space comparison against static function call is not a generic call",
+			input: "a<Response::new(2)",
+			output: Program{
+				Imports: []Import{},
+				Statements: []Statement{
+					&BinaryExpression{
+						Operator: LessThan,
+						Left:     &Identifier{Name: "a"},
+						Right: &StaticFunction{
+							Target: &Identifier{Name: "Response"},
+							Function: FunctionCall{
+								Name:     "new",
+								Args:     []Argument{{Name: "", Value: &NumLiteral{Value: "2"}}},
+								Comments: []Comment{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "Static property comparison is not a static generic call",
+			input: "foo::bar < baz",
+			output: Program{
+				Imports: []Import{},
+				Statements: []Statement{
+					&BinaryExpression{
+						Operator: LessThan,
+						Left: &StaticProperty{
+							Target:   &Identifier{Name: "foo"},
+							Property: &Identifier{Name: "bar"},
+						},
+						Right: &Identifier{Name: "baz"},
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestListLiterals(t *testing.T) {
 	runTests(t, []test{
 		{

--- a/compiler/parse/parser.go
+++ b/compiler/parse/parser.go
@@ -31,6 +31,7 @@ type parser struct {
 	fileName               string
 	errors                 []ParseError
 	disallowStructInstance bool
+	inCallTypeArguments    bool
 }
 
 func Parse(source []byte, fileName string) ParseResult {
@@ -151,6 +152,17 @@ func (p *parser) synchronizeToBlockEnd() {
 	}
 }
 
+func adjacent(left Location, right *token) bool {
+	if right == nil || left.End.Row != right.line {
+		return false
+	}
+	endCol := left.End.Col
+	if endCol < left.Start.Col {
+		endCol = left.Start.Col
+	}
+	return endCol+1 == right.column
+}
+
 // synchronizeToTokens skips tokens until reaching one of the specified target tokens.
 // Automatically handles nesting when targeting closing brackets (}, ], ), >).
 func (p *parser) synchronizeToTokens(tokens ...kind) {
@@ -169,6 +181,13 @@ func (p *parser) synchronizeToTokens(tokens ...kind) {
 	for !p.isAtEnd() {
 		current := p.peek().kind
 
+		// Stop before consuming a requested top-level delimiter. Check this
+		// before decrementing nesting so an unmatched closer at the recovery
+		// boundary does not push nesting negative and skip past the delimiter.
+		if (!needsNesting || nestingLevel == 0) && slices.Contains(tokens, current) {
+			return
+		}
+
 		if needsNesting && nestingLevel == 0 && current == right_brace && !slices.Contains(tokens, right_brace) {
 			return // Don't consume an enclosing block while recovering an inner delimiter.
 		}
@@ -179,14 +198,9 @@ func (p *parser) synchronizeToTokens(tokens ...kind) {
 			case left_paren, left_bracket, left_brace, less_than:
 				nestingLevel++
 			case right_paren, right_bracket, right_brace, greater_than:
-				nestingLevel--
-			}
-		}
-
-		// Only stop at target tokens if nesting is balanced (or nesting not needed)
-		if !needsNesting || nestingLevel == 0 {
-			if slices.Contains(tokens, current) {
-				return // Found target token, stop here (don't consume it)
+				if nestingLevel > 0 {
+					nestingLevel--
+				}
 			}
 		}
 
@@ -1423,6 +1437,42 @@ func (p *parser) parseType() DeclaredType {
 		}
 	}
 
+	if p.match(left_paren) {
+		inner := p.parseType()
+		if inner == nil {
+			p.addError(p.peek(), "Expected type inside grouped type")
+			if p.match(right_paren) {
+				p.match(question_mark)
+			} else {
+				p.synchronizeToTokens(equal, new_line, right_paren)
+				if p.match(right_paren) {
+					p.match(question_mark)
+				}
+			}
+			return nil
+		}
+		if !p.match(right_paren) {
+			p.addError(p.peek(), "Expected ')' after grouped type")
+			p.synchronizeToTokens(equal, new_line, right_paren)
+			if p.match(right_paren) {
+				p.match(question_mark)
+			}
+			return inner
+		}
+		if p.match(question_mark) {
+			if inner.IsNullable() {
+				p.addError(p.previous(), "Grouped type is already nullable")
+				return inner
+			}
+			if _, ok := inner.(*MutableType); ok {
+				p.addError(p.previous(), "Mutable types cannot be nullable")
+				return inner
+			}
+			return nullableDeclaredType(inner)
+		}
+		return inner
+	}
+
 	static := p.parseStaticPath()
 	if static != nil {
 		// Parse generic type arguments if present
@@ -1506,8 +1556,12 @@ func (p *parser) parseType() DeclaredType {
 
 		// Expect closing paren (only if we had opening paren)
 		hasRightParen := false
+		var paramClose token
 		if hasLeftParen {
 			hasRightParen = p.match(right_paren)
+			if hasRightParen {
+				paramClose = *p.previous()
+			}
 			if !hasRightParen {
 				p.addError(p.peek(), "Expected ')' after function parameters")
 				// Skip until we find type boundaries
@@ -1518,8 +1572,13 @@ func (p *parser) parseType() DeclaredType {
 		// Parse return type directly (no arrow in Ard syntax)
 		// Return type is optional - if omitted, implicitly returns Void
 		var returnType DeclaredType
-		if !p.check(right_bracket) && !p.check(right_paren) && !p.check(comma) && !p.check(equal) && !p.check(new_line) {
+		returnStartsAdjacentCallArgs := p.startsAdjacentCallArgsAfterFunctionType(paramClose, hasRightParen)
+		if !p.check(right_bracket) && !p.check(right_paren) && !p.check(comma) && !p.check(equal) && !p.check(new_line) && !returnStartsAdjacentCallArgs {
 			returnType = p.parseType()
+		}
+
+		if isNullableVoidType(returnType) {
+			p.addError(p.previous(), "Function type return cannot be Void?; use (fn(...) Void)? for a nullable function")
 		}
 
 		// Check for nullable
@@ -1638,6 +1697,61 @@ func (p *parser) parseType() DeclaredType {
 	}
 
 	return nil
+}
+
+func (p *parser) startsAdjacentCallArgsAfterFunctionType(paramClose token, hasRightParen bool) bool {
+	if !p.inCallTypeArguments || !hasRightParen || !p.check(left_paren) || !adjacent(paramClose.getLocation(), p.peek()) {
+		return false
+	}
+
+	savedIndex := p.index
+	savedErrorCount := len(p.errors)
+	groupedReturn := p.parseType()
+	canBeGroupedReturn := groupedReturn != nil && len(p.errors) == savedErrorCount && p.isCallTypeArgumentDelimiter()
+	p.index = savedIndex
+	p.errors = p.errors[:savedErrorCount]
+
+	return !canBeGroupedReturn
+}
+
+func (p *parser) isCallTypeArgumentDelimiter() bool {
+	return p.check(greater_than) || p.check(comma) || p.check(right_bracket) || p.check(right_paren)
+}
+
+func isNullableVoidType(t DeclaredType) bool {
+	if t == nil || !t.IsNullable() {
+		return false
+	}
+	_, ok := t.(*VoidType)
+	return ok
+}
+
+func nullableDeclaredType(t DeclaredType) DeclaredType {
+	switch ty := t.(type) {
+	case *StringType:
+		ty.nullable = true
+	case *IntType:
+		ty.nullable = true
+	case *FloatType:
+		ty.nullable = true
+	case *BooleanType:
+		ty.nullable = true
+	case *VoidType:
+		ty.nullable = true
+	case *List:
+		ty.nullable = true
+	case *Map:
+		ty.nullable = true
+	case *CustomType:
+		ty.nullable = true
+	case *GenericType:
+		ty.nullable = true
+	case *ResultType:
+		ty.nullable = true
+	case *FunctionType:
+		ty.Nullable = true
+	}
+	return t
 }
 
 func (p *parser) parseNamedType() DeclaredType {
@@ -2923,114 +3037,10 @@ func (p *parser) memberAccess() (Expression, error) {
 				}
 			}
 		} else {
-			// Check for type arguments in static function calls
-			if p.check(identifier, less_than) {
-				// This is a static function call with type arguments
-				if !p.match(identifier) {
-					p.addError(p.peek(), "Expected function name")
-					p.synchronizeToTokens(left_paren)
-					return nil, nil
-				}
-
-				funcName := p.previous()
-
-				// Parse type arguments
-				if !p.check(less_than) {
-					p.addError(p.peek(), "Expected '<'")
-					p.synchronizeToTokens(less_than, left_paren)
-					if !p.check(less_than) {
-						// Could not find '<', skip type arguments and try regular function call
-						return nil, nil
-					}
-				}
-				p.advance() // consume the '<'
-
-				typeArgs := []DeclaredType{}
-
-				typeArg := p.parseType()
-				typeArgs = append(typeArgs, typeArg)
-
-				for p.match(comma) {
-					typeArg = p.parseType()
-					typeArgs = append(typeArgs, typeArg)
-				}
-
-				if !p.check(greater_than) {
-					p.addError(p.peek(), "Expected '>' after type arguments")
-					p.synchronizeToTokens(greater_than, left_paren)
-					if !p.check(greater_than) {
-						// Could not find '>', skip to function arguments or bail
-						if !p.check(left_paren) {
-							return nil, nil
-						}
-					} else {
-						p.advance() // consume the '>'
-					}
-				} else {
-					p.advance() // consume the '>'
-				}
-
-				// Parse arguments
-				if !p.check(left_paren) {
-					p.addError(p.peek(), "Expected '(' after type arguments")
-					p.synchronizeToTokens(left_paren)
-					if !p.check(left_paren) {
-						// Could not find '(', skip this function call
-						return nil, nil
-					}
-				}
-				p.advance() // consume the '('
-
-				p.match(new_line)
-				args, argComments, err := p.parseFunctionArguments()
-				if err != nil {
-					return nil, err
-				}
-
-				if !p.check(right_paren) {
-					p.addError(p.peek(), "Expected ')' to close function call")
-					p.synchronizeToTokens(right_paren)
-					if !p.check(right_paren) {
-						// Could not find ')', return partial function call
-						return &StaticFunction{
-							Location: Location{
-								Start: expr.GetLocation().Start,
-								End:   Point{Row: funcName.line, Col: funcName.column},
-							},
-							Target: expr,
-							Function: FunctionCall{
-								Name:     funcName.text,
-								TypeArgs: typeArgs,
-								Args:     args,
-								Comments: argComments,
-								Location: Location{
-									Start: expr.GetLocation().Start,
-									End:   Point{Row: funcName.line, Col: funcName.column},
-								},
-							},
-						}, nil
-					}
-				}
-				p.advance() // consume the ')'
-
-				// Create the StaticFunction with type arguments
-				expr = &StaticFunction{
-					Location: Location{
-						Start: expr.GetLocation().Start,
-						End:   Point{Row: p.previous().line, Col: p.previous().column},
-					},
-					Target: expr,
-					Function: FunctionCall{
-						Name:     funcName.text,
-						TypeArgs: typeArgs,
-						Args:     args,
-						Comments: argComments,
-						Location: Location{
-							Start: Point{Row: funcName.line, Col: funcName.column},
-							End:   Point{Row: p.previous().line, Col: p.previous().column},
-						},
-					},
-				}
+			if staticCall, ok, err := p.tryStaticGenericFunctionCall(expr); err != nil {
+				return nil, err
+			} else if ok {
+				expr = staticCall
 			} else {
 				call, err := p.call()
 				if err != nil {
@@ -3063,6 +3073,149 @@ func (p *parser) memberAccess() (Expression, error) {
 	return expr, nil
 }
 
+func (p *parser) tryStaticGenericFunctionCall(target Expression) (Expression, bool, error) {
+	if !p.check(identifier, less_than) || !adjacent(p.peek().getLocation(), &p.tokens[p.index+1]) {
+		return nil, false, nil
+	}
+
+	savedIndex := p.index
+	savedErrorCount := len(p.errors)
+
+	funcName := p.advance()
+	p.advance() // consume the '<'
+	typeArgs := p.parseCallTypeArguments()
+
+	hasTypeArgsOrErrors := len(typeArgs) > 0 || len(p.errors) > savedErrorCount
+	hasGreaterThenCall := p.check(greater_than) && p.index+1 < len(p.tokens) && p.tokens[p.index+1].kind == left_paren && hasTypeArgsOrErrors
+	missingGreaterBeforeCall := !p.check(greater_than) && p.check(left_paren) && (hasUnambiguousCallTypeArgs(typeArgs) || len(p.errors) > savedErrorCount)
+	if !hasGreaterThenCall && !missingGreaterBeforeCall {
+		p.index = savedIndex
+		p.errors = p.errors[:savedErrorCount]
+		return nil, false, nil
+	}
+
+	if hasGreaterThenCall {
+		p.advance() // consume the '>'
+	} else {
+		p.addError(p.peek(), "Expected '>' after type arguments")
+	}
+	p.advance() // consume the '('
+	p.match(new_line)
+	args, argComments, err := p.parseFunctionArguments()
+	if err != nil {
+		return nil, true, err
+	}
+
+	if !p.check(right_paren) {
+		p.addError(p.peek(), "Expected ')' to close function call")
+		p.synchronizeToTokens(right_paren)
+		if !p.check(right_paren) {
+			return &StaticFunction{
+				Location: Location{
+					Start: target.GetLocation().Start,
+					End:   Point{Row: funcName.line, Col: funcName.column},
+				},
+				Target: target,
+				Function: FunctionCall{
+					Name:     funcName.text,
+					TypeArgs: typeArgs,
+					Args:     args,
+					Comments: argComments,
+					Location: Location{
+						Start: target.GetLocation().Start,
+						End:   Point{Row: funcName.line, Col: funcName.column},
+					},
+				},
+			}, true, nil
+		}
+	}
+	p.advance() // consume the ')'
+
+	return &StaticFunction{
+		Location: Location{
+			Start: target.GetLocation().Start,
+			End:   Point{Row: p.previous().line, Col: p.previous().column},
+		},
+		Target: target,
+		Function: FunctionCall{
+			Name:     funcName.text,
+			TypeArgs: typeArgs,
+			Args:     args,
+			Comments: argComments,
+			Location: Location{
+				Start: Point{Row: funcName.line, Col: funcName.column},
+				End:   Point{Row: p.previous().line, Col: p.previous().column},
+			},
+		},
+	}, true, nil
+}
+
+func (p *parser) parseCallTypeArguments() []DeclaredType {
+	wasInCallTypeArguments := p.inCallTypeArguments
+	p.inCallTypeArguments = true
+	defer func() { p.inCallTypeArguments = wasInCallTypeArguments }()
+
+	typeArgs := []DeclaredType{}
+	if p.check(greater_than) {
+		p.addError(p.peek(), "Expected type argument")
+		return typeArgs
+	}
+
+	for {
+		if p.check(greater_than) {
+			p.addError(p.peek(), "Expected type argument")
+			break
+		}
+		typeArg := p.parseType()
+		if typeArg != nil {
+			typeArgs = append(typeArgs, typeArg)
+		}
+		if !p.match(comma) {
+			break
+		}
+	}
+	return typeArgs
+}
+
+func hasUnambiguousCallTypeArgs(typeArgs []DeclaredType) bool {
+	if len(typeArgs) == 0 {
+		return false
+	}
+	for _, typeArg := range typeArgs {
+		if !isUnambiguousCallTypeArg(typeArg) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasFunctionTypeCallTypeArgs(typeArgs []DeclaredType) bool {
+	if len(typeArgs) == 0 {
+		return false
+	}
+	for _, typeArg := range typeArgs {
+		if _, ok := typeArg.(*FunctionType); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func isUnambiguousCallTypeArg(typeArg DeclaredType) bool {
+	switch ty := typeArg.(type) {
+	case *IntType, *FloatType, *StringType, *BooleanType, *VoidType, *GenericType, *FunctionType, *List, *Map, *ResultType, *MutableType:
+		return true
+	case *CustomType:
+		return strings.Contains(ty.Name, "::") || startsUppercase(ty.Name) || len(ty.TypeArgs) > 0
+	default:
+		return false
+	}
+}
+
+func startsUppercase(name string) bool {
+	return len(name) > 0 && name[0] >= 'A' && name[0] <= 'Z'
+}
+
 func (p *parser) call() (Expression, error) {
 	expr, err := p.primary()
 	if err != nil {
@@ -3076,25 +3229,32 @@ func (p *parser) call() (Expression, error) {
 	// Only parse as type arguments if we have an identifier followed by <
 	_, isIdentifier := expr.(*Identifier)
 
-	if isIdentifier && p.check(less_than) && !p.check(less_than, number) && !p.check(less_than, identifier, less_than) {
+	if isIdentifier && p.check(less_than) && !p.check(less_than, number) && !p.check(less_than, identifier, less_than) && adjacent(expr.GetLocation(), p.peek()) {
 		// Look ahead to see if this is a type argument or a comparison
 		p.advance() // consume the '<'
 
-		// Save position so we can rewind if this isn't a type argument
+		// Save position and errors so we can rewind if this isn't a type argument
 		savedIndex := p.index
+		savedErrorCount := len(p.errors)
 
-		// Try to parse as a type
-		typeArg := p.parseType()
+		// Try to parse type arguments
+		typeArgs := p.parseCallTypeArguments()
 
-		// If we have a '>' after parsing the type, this is probably a type argument
-		if p.check(greater_than) {
-			p.advance() // consume the '>'
+		// If type arguments are followed by a call, this is a generic call. Keep
+		// type diagnostics when the call shape is otherwise clear, including recovery
+		// for a missing '>' before the argument list.
+		hasTypeArgsOrErrors := len(typeArgs) > 0 || len(p.errors) > savedErrorCount
+		hasGreaterThenCall := p.check(greater_than) && p.index+1 < len(p.tokens) && p.tokens[p.index+1].kind == left_paren && hasTypeArgsOrErrors
+		missingGreaterBeforeCall := !p.check(greater_than) && p.check(left_paren) && hasFunctionTypeCallTypeArgs(typeArgs)
+		if hasGreaterThenCall || missingGreaterBeforeCall {
+			if hasGreaterThenCall {
+				p.advance() // consume the '>'
+			} else {
+				p.addError(p.peek(), "Expected '>' after type arguments")
+			}
 
 			// If a left parenthesis follows, this is definitely a generic function call
 			if p.check(left_paren) {
-				// This is a function call with generic type arguments
-				typeArgs := []DeclaredType{typeArg}
-
 				// Parse arguments
 				if !p.check(left_paren) {
 					p.addError(p.peek(), "Expected '(' after type arguments")
@@ -3145,6 +3305,7 @@ func (p *parser) call() (Expression, error) {
 
 		// Rewind if this wasn't a type argument
 		p.index = savedIndex - 1 // go back to before the '<'
+		p.errors = p.errors[:savedErrorCount]
 	}
 
 	// Check for struct instantiation syntax: Name { field: value, ... }

--- a/compiler/parse/variables_test.go
+++ b/compiler/parse/variables_test.go
@@ -136,6 +136,113 @@ func TestFunctionTypes(t *testing.T) {
 			input:    "let f: fn(Int, String) Bool = test",
 			wantErrs: []string{},
 		},
+		{
+			name:  "Grouped nullable function type",
+			input: "let f: (fn(Int) Void)? = test",
+			output: Program{
+				Statements: []Statement{
+					&VariableDeclaration{
+						Name: "f",
+						Type: &FunctionType{
+							Params:   []DeclaredType{&IntType{}},
+							Return:   &VoidType{},
+							Nullable: true,
+						},
+						Value: &Identifier{Name: "test"},
+					},
+				},
+			},
+		},
+		{
+			name:     "Function type returning nullable void is rejected",
+			input:    "let f: fn(Int) Void? = test",
+			wantErrs: []string{"Function type return cannot be Void?; use (fn(...) Void)? for a nullable function"},
+		},
+		{
+			name:     "Empty grouped type is rejected",
+			input:    "let f: ()? = test",
+			wantErrs: []string{"Expected type inside grouped type"},
+		},
+		{
+			name:     "Grouped nullable mutable type is rejected",
+			input:    "let f: (mut Int)? = test",
+			wantErrs: []string{"Mutable types cannot be nullable"},
+		},
+		{
+			name:     "Already nullable grouped type is rejected",
+			input:    "let f: (Int?)? = test",
+			wantErrs: []string{"Grouped type is already nullable"},
+		},
+		{
+			name:     "Malformed grouped type recovers at closing paren",
+			input:    "let f: (Int String) = test",
+			wantErrs: []string{"Expected ')' after grouped type"},
+		},
+		{
+			name:     "Malformed grouped type recovers past comma",
+			input:    "let f: (Int, String) = test",
+			wantErrs: []string{"Expected ')' after grouped type"},
+		},
+		{
+			name:     "Malformed grouped nullable type consumes question mark during recovery",
+			input:    "let f: (Int, String)? = test",
+			wantErrs: []string{"Expected ')' after grouped type"},
+		},
+		{
+			name:     "Invalid grouped type recovers at closing paren",
+			input:    "let f: (@) = test",
+			wantErrs: []string{"Expected type inside grouped type"},
+		},
+	})
+}
+
+func TestGenericCallTypeArgumentDiagnostics(t *testing.T) {
+	runTests(t, []test{
+		{
+			name:     "Invalid generic function type argument keeps type diagnostic",
+			input:    "foo<fn(Int) Void?>()",
+			wantErrs: []string{"Function type return cannot be Void?; use (fn(...) Void)? for a nullable function"},
+		},
+		{
+			name:     "Missing generic function type argument keeps type diagnostic",
+			input:    "foo<()>()",
+			wantErrs: []string{"Expected type inside grouped type"},
+		},
+		{
+			name:     "Empty static generic function type argument is rejected",
+			input:    "maybe::none<>()",
+			wantErrs: []string{"Expected type argument"},
+		},
+		{
+			name:     "Invalid static generic function type argument keeps type diagnostic",
+			input:    "maybe::none<()>()",
+			wantErrs: []string{"Expected type inside grouped type"},
+		},
+		{
+			name:     "Static generic function call missing greater than is diagnosed",
+			input:    `json::parse<Int("1")`,
+			wantErrs: []string{"Expected '>' after type arguments"},
+		},
+		{
+			name:     "Generic function call with implicit void function type argument missing greater than is diagnosed",
+			input:    "foo<fn(Int)()",
+			wantErrs: []string{"Expected '>' after type arguments"},
+		},
+		{
+			name:     "Static generic function call with implicit void function type argument missing greater than is diagnosed",
+			input:    "maybe::none<fn(Int)()",
+			wantErrs: []string{"Expected '>' after type arguments"},
+		},
+		{
+			name:     "Generic function call with implicit void function type argument and arguments missing greater than is diagnosed",
+			input:    "foo<fn(Int)(1)",
+			wantErrs: []string{"Expected '>' after type arguments"},
+		},
+		{
+			name:     "Static generic function call with implicit void function type argument and arguments missing greater than is diagnosed",
+			input:    "maybe::none<fn(Int)(1)",
+			wantErrs: []string{"Expected '>' after type arguments"},
+		},
 	})
 }
 

--- a/website/src/content/docs/guide/functions.md
+++ b/website/src/content/docs/guide/functions.md
@@ -172,3 +172,13 @@ let operation: fn(Int, Int) Int = add
 let printer: fn(Str) = io::print
 let generator: fn() Int = get_random_number
 ```
+
+Use `?` after the function type for nullable function values. If the function type has an explicit return type, wrap the whole type in parentheses so the `?` applies to the function instead of the return type:
+
+```ard
+let optional_printer: fn(Str)? = maybe::none()          // nullable fn(Str) Void
+let optional_mapper: (fn(Int) Str)? = maybe::none()    // nullable fn(Int) Str
+let maybe_name: fn(Int) Str? = lookup_name             // non-null function returning Str?
+```
+
+`fn(Int) Void?` is rejected because it is ambiguous and usually means an optional callback. Use `fn(Int)?` or `(fn(Int) Void)?` instead.


### PR DESCRIPTION
## Summary
- support grouped nullable function types like `(fn(Int) Void)?`
- reject ambiguous `fn(...) Void?` syntax with a parser diagnostic
- preserve grouped nullable function/result types in formatter and diagnostics

Fixes #231

## Tests
- `cd compiler && go test ./...`
- `cd website && npm run build`
- `git diff --check`